### PR TITLE
Add support for building a snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: onefetch
+base: core18 # the base snap is the execution environment for this snap
+adopt-info: onefetch
+summary: Neofetch for your source code
+description: |
+  Onefetch is a command-line system information tool that displays information
+  about your Source Code directly on your terminal..
+
+grade: stable
+confinement: strict
+
+parts:
+  onefetch:
+    plugin: rust
+    source: .
+    stage-packages:
+      - git
+    override-build: |
+      snapcraftctl build 
+      snapcraftctl set-version $(git describe --tags)
+
+apps:
+  onefetch:
+    command: bin/onefetch
+    plugs: 
+      - home
+      - removable-media


### PR DESCRIPTION
I recently discovered onefetch, and as a command-line nerd and fan of neofetch, I love it :D Thanks for making it. I’m keen to to help you reach more developers building software on Linux.

So I created a snap package of onefetch so it can be featured in the [Snap Store](https://snapcraft.io/store), which is a cross-distribution app-store for Linux. Once in the store, it can be easily installed via ‘snap install’ or via GNOME Software or KDE Discover on most distros. 

The single snap built from this yaml, once published in the Snap Store will be installable on numerous popular Linux distributions without change. It’ll also be discoverable via the [Snap Store](https://snapcraft.io/store), where releases are under your control.

If you're willing to publish this under the onefetch project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the onefetch name](https://snapcraft.io/register-snap).

A snap file created by snapcraft (our free software tool for building snaps) can then be released in the Snap Store with `snap push --release stable *.snap`. You'll want to install snapcraft (brew install snapcraft, snap install snapcraft, or apt install snapcraft) and login (snapcraft login) first, though.

You may also want to consider using [https://build.snapcraft.io/](https://build.snapcraft.io/) which is a free build service, that can create armhf, amd64, i386, arm64 and other builds of onefetch, and push them to the store automatically. Alternatively it’s possible to integrate publishing the snap via your existing travis CI / release process.
I appreciate you may not be aware of snaps and snapcraft, and I’d of course be happy to answer any questions you may have. 
