### PR TITLE
Automate Homebrew release

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,19 @@
+name: homebrew-update-formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: macos-latest
+
+    env:
+      HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+
+    steps:
+    - name: Open Homebrew Formula PR
+      run: brew update-formula-pr --url=$TARBALL_URL
+      env:
+        TARBALL_URL: ${{ format('https://github.com/{0}/archive/{1}.tar.gz', github.repository, github.event.release.tag_name) }}

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
     - name: Open Homebrew Formula PR
-      run: brew update-formula-pr --url=$TARBALL_URL
+      run: brew bump-formula-pr --url=$TARBALL_URL --version=$TAG_NAME onefetch
       env:
-        TARBALL_URL: ${{ format('https://github.com/{0}/archive/{1}.tar.gz', github.repository, github.event.release.tag_name) }}
+        TARBALL_URL: ${{ github.event.release.tarball_url }}
+        TAG_NAME: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
This PR aims to add a GitHub Action that automatically creates a PR in the `homebrew/homebrew-core` repository that updates the Formula. I don't really know if there is a _great_ way to test this without publishing releases manually now. Also we should figure out which `HOMEBREW_GITHUB_API_TOKEN` we should provide, as I don't think the `github-actions-bot` has enough permissions to create a PR in another repository.

- [x] Figure out the right API token.
- [x] Test the workflow.