### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = LF
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml,md}]
+indent_size = 2
+
+[*.ascii]
+trim_trailing_whitespace = false
+
+[{Makefile,.SRCINFO}]
+indent_style = tab


### PR DESCRIPTION
Hello! While working on an issue, I noticed a few irregularities in the code (tab indentation mixed with space indentation, some trailing whitespace). I thought you might want to add an [`.editorconfig`](https://editorconfig.org/) file, so that contributor's IDEs and text editors would behave in a more uniform way.

Based on the files I've looked at, I think this should cover how you want the files in your project to be formatted. But it's your project, @o2sh, so please suggest any additions/changes you might want!