### PR TITLE
Feature: allow user to disable info fields with flag --disable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -449,13 +449,6 @@ fn main() -> Result<()> {
             .multiple(true)
             .takes_value(true)
             .case_insensitive(true)
-            .possible_values(&InfoFields::iter()
-                .take(InfoFields::count() - 1)
-                .map(|field| field.into())
-                .collect::<Vec<&str>>()
-                .as_slice())
-            .possible_value("")
-            .hide_possible_values(true)
             .default_value("")
             .hide_default_value(true)
             .help(&format!("Disable fields to show\nPossible values: {:?}", 
@@ -516,18 +509,15 @@ Possible values: [{0}{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}{11}{12}{13}{14}{15}]",
             .unwrap()
             .to_lowercase())
         .unwrap_or(Language::Unknown);
-    let disable_fields: Vec<InfoFields> = if let Some(values) = matches.values_of("disable_field") {
-            values
-                .map(String::from)
-                .filter_map(|field: String| {
-                    let item = InfoFields::from_str(field.to_lowercase().as_str())
-                        .unwrap_or(InfoFields::UnrecognizedField);
-                    if item == InfoFields::UnrecognizedField { None } else { Some(item) }
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
+    let disable_fields: Vec<InfoFields> = matches.values_of("disable_field")
+        .unwrap()
+        .map(String::from)
+        .filter_map(|field: String| {
+            let item = InfoFields::from_str(field.to_lowercase().as_str())
+                .unwrap_or(InfoFields::UnrecognizedField);
+            if item == InfoFields::UnrecognizedField { None } else { Some(item) }
+        })
+        .collect();
 
     let tokei_langs = project_languages(&dir);
     let languages_stat = get_languages_stat(&tokei_langs).ok_or(Error::SourceCodeNotFound)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use std::{
     result,
     str::FromStr,
 };
+use strum::{IntoEnumIterator, EnumCount};
 
 type Result<T> = result::Result<T, Error>;
 
@@ -319,7 +320,7 @@ impl fmt::Display for CommitInfo {
     }
 }
 
-#[derive(PartialEq, Eq, EnumString, EnumVariantNames)]
+#[derive(PartialEq, Eq, EnumString, EnumCount, EnumIter, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 enum InfoFields {
     Project,
@@ -334,6 +335,7 @@ enum InfoFields {
     LinesOfCode,
     Size,
     License,
+    UnrecognizedField,
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, EnumString)]
@@ -447,8 +449,21 @@ fn main() -> Result<()> {
             .multiple(true)
             .takes_value(true)
             .case_insensitive(true)
-            .possible_values(&InfoFields::variants())
-            .help("Disable fields to show"))
+            .possible_values(&InfoFields::iter()
+                .take(InfoFields::count() - 1)
+                .map(|field| field.into())
+                .collect::<Vec<&str>>()
+                .as_slice())
+            .possible_value("")
+            .hide_possible_values(true)
+            .default_value("")
+            .hide_default_value(true)
+            .help(&format!("Disable fields to show\nPossible values: {:?}", 
+                &InfoFields::iter()
+                    .take(InfoFields::count() - 1)
+                    .map(|field| field.into())
+                    .collect::<Vec<&str>>()
+                    .as_slice())))
         .arg(Arg::with_name("colors")
             .short("c")
             .long("colors")
@@ -504,7 +519,11 @@ Possible values: [{0}{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}{11}{12}{13}{14}{15}]",
     let disable_fields: Vec<InfoFields> = if let Some(values) = matches.values_of("disable_field") {
             values
                 .map(String::from)
-                .map(|field: String| InfoFields::from_str(field.to_lowercase().as_str()).unwrap())
+                .filter_map(|field: String| {
+                    let item = InfoFields::from_str(field.to_lowercase().as_str())
+                        .unwrap_or(InfoFields::UnrecognizedField);
+                    if item == InfoFields::UnrecognizedField { None } else { Some(item) }
+                })
                 .collect()
         } else {
             Vec::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use std::{
     result,
     str::FromStr,
 };
+use strum::{IntoEnumIterator, EnumCount};
 
 type Result<T> = result::Result<T, Error>;
 
@@ -45,6 +46,7 @@ struct Info {
     license: String,
     custom_logo: Language,
     custom_colors: Vec<String>,
+    disable_fields: Vec<InfoFields>,
 }
 
 impl fmt::Display for Info {
@@ -55,35 +57,43 @@ impl fmt::Display for Info {
             None => Color::White,
         };
 
-        writeln!(
-            buffer,
-            "{}{}",
-            "Project: ".color(color).bold(),
-            self.project_name
-        )?;
+        if !self.disable_fields.contains(&InfoFields::Project) {
+            writeln!(
+                buffer,
+                "{}{}",
+                "Project: ".color(color).bold(),
+                self.project_name
+            )?;
+        }
 
-        writeln!(
-            buffer,
-            "{}{}",
-            "HEAD: ".color(color).bold(),
-            self.current_commit
-        )?;
+        if !self.disable_fields.contains(&InfoFields::HEAD) {
+            writeln!(
+                buffer,
+                "{}{}",
+                "HEAD: ".color(color).bold(),
+                self.current_commit
+            )?;
+        }
 
-        writeln!(
-            buffer,
-            "{}{}",
-            "Version: ".color(color).bold(),
-            self.version
-        )?;
+        if !self.disable_fields.contains(&InfoFields::Version) {
+            writeln!(
+                buffer,
+                "{}{}",
+                "Version: ".color(color).bold(),
+                self.version
+            )?;
+        }
 
-        writeln!(
-            buffer,
-            "{}{}",
-            "Created: ".color(color).bold(),
-            self.creation_date
-        )?;        
+        if !self.disable_fields.contains(&InfoFields::Created) {
+            writeln!(
+                buffer,
+                "{}{}",
+                "Created: ".color(color).bold(),
+                self.creation_date
+            )?;
+        }
 
-        if !self.languages.is_empty() {
+        if !self.disable_fields.contains(&InfoFields::Languages) && !self.languages.is_empty() {
             if self.languages.len() > 1 {
                 let title = "Languages: ";
                 let pad = " ".repeat(title.len());
@@ -108,7 +118,7 @@ impl fmt::Display for Info {
             };
         }
 
-        if !self.authors.is_empty() {
+        if !self.disable_fields.contains(&InfoFields::Authors) && !self.authors.is_empty() {
             let title = if self.authors.len() > 1 {
                 "Authors: "
             } else {
@@ -124,38 +134,54 @@ impl fmt::Display for Info {
             }
         }
 
-        writeln!(
-            buffer,
-            "{}{}",
-            "Last change: ".color(color).bold(),
-            self.last_change
-        )?;
+        if !self.disable_fields.contains(&InfoFields::LastChange) {
+            writeln!(
+                buffer,
+                "{}{}",
+                "Last change: ".color(color).bold(),
+                self.last_change
+            )?;
+        }
 
-        writeln!(buffer, "{}{}", "Repo: ".color(color).bold(), self.repo)?;
-        writeln!(
-            buffer,
-            "{}{}",
-            "Commits: ".color(color).bold(),
-            self.commits
-        )?;
-        writeln!(
-            buffer,
-            "{}{}",
-            "Lines of code: ".color(color).bold(),
-            self.number_of_lines
-        )?;
-        writeln!(
-            buffer,
-            "{}{}",
-            "Size: ".color(color).bold(),
-            self.repo_size
-        )?;
-        writeln!(
-            buffer,
-            "{}{}",
-            "License: ".color(color).bold(),
-            self.license
-        )?;
+        if !self.disable_fields.contains(&InfoFields::Repo) {
+            writeln!(buffer, "{}{}", "Repo: ".color(color).bold(), self.repo)?;
+        }
+
+        if !self.disable_fields.contains(&InfoFields::Commits) {
+            writeln!(
+                buffer,
+                "{}{}",
+                "Commits: ".color(color).bold(),
+                self.commits
+            )?;
+        }
+
+        if !self.disable_fields.contains(&InfoFields::LinesOfCode) {
+            writeln!(
+                buffer,
+                "{}{}",
+                "Lines of code: ".color(color).bold(),
+                self.number_of_lines
+            )?;
+        }
+
+        if !self.disable_fields.contains(&InfoFields::Size) {
+            writeln!(
+                buffer,
+                "{}{}",
+                "Size: ".color(color).bold(),
+                self.repo_size
+            )?;
+        }
+
+        if !self.disable_fields.contains(&InfoFields::License) {
+            writeln!(
+                buffer,
+                "{}{}",
+                "License: ".color(color).bold(),
+                self.license
+            )?;
+        }
 
         writeln!(
            buffer,
@@ -294,6 +320,24 @@ impl fmt::Display for CommitInfo {
     }
 }
 
+#[derive(PartialEq, Eq, EnumString, EnumCount, EnumIter, IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+enum InfoFields {
+    Project,
+    HEAD,
+    Version,
+    Created,
+    Languages,
+    Authors,
+    LastChange,
+    Repo,
+    Commits,
+    LinesOfCode,
+    Size,
+    License,
+    UnrecognizedField,
+}
+
 #[derive(PartialEq, Eq, Hash, Clone, EnumString)]
 #[strum(serialize_all = "lowercase")]
 enum Language {
@@ -400,6 +444,26 @@ fn main() -> Result<()> {
             .takes_value(true)
             .default_value("")
             .help("Overrides showing the dominant language ascii logo"))
+        .arg(Arg::with_name("disable_field")
+            .long("disable")
+            .multiple(true)
+            .takes_value(true)
+            .case_insensitive(true)
+            .possible_values(&InfoFields::iter()
+                .take(InfoFields::count() - 1)
+                .map(|field| field.into())
+                .collect::<Vec<&str>>()
+                .as_slice())
+            .possible_value("")
+            .hide_possible_values(true)
+            .default_value("")
+            .hide_default_value(true)
+            .help(&format!("Disable fields to show\nPossible values: {:?}", 
+                &InfoFields::iter()
+                    .take(InfoFields::count() - 1)
+                    .map(|field| field.into())
+                    .collect::<Vec<&str>>()
+                    .as_slice())))
         .arg(Arg::with_name("colors")
             .short("c")
             .long("colors")
@@ -452,6 +516,18 @@ Possible values: [{0}{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}{11}{12}{13}{14}{15}]",
             .unwrap()
             .to_lowercase())
         .unwrap_or(Language::Unknown);
+    let disable_fields: Vec<InfoFields> = if let Some(values) = matches.values_of("disable_field") {
+            values
+                .map(String::from)
+                .filter_map(|field: String| {
+                    let item = InfoFields::from_str(field.to_lowercase().as_str())
+                        .unwrap_or(InfoFields::UnrecognizedField);
+                    if item == InfoFields::UnrecognizedField { None } else { Some(item) }
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
 
     let tokei_langs = project_languages(&dir);
     let languages_stat = get_languages_stat(&tokei_langs).ok_or(Error::SourceCodeNotFound)?;
@@ -489,6 +565,7 @@ Possible values: [{0}{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}{11}{12}{13}{14}{15}]",
         license: project_license(&dir)?,
         custom_logo,
         custom_colors,
+        disable_fields,
     };
 
     println!("{}", info);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,6 @@ use std::{
     result,
     str::FromStr,
 };
-use strum::{IntoEnumIterator, EnumCount};
 
 type Result<T> = result::Result<T, Error>;
 
@@ -320,7 +319,7 @@ impl fmt::Display for CommitInfo {
     }
 }
 
-#[derive(PartialEq, Eq, EnumString, EnumCount, EnumIter, IntoStaticStr)]
+#[derive(PartialEq, Eq, EnumString, EnumVariantNames)]
 #[strum(serialize_all = "snake_case")]
 enum InfoFields {
     Project,
@@ -335,7 +334,6 @@ enum InfoFields {
     LinesOfCode,
     Size,
     License,
-    UnrecognizedField,
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, EnumString)]
@@ -449,21 +447,8 @@ fn main() -> Result<()> {
             .multiple(true)
             .takes_value(true)
             .case_insensitive(true)
-            .possible_values(&InfoFields::iter()
-                .take(InfoFields::count() - 1)
-                .map(|field| field.into())
-                .collect::<Vec<&str>>()
-                .as_slice())
-            .possible_value("")
-            .hide_possible_values(true)
-            .default_value("")
-            .hide_default_value(true)
-            .help(&format!("Disable fields to show\nPossible values: {:?}", 
-                &InfoFields::iter()
-                    .take(InfoFields::count() - 1)
-                    .map(|field| field.into())
-                    .collect::<Vec<&str>>()
-                    .as_slice())))
+            .possible_values(&InfoFields::variants())
+            .help("Disable fields to show"))
         .arg(Arg::with_name("colors")
             .short("c")
             .long("colors")
@@ -519,11 +504,7 @@ Possible values: [{0}{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}{11}{12}{13}{14}{15}]",
     let disable_fields: Vec<InfoFields> = if let Some(values) = matches.values_of("disable_field") {
             values
                 .map(String::from)
-                .filter_map(|field: String| {
-                    let item = InfoFields::from_str(field.to_lowercase().as_str())
-                        .unwrap_or(InfoFields::UnrecognizedField);
-                    if item == InfoFields::UnrecognizedField { None } else { Some(item) }
-                })
+                .map(|field: String| InfoFields::from_str(field.to_lowercase().as_str()).unwrap())
                 .collect()
         } else {
             Vec::new()


### PR DESCRIPTION
I implemented the feature using the package `Strum` to work with the new `InfoFields` enum. The package allows iteration over enums and creates static str for each value in the enum essentially allowing us to create a vector of selected values from the enum (less code). In this case, I hid a enum value `UnrecognizedField` as the end user should not see that value in the output of possible values. That value is used to filter out the default value which is an empty string allowing all info fields to be shown.

Use:
Overrides showing the dominant language ascii logo
```
--disable <disable_field>...         Disable fields to show
                                     Possible values: ["project", "head", "version", "created", "languages",
                                     "authors", "last_change", "repo", "commits", "lines_of_code", "size",
                                     "license"]`
```

Examples:
1. Flag used with no value provided, defaults to showing all info

![image](https://user-images.githubusercontent.com/6343135/66736778-28b46100-ee38-11e9-9367-53f7cc69e701.png)

2. Flag used with unrecognized field, CLI errors out

![image](https://user-images.githubusercontent.com/6343135/66736822-4bdf1080-ee38-11e9-8aac-e611f9ae8f75.png)

3. Flag used with recognized field, shows all info except that field

![image](https://user-images.githubusercontent.com/6343135/66736883-76c96480-ee38-11e9-9bee-866fdf1637c5.png)

4. Flag used with multiple recognized fields in different cases, shows all info except those fields

![image](https://user-images.githubusercontent.com/6343135/66736935-9bbdd780-ee38-11e9-92dd-65e9f63e372d.png)

5. Flag used with languages, shows all info except languages and ASCII logo still shows

![image](https://user-images.githubusercontent.com/6343135/66737024-d6277480-ee38-11e9-944c-52dace6882cc.png)

6. Flag used with recognized and unrecognized fields, CLI errors out

![image](https://user-images.githubusercontent.com/6343135/66737078-ffe09b80-ee38-11e9-899f-32296ef8f3eb.png)

7. Flag used with all recognized fields, no info shows

![image](https://user-images.githubusercontent.com/6343135/66737204-551cad00-ee39-11e9-9bad-0797b057f49e.png)


Addresses issue #73.