### PR TITLE
fix number of branches to ignore HEAD

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -428,7 +428,11 @@ impl Info {
 
             let branches = String::from_utf8_lossy(&output.stdout);
 
-            branches.lines().count() - 1 //Exclude origin/HEAD -> origin/master
+            if branches.lines().count() > 0 {
+                branches.lines().count() - 1 //Exclude origin/HEAD -> origin/master
+            } else {
+                0
+            }
         };
 
         futures::join!(tags, branches)

--- a/src/info.rs
+++ b/src/info.rs
@@ -428,7 +428,7 @@ impl Info {
 
             let branches = String::from_utf8_lossy(&output.stdout);
 
-            branches.lines().count()
+            branches.lines().count() - 1 //Exclude origin/HEAD -> origin/master
         };
 
         futures::join!(tags, branches)


### PR DESCRIPTION
Exclude `origin/HEAD -> origin/master` from total of remote branches