### PR TITLE
Enable ASCII max size integration tests  🎉  🎉 

### DIFF
--- a/src/onefetch/language.rs
+++ b/src/onefetch/language.rs
@@ -76,7 +76,6 @@ macro_rules! define_languages {
             $(
                 paste! {
                     #[test]
-                    #[ignore]
                     fn [<$name:lower _width>] () {
                         const ASCII: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/", $ascii));
 
@@ -89,7 +88,6 @@ macro_rules! define_languages {
                     }
 
                     #[test]
-                    #[ignore]
                     fn [<$name:lower _height>] () {
                         const ASCII: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/", $ascii));
                         assert_le!(ASCII.lines().count(), MAX_HEIGHT, concat!($ascii, " is too tall."));


### PR DESCRIPTION
That's it! We've finally manged to get all of our ASCII logos to comply with the max size imposed by the Guidelines.

As a result, we can now remove the #[ignored] attribute from the `ascii_size` unit tests and have them run as part of CI/CD.

This was made possible thanks to:

@maash3r (Lua, Clojure, Jupyter-Notebooks, Tex, Zig)
@atluft (Swift, Objective-C)
@rootEnginear (Php)
@tianlangwu (Nim)

and of course @spenserblack for suggesting the idea and implementing the UTs.