### PR TITLE
Use git log once for get_commits/get_creation_time/get_authors and get_last change

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -367,7 +367,7 @@ impl Info {
             args.push("--no-merges");
         }
 
-        args.push("--pretty=format:%cr%x09%an");
+        args.push("--pretty=\"format:%cr\t%an\"");
 
         let output = Command::new("git")
             .args(args)
@@ -443,15 +443,14 @@ impl Info {
         let mut authors = std::collections::HashMap::new();
         let mut total_commits = 0;
         for line in git_history {
-            let commit_author = line.split('\u{09}').collect::<Vec<_>>()[1].to_string();
+            let commit_author = line.split('\t').collect::<Vec<_>>()[1].to_string();
             let commit_count = authors.entry(commit_author.to_string()).or_insert(0);
             *commit_count += 1;
             total_commits += 1;
         }
 
         let mut authors: Vec<(String, usize)> = authors.into_iter().collect();
-        authors.sort_by_key(|(_, c)| *c);
-        authors.reverse();
+        authors.sort_by(|(_, a_count), (_, b_count)| b_count.cmp(a_count));
 
         authors.truncate(n);
 
@@ -617,7 +616,7 @@ impl Info {
         let last_commit = git_history.first();
 
         let output = match last_commit {
-            Some(date) => date.split('\u{09}').collect::<Vec<_>>()[0].to_string(),
+            Some(date) => date.split('\t').collect::<Vec<_>>()[0].to_string(),
             None => "??".into(),
         };
 
@@ -628,7 +627,7 @@ impl Info {
         let first_commit = git_history.last();
 
         let output = match first_commit {
-            Some(creation_time) => creation_time.split('\u{09}').collect::<Vec<_>>()[0].to_string(),
+            Some(creation_time) => creation_time.split('\t').collect::<Vec<_>>()[0].to_string(),
             None => "??".into(),
         };
 


### PR DESCRIPTION
Fixes  #198 

Hopefully the code isn't too messy...:shit::shit:

Response time on the linux repo:

```
get_language_stats --> 2.496199699s
get_configuration --> 556ns
get_current_commit_info --> 586.312µs
get_project_license --> 149.397478ms
get_version --> 168.437398ms
get_pending_pending --> 167.720066ms
get_git_info --> 171.087506ms
get_packed_size --> 198.697039ms
get_git_history --> 12.227256108s
get_creation_date --> 2.054µs
get_authors --> 177.582094ms
get_last_change --> 1.343µs
```

The new entry `get_git_history` is the new function responsible for executing the `git log`, the results are then passed on to the other functions.