### PR TITLE
Add dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
     open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
This allows dependabot to make PRs to update GitHub Action dependencies.

downgraded `checkout@master` to `checkout@v2` so that we use the latest stable version and not the latest push to master.