### PR TITLE
Set up basic CLI with clap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 *.snap
 /parts
 /prime
+.idea/
 .gitignore.swp
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ git2 = {version = "0.7.5", default-features = false}
 tokei = "8.0"
 license = "0.7.1"
 bytecount = "0.5.1"
+clap = "2.33.0"


### PR DESCRIPTION
Set up a basic CLI using clap addressing issue #40.

- Added dependency on Clap
- Removed TooManyArgts and TooFewArgs (handled by Clap)
- Get args from Clap
