### PR TITLE
Get project name if URL ends with /

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -358,6 +358,11 @@ fn project_license(dir: &str) -> Result<String> {
                         .map(OsStr::to_string_lossy)
                         .unwrap_or_else(|| "".into())
                         .starts_with("LICENSE")
+                    || entry
+                        .file_name()
+                        .map(OsStr::to_string_lossy)
+                        .unwrap_or_else(|| "".into())
+                        .starts_with("LICENCE")
             }, // TODO: multiple prefixes, like COPYING?
         )
         .map(|entry| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -471,6 +471,9 @@ fn get_configuration(dir: &str) -> Result<Configuration> {
 
     if !name_parts.is_empty() {
         repository_name = name_parts[name_parts.len() - 1].to_string();
+        if repository_name.is_empty() {
+            repository_name = name_parts[name_parts.len() - 2].to_string();
+        }
     }
 
     if repository_name.contains(".git") {


### PR DESCRIPTION
If the remote URL ends with a / then the project name was reported as empty. This provides a workaround.