### PR TITLE
Error types instead of process:exit() for main and get_color() moved to impl fn of Info

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ impl fmt::Display for Info {
                 buffer,
                 "{}{}",
                 title.color(color).bold(),
-                self.authors.first().unwrap()
+                self.authors[0]
             )?;
 
             let title = " ".repeat(title.len());

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ struct Info {
 impl fmt::Display for Info {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut buffer = String::new();
-        let color = self.language.color();
+        let color = self.color();
 
         writeln!(
             buffer,
@@ -119,29 +119,6 @@ enum Language {
     Scala,
     Shell,
     TypeScript,
-}
-
-impl Language {
-    fn color(&self) -> Color {
-        match self {
-            Language::C => Color::Cyan,
-            Language::Clojure => Color::Cyan,
-            Language::Cpp => Color::Yellow,
-            Language::Csharp => Color::White,
-            Language::Go => Color::White,
-            Language::Haskell => Color::Cyan,
-            Language::Java => Color::Green,
-            Language::Lisp => Color::Yellow,
-            Language::Lua => Color::Blue,
-            Language::Python => Color::Magenta,
-            Language::R => Color::Blue,
-            Language::Ruby => Color::Magenta,
-            Language::Rust => Color::Cyan,
-            Language::Scala => Color::Blue,
-            Language::Shell => Color::Green,
-            Language::TypeScript => Color::Cyan,
-        }
-    }
 }
 
 impl fmt::Display for Language {
@@ -410,6 +387,27 @@ impl Info {
             Language::Shell => include_str!("../resources/shell.ascii"),
             Language::TypeScript => include_str!("../resources/typescript.ascii"),
             // _ => include_str!("../resources/unknown.ascii"),
+        }
+    }
+
+    fn color(&self) -> Color {
+        match self.language {
+            Language::C => Color::Cyan,
+            Language::Clojure => Color::Cyan,
+            Language::Cpp => Color::Yellow,
+            Language::Csharp => Color::White,
+            Language::Go => Color::White,
+            Language::Haskell => Color::Cyan,
+            Language::Java => Color::Green,
+            Language::Lisp => Color::Yellow,
+            Language::Lua => Color::Blue,
+            Language::Python => Color::Magenta,
+            Language::R => Color::Blue,
+            Language::Ruby => Color::Magenta,
+            Language::Rust => Color::Cyan,
+            Language::Scala => Color::Blue,
+            Language::Shell => Color::Green,
+            Language::TypeScript => Color::Cyan,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,7 +288,7 @@ fn get_authors(n: usize) -> Vec<String> {
 
     // sort authors by commit count where the one with most commit count is first
     let mut authors: Vec<(String, usize)> = authors.into_iter().collect();
-    authors.sort_by(|(_, count1), (_, count2)| count2.cmp(count1));
+    authors.sort_by_key(|(_, c)| *c);
 
     // truncate the vector so we only get the count of authors we specified as 'n'
     authors.truncate(n);


### PR DESCRIPTION
I implemented a custom error type and proper error handling since main can return Result.

I also moved the `get_color(&language)` function to be an implemented function on Info such that the color of a project/language can be retrieved by calling `Info.color()`.