### PR TITLE
Shorten commit hash to 7 characters

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -248,13 +248,14 @@ impl CommitInfo {
 
 impl fmt::Display for CommitInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let short_commit = self.commit.to_string().chars().take(7).collect::<String>();
         if self.refs.len() > 0 {
             let refs_str = self.refs.iter().map(|ref_name| {
                 ref_name.as_str()
             }).collect::<Vec<&str>>().join(", ");
-            write!(f, "{} ({})", self.commit, refs_str)
+            write!(f, "{} ({})", short_commit, refs_str)
         } else {
-            write!(f, "{}", self.commit)
+            write!(f, "{}", short_commit)
         }
     }
 }


### PR DESCRIPTION
Fixes #50

I'm new to Rust but hopefully this will be ok!