### PR TITLE
Enable image backends on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ error-chain = "0.12"
 [target.'cfg(windows)'.dependencies]
 ansi_term = "0.12"
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(not(target_os = "windows"))'.dependencies]
 libc = "0.2.79"
 base64 = "0.13.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ error-chain = "0.12"
 [target.'cfg(windows)'.dependencies]
 ansi_term = "0.12"
 
-[target.'cfg(not(target_os = "windows"))'.dependencies]
+[target.'cfg(not(windows))'.dependencies]
 libc = "0.2.79"
 base64 = "0.13.0"
 

--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -26,9 +26,9 @@ pub struct Cli {
 impl Cli {
     /// Build `Options` from command line arguments.
     pub fn new() -> Result<Self> {
-        #[cfg(target_os = "linux")]
+        #[cfg(not(target_os = "windows"))]
         let possible_backends = ["kitty", "sixel"];
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(target_os = "windows")]
         let possible_backends = [];
 
         let matches = App::new(crate_name!())

--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -26,9 +26,9 @@ pub struct Cli {
 impl Cli {
     /// Build `Options` from command line arguments.
     pub fn new() -> Result<Self> {
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(not(windows))]
         let possible_backends = ["kitty", "sixel"];
-        #[cfg(target_os = "windows")]
+        #[cfg(windows)]
         let possible_backends = [];
 
         let matches = App::new(crate_name!())

--- a/src/onefetch/image_backends/mod.rs
+++ b/src/onefetch/image_backends/mod.rs
@@ -1,15 +1,15 @@
 use image::DynamicImage;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 pub mod kitty;
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 pub mod sixel;
 
 pub trait ImageBackend {
     fn add_image(&self, lines: Vec<String>, image: &DynamicImage) -> String;
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(windows))]
 pub fn get_best_backend() -> Option<Box<dyn ImageBackend>> {
     if kitty::KittyBackend::supported() {
         Some(Box::new(kitty::KittyBackend::new()))
@@ -21,18 +21,18 @@ pub fn get_best_backend() -> Option<Box<dyn ImageBackend>> {
 }
 
 pub fn get_image_backend(backend_name: &str) -> Option<Box<dyn ImageBackend>> {
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(windows))]
     let backend = Some(match backend_name {
         "kitty" => Box::new(kitty::KittyBackend::new()) as Box<dyn ImageBackend>,
         "sixel" => Box::new(sixel::SixelBackend::new()) as Box<dyn ImageBackend>,
         _ => unreachable!(),
     });
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     let backend = None;
     backend
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 pub fn get_best_backend() -> Option<Box<dyn ImageBackend>> {
     None
 }

--- a/src/onefetch/image_backends/mod.rs
+++ b/src/onefetch/image_backends/mod.rs
@@ -1,15 +1,15 @@
 use image::DynamicImage;
 
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "windows"))]
 pub mod kitty;
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "windows"))]
 pub mod sixel;
 
 pub trait ImageBackend {
     fn add_image(&self, lines: Vec<String>, image: &DynamicImage) -> String;
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "windows"))]
 pub fn get_best_backend() -> Option<Box<dyn ImageBackend>> {
     if kitty::KittyBackend::supported() {
         Some(Box::new(kitty::KittyBackend::new()))
@@ -21,18 +21,18 @@ pub fn get_best_backend() -> Option<Box<dyn ImageBackend>> {
 }
 
 pub fn get_image_backend(backend_name: &str) -> Option<Box<dyn ImageBackend>> {
-    #[cfg(target_os = "linux")]
+    #[cfg(not(target_os = "windows"))]
     let backend = Some(match backend_name {
         "kitty" => Box::new(kitty::KittyBackend::new()) as Box<dyn ImageBackend>,
         "sixel" => Box::new(sixel::SixelBackend::new()) as Box<dyn ImageBackend>,
         _ => unreachable!(),
     });
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "windows")]
     let backend = None;
     backend
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "windows")]
 pub fn get_best_backend() -> Option<Box<dyn ImageBackend>> {
     None
 }


### PR DESCRIPTION
Enable image backends on macOS because we have terminals with graphics support on macOS.

mlterm supports sixel:
![スクリーンショット 2020-10-15 19 14 52](https://user-images.githubusercontent.com/107537/96110432-d3170680-0f1a-11eb-8374-31bcc11dee81.png)

kitty:
![スクリーンショット 2020-10-15 19 12 55](https://user-images.githubusercontent.com/107537/96110492-e6c26d00-0f1a-11eb-89ee-c0ef3e6056a7.png)

NOTE: iTerm2 also supports sixel but it shows broken output (I think it is a iTerm2 issue):
![スクリーンショット 2020-10-15 19 19 25](https://user-images.githubusercontent.com/107537/96110924-8122b080-0f1b-11eb-9a16-d2d216608b31.png)
