### PR TITLE
Bump license from 0.7.1 to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,14 +7,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "aho-corasick"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -583,14 +575,8 @@ dependencies = [
 
 [[package]]
 name = "license"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "log"
@@ -717,7 +703,7 @@ dependencies = [
  "git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "license 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "license 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokei 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1292,7 +1278,6 @@ dependencies = [
 
 [metadata]
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
-"checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -1360,7 +1345,7 @@ dependencies = [
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum libgit2-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "48441cb35dc255da8ae72825689a95368bf510659ae1ad55dc4aa88cb1789bf1"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
-"checksum license 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f5fff7c2c2727bed5fa82d8979e9aa00b8f2777305b5175fbf53f8b6a7c828bc"
+"checksum license 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce4a70a69d7a45a98ee83cbe56e896054f02a982f6d0244b90490cff713c5948"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["assets/*.png"]
 colored= "1.8.0"
 git2 = {version = "0.7.5", default-features = false}
 tokei = "10.0"
-license = "0.7.1"
+license = "0.8.1"
 bytecount = "0.5.1"
 clap = "2.33.0"
 strum = "0.16.0"

--- a/src/info.rs
+++ b/src/info.rs
@@ -2,11 +2,10 @@ use std::ffi::OsStr;
 use std::fmt::Write;
 use std::fs;
 use std::process::Command;
-use std::str::FromStr;
 
 use colored::{Color, Colorize, ColoredString};
 use git2::Repository;
-use license::License;
+use license;
 use image::DynamicImage;
 
 use crate::language::Language;
@@ -530,10 +529,9 @@ impl Info {
                             .is_empty())
                 }, // TODO: multiple prefixes, like COPYING?
             )
-            .map(|entry| {
-                license::Kind::from_str(&fs::read_to_string(entry).unwrap_or_else(|_| "".into()))
+            .filter_map(|entry| {
+                license::from_text_ext(&fs::read_to_string(entry).unwrap_or_else(|_| "".into()))
             })
-            .filter_map(std::result::Result::ok)
             .map(|license| license.name().to_string())
             .collect::<Vec<_>>()
             .join(", ");


### PR DESCRIPTION
Use new from_text_ext API instead of the Kind Enum
Fixes #119 