### PR TITLE
Use raw images for screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/o2sh/onefetch/blob/master/assets/onefetch.png" height="130px"></h3><br><br>
+  <img src="https://raw.githubusercontent.com/o2sh/onefetch/master/assets/onefetch.png" height="130px"></h3><br><br>
   <a href="https://crates.io/crates/onefetch"><img src="https://img.shields.io/badge/crates.io-1.6.0-red.svg" alt="cargo"></a>
   <a href="https://travis-ci.org/o2sh/onefetch"><img src="https://travis-ci.org/o2sh/onefetch.svg?branch=master" alt="Build Status"></a>
   <a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
@@ -12,8 +12,8 @@
 Onefetch is a command line tool that displays information about your Git project directly on your terminal. Onefetch supports almost 20 different programming languages. If your language of choice isn't supported: Open up an issue and support will be added.
 
 <p align="center">
-<img src="https://github.com/o2sh/onefetch/blob/master/assets/cpp.png" align="left" height="200px" width="420px">
-<img src="https://github.com/o2sh/onefetch/blob/master/assets/dart.png" height="200px" width="420px">
+<img src="https://raw.githubusercontent.com/o2sh/onefetch/master/assets/cpp.png" align="left" height="200px" width="420px">
+<img src="https://raw.githubusercontent.com/o2sh/onefetch/master/assets/dart.png" height="200px" width="420px">
 </p>
 
 ## Usage


### PR DESCRIPTION
Should fix images not rendering on [crates.io page](https://crates.io/crates/onefetch).
Looks like crates.io strips HTML alignment attributes, so it will still be left-aligned, unfortunately.
docs.rs Also seems to strip all HTML from the README.