### PR TITLE
Fix layout with sixel image backend

### DIFF
--- a/src/onefetch/image_backends/sixel.rs
+++ b/src/onefetch/image_backends/sixel.rs
@@ -77,8 +77,10 @@ impl super::ImageBackend for SixelBackend {
             ioctl(STDOUT_FILENO, TIOCGWINSZ, &tty_size);
             tty_size
         };
-        let width_ratio = tty_size.ws_col as f64 / tty_size.ws_xpixel as f64;
-        let height_ratio = tty_size.ws_row as f64 / tty_size.ws_ypixel as f64;
+        let cw = tty_size.ws_xpixel / tty_size.ws_col;
+        let lh = tty_size.ws_ypixel / tty_size.ws_row;
+        let width_ratio = 1.0 / cw as f64;
+        let height_ratio = 1.0 / lh as f64;
 
         // resize image to fit the text height with the Lanczos3 algorithm
         let image = image.resize(

--- a/src/onefetch/image_backends/sixel.rs
+++ b/src/onefetch/image_backends/sixel.rs
@@ -152,7 +152,7 @@ impl super::ImageBackend for SixelBackend {
         }
         image_data.extend(b"\x1B\\");
 
-        image_data.extend(format!("\x1B[{}A", image_rows as u32 + 2).as_bytes()); // move cursor to top-left corner
+        image_data.extend(format!("\x1B[{}A", image_rows as u32).as_bytes()); // move cursor to top-left corner
         image_data.extend(format!("\x1B[{}C", image_columns as u32 + 1).as_bytes()); // move cursor to top-right corner of image
         let mut i = 0;
         for line in &lines {


### PR DESCRIPTION
# Problem

With sixel image backend, unnecessary +2 on cursor up CSI sequence causes misalignment between image and text:

<img width="478" alt="original" src="https://user-images.githubusercontent.com/107537/96339287-b91e2500-10ce-11eb-828b-6c9e7b107511.png">

while +2 keeps alignment on terminal in fullscreen mode:

<img width="409" alt="orig_full" src="https://user-images.githubusercontent.com/107537/96339308-dc48d480-10ce-11eb-852d-6f3050c9fa8e.png">

# How to fix

* remove unnecessary +2 for terminal not in fullscreen mode
* fix row number calculation for terminal in fullscreen mode

# Screenshots of the fixed version

## not in fullscreen mode

<img width="478" alt="fixed" src="https://user-images.githubusercontent.com/107537/96339401-76a91800-10cf-11eb-8a77-48f90aabe3ca.png">

## in fullscreen mode

<img width="405" alt="fixed_full" src="https://user-images.githubusercontent.com/107537/96339404-7c066280-10cf-11eb-96c4-98771bcb89ad.png">

# Environment

* onefetch runs on Ubuntu 20.04
* mlterm runs on Windows 10