### PR TITLE
Exclude images from crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["o2sh <ossama-hjaji@live.fr>"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/o2sh/onefetch"
+exclude = ["assets/*.png"]
 
 [dependencies]
 colored= "1.6.1"


### PR DESCRIPTION
Next time this crate is published to crates.io, this should make the crate around 26KB, instead of 312KB (checked with `cargo package && ls -lh target/package/`).