### PR TITLE
Allow command to run from subfolder

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ impl std::fmt::Debug for Error {
             Error::GitNotInstalled => "Git failed to execute",
             Error::NoGitData => "Could not retrieve git configuration data",
             Error::ReadDirectory => "Could not read directory",
-            Error::NotGitRepo => "This is not a Git Repo",
+            Error::NotGitRepo => "Could not find a valid git repo on the current path",
             Error::ReferenceInfoError => "Error while retrieving reference information",
             Error::ImageLoadError => "Could not load the specified image",
         };

--- a/src/info.rs
+++ b/src/info.rs
@@ -326,7 +326,7 @@ impl Info {
     }
 
     fn get_current_commit_info(dir: &str) -> Result<CommitInfo> {
-        let repo = Repository::open(dir).map_err(|_| Error::NotGitRepo)?;
+        let repo = Repository::discover(dir).map_err(|_| Error::NotGitRepo)?;
         let head = repo.head().map_err(|_| Error::ReferenceInfoError)?;
         let head_oid = head.target().ok_or(Error::ReferenceInfoError)?;
         let refs = repo.references().map_err(|_| Error::ReferenceInfoError)?;
@@ -350,7 +350,7 @@ impl Info {
     }
 
     fn get_configuration(dir: &str) -> Result<Configuration> {
-        let repo = Repository::open(dir).map_err(|_| Error::NotGitRepo)?;
+        let repo = Repository::discover(dir).map_err(|_| Error::NotGitRepo)?;
         let config = repo.config().map_err(|_| Error::NoGitData)?;
         let mut remote_url = String::new();
         let mut repository_name = String::new();


### PR DESCRIPTION
Related Issue: https://github.com/o2sh/onefetch/issues/129

According to the `git2` documentation, we can use the [`discover`](https://docs.rs/git2/0.10.1/git2/struct.Repository.html#method.discover) method to check for git repositories on the current path.

The error message was also changed to reflect this behavior.