### PR TITLE
Add flag to list supported languages

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -4,7 +4,7 @@ use colored::Color;
 
 use crate::{Error, Result};
 
-#[derive(PartialEq, Eq, Hash, Clone, EnumString)]
+#[derive(PartialEq, Eq, Hash, Clone, EnumString, EnumIter)]
 #[strum(serialize_all = "lowercase")]
 pub enum Language {
     Assembly,

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,24 @@ Possible values: [{0}{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}{11}{12}{13}{14}{15}]",
                     "15".bright_white(),
                 )),
         )
+        .arg(
+            Arg::with_name("list")
+            .short("l")
+            .long("list")
+            .help("Prints a list of all supported languages")
+        )
         .get_matches();
+
+    if matches.is_present("list") {
+        let list = Language::iter()
+            .filter(|x| *x != Language::Unknown)
+            .map(|x| x.to_string().color(x.get_colors()[0]).to_string())
+            .collect::<Vec<String>>().join(", ");
+
+        print!("Supported languages:\n\n{}\n", list);
+        std::process::exit(0);
+    }
+
     let dir = String::from(matches.value_of("directory").unwrap());
     let custom_logo: Language =
         Language::from_str(&matches.value_of("ascii_language").unwrap().to_lowercase())

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,14 +154,14 @@ Possible values: [{0}{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}{11}{12}{13}{14}{15}]",
                 )),
         )
         .arg(
-            Arg::with_name("list")
-                .short("l")
-                .long("list")
+            Arg::with_name("supported")
+                .short("s")
+                .long("supported")
                 .help("Prints a list of all supported languages"),
         )
         .get_matches();
 
-    if matches.is_present("list") {
+    if matches.is_present("supported") {
         let list = Language::iter()
             .filter(|x| *x != Language::Unknown)
             .map(|x| x.to_string().color(x.get_colors()[0]).to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,9 +155,9 @@ Possible values: [{0}{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}{11}{12}{13}{14}{15}]",
         )
         .arg(
             Arg::with_name("list")
-            .short("l")
-            .long("list")
-            .help("Prints a list of all supported languages")
+                .short("l")
+                .long("list")
+                .help("Prints a list of all supported languages"),
         )
         .get_matches();
 
@@ -165,7 +165,8 @@ Possible values: [{0}{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}{11}{12}{13}{14}{15}]",
         let list = Language::iter()
             .filter(|x| *x != Language::Unknown)
             .map(|x| x.to_string().color(x.get_colors()[0]).to_string())
-            .collect::<Vec<String>>().join(", ");
+            .collect::<Vec<String>>()
+            .join(", ");
 
         print!("Supported languages:\n\n{}\n", list);
         std::process::exit(0);


### PR DESCRIPTION
Resolves #102 

Usage: `onefetch <-s | --supported>`
Output:
```
$ onefetch -s
Supported languages:

Assembly, C, Clojure, CoffeeScript, C++, C#, CSS, Dart, Elixir, Elm, Erlang, Forth, Go, Haskell, HTML, Idris, Java, JavaScript, Kotlin, Lisp, Lua, Nim, Objective-C, Perl, Php, PureScript, Python, R, Ruby, Rust, Scala, Shell, Swift, Tcl, Tex, TypeScript, Vue, XML, Zig
```

Also colors every language after its first associated color in `Language.get_colors`.