### PR TITLE
Exempt "help wanted" from stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
+  - "help wanted"
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Since `help wanted` implies that an issue is valid for onefetch, I thought it should be exempted.

What do you think?