### PR TITLE
Improve running command from subfolder

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,8 @@ pub enum Error {
     /// Not in a Git Repo
     NotGitRepo,
     /// Error while getting branch info
+    BareGitRepo,
+    /// Repository is a bare git repo
     ReferenceInfoError,
     /// Image probably doesn't exist or has wrong format
     ImageLoadError,
@@ -24,6 +26,7 @@ impl std::fmt::Debug for Error {
             Error::NoGitData => "Could not retrieve git configuration data",
             Error::ReadDirectory => "Could not read directory",
             Error::NotGitRepo => "Could not find a valid git repo on the current path",
+            Error::BareGitRepo => "Unable to run onefetch on bare git repos",
             Error::ReferenceInfoError => "Error while retrieving reference information",
             Error::ImageLoadError => "Could not load the specified image",
         };

--- a/src/info.rs
+++ b/src/info.rs
@@ -292,10 +292,10 @@ impl Info {
         let workdir = repo.workdir().ok_or(Error::BareGitRepo)?;
         let workdir_str = workdir.to_str().unwrap();
 
+        let config = Info::get_configuration(&repo)?;
+        let current_commit_info = Info::get_current_commit_info(&repo)?;
         let authors = Info::get_authors(workdir_str, no_merges, 3);
         let (git_v, git_user) = Info::get_git_info(workdir_str);
-        let current_commit_info = Info::get_current_commit_info(&repo)?;
-        let config = Info::get_configuration(&repo)?;
         let version = Info::get_version(workdir_str)?;
         let commits = Info::get_commits(workdir_str, no_merges)?;
         let repo_size = Info::get_packed_size(workdir_str)?;
@@ -327,6 +327,66 @@ impl Info {
             bold_enabled: bold_flag,
             custom_image,
         })
+    }
+
+    fn get_configuration(repo: &Repository) -> Result<Configuration> {
+        let config = repo.config().map_err(|_| Error::NoGitData)?;
+        let mut remote_url = String::new();
+        let mut repository_name = String::new();
+        let mut remote_upstream: Option<String> = None;
+
+        for entry in &config.entries(None).unwrap() {
+            let entry = entry.unwrap();
+            match entry.name().unwrap() {
+                "remote.origin.url" => remote_url = entry.value().unwrap().to_string(),
+                "remote.upstream.url" => remote_upstream = Some(entry.value().unwrap().to_string()),
+                _ => (),
+            }
+        }
+
+        if let Some(url) = remote_upstream {
+            remote_url = url.clone();
+        }
+
+        let url = remote_url.clone();
+        let name_parts: Vec<&str> = url.split('/').collect();
+
+        if !name_parts.is_empty() {
+            repository_name = name_parts[name_parts.len() - 1].to_string();
+        }
+
+        if repository_name.contains(".git") {
+            let repo_name = repository_name.clone();
+            let parts: Vec<&str> = repo_name.split(".git").collect();
+            repository_name = parts[0].to_string();
+        }
+
+        Ok(Configuration {
+            repository_name: repository_name.clone(),
+            repository_url: name_parts.join("/"),
+        })
+    }
+
+    fn get_current_commit_info(repo: &Repository) -> Result<CommitInfo> {
+        let head = repo.head().map_err(|_| Error::ReferenceInfoError)?;
+        let head_oid = head.target().ok_or(Error::ReferenceInfoError)?;
+        let refs = repo.references().map_err(|_| Error::ReferenceInfoError)?;
+        let refs_info = refs
+            .filter_map(|reference| match reference {
+                Ok(reference) => match (reference.target(), reference.shorthand()) {
+                    (Some(oid), Some(shorthand)) if oid == head_oid => {
+                        Some(if reference.is_tag() {
+                            String::from("tags/") + shorthand
+                        } else {
+                            String::from(shorthand)
+                        })
+                    }
+                    _ => None,
+                },
+                Err(_) => None,
+            })
+            .collect::<Vec<String>>();
+        Ok(CommitInfo::new(head_oid, refs_info))
     }
 
     // Return first n most active commiters as authors within this project.
@@ -392,66 +452,6 @@ impl Info {
             .expect("Failed to execute git.");
         let username = String::from_utf8_lossy(&username.stdout).replace('\n', "");
         (version, username)
-    }
-
-    fn get_current_commit_info(repo: &Repository) -> Result<CommitInfo> {
-        let head = repo.head().map_err(|_| Error::ReferenceInfoError)?;
-        let head_oid = head.target().ok_or(Error::ReferenceInfoError)?;
-        let refs = repo.references().map_err(|_| Error::ReferenceInfoError)?;
-        let refs_info = refs
-            .filter_map(|reference| match reference {
-                Ok(reference) => match (reference.target(), reference.shorthand()) {
-                    (Some(oid), Some(shorthand)) if oid == head_oid => {
-                        Some(if reference.is_tag() {
-                            String::from("tags/") + shorthand
-                        } else {
-                            String::from(shorthand)
-                        })
-                    }
-                    _ => None,
-                },
-                Err(_) => None,
-            })
-            .collect::<Vec<String>>();
-        Ok(CommitInfo::new(head_oid, refs_info))
-    }
-
-    fn get_configuration(repo: &Repository) -> Result<Configuration> {
-        let config = repo.config().map_err(|_| Error::NoGitData)?;
-        let mut remote_url = String::new();
-        let mut repository_name = String::new();
-        let mut remote_upstream: Option<String> = None;
-
-        for entry in &config.entries(None).unwrap() {
-            let entry = entry.unwrap();
-            match entry.name().unwrap() {
-                "remote.origin.url" => remote_url = entry.value().unwrap().to_string(),
-                "remote.upstream.url" => remote_upstream = Some(entry.value().unwrap().to_string()),
-                _ => (),
-            }
-        }
-
-        if let Some(url) = remote_upstream {
-            remote_url = url.clone();
-        }
-
-        let url = remote_url.clone();
-        let name_parts: Vec<&str> = url.split('/').collect();
-
-        if !name_parts.is_empty() {
-            repository_name = name_parts[name_parts.len() - 1].to_string();
-        }
-
-        if repository_name.contains(".git") {
-            let repo_name = repository_name.clone();
-            let parts: Vec<&str> = repo_name.split(".git").collect();
-            repository_name = parts[0].to_string();
-        }
-
-        Ok(Configuration {
-            repository_name: repository_name.clone(),
-            repository_url: name_parts.join("/"),
-        })
     }
 
     fn get_version(dir: &str) -> Result<String> {


### PR DESCRIPTION
Related Issue: https://github.com/o2sh/onefetch/issues/129

So, while doing some investigation, I discovered that whenever the `git` cmd is executed in a subfolder, it does a recursive search for the git repo on the current path.

Although the impact on this program is very low, since we only do ~10 git calls per run, I was already going to extract the working dir to fix the LICENSE issue, so why not improve the other calls?

Also, we can't call `workdir()` on bare git folders, but the program was already not working on them, since they don't have any content.

I can also reorder the functions that receive the `Repository` to keep the code more uniform, but some people don't like big git changes since it messes their git blame ¯\\_(ツ)_/¯