### PR TITLE
Separate build and install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-install:
+build:
 	cargo build --release
+install: build
 	sudo cp target/release/onefetch /usr/local/bin
 uninstall:
 	sudo rm -f /usr/local/bin/onefetch
+clean:
+	cargo clean


### PR DESCRIPTION
I don't have root on my work machine, and expected to be able to run `make` just to build the app. I was a little startled to see a `sudo` prompt when I just ran `make`.

Thanks for this utility!