### PR TITLE
Add CLI option to disable image

### DIFF
--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -23,6 +23,7 @@ pub struct Cli {
     pub excluded: Vec<String>,
     pub print_languages: bool,
     pub true_color: bool,
+    pub image_off: bool,
 }
 
 impl Cli {
@@ -172,12 +173,18 @@ impl Cli {
                 .multiple(true)
                 .takes_value(true)
                 .help("Ignore all files & directories matching EXCLUDE."),
+            )
+        .arg(
+            Arg::with_name("off")
+                .long("off")
+                .help("Prevents the ASCII art or image from displaying"), 
             ).get_matches();
 
         let no_bold = matches.is_present("no-bold");
         let no_merges = matches.is_present("no-merge-commits");
         let no_color_blocks = matches.is_present("no-color-blocks");
         let print_languages = matches.is_present("languages");
+        let image_off = matches.is_present("off");
         let true_color = is_truecolor_terminal();
 
         let fields_to_hide: Vec<String> = if let Some(values) = matches.values_of("disable-fields")
@@ -248,6 +255,7 @@ impl Cli {
             excluded,
             print_languages,
             true_color,
+            image_off,
         })
     }
 

--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -23,7 +23,7 @@ pub struct Cli {
     pub excluded: Vec<String>,
     pub print_languages: bool,
     pub true_color: bool,
-    pub image_off: bool,
+    pub art_off: bool,
 }
 
 impl Cli {
@@ -177,14 +177,15 @@ impl Cli {
         .arg(
             Arg::with_name("off")
                 .long("off")
-                .help("Prevents the ASCII art or image from displaying"), 
+                .help("Prevents the ASCII art or image from displaying")
+                .conflicts_with_all(&["image", "ascii-language", "ascii-input"]), 
             ).get_matches();
 
         let no_bold = matches.is_present("no-bold");
         let no_merges = matches.is_present("no-merge-commits");
         let no_color_blocks = matches.is_present("no-color-blocks");
         let print_languages = matches.is_present("languages");
-        let image_off = matches.is_present("off");
+        let art_off = matches.is_present("off");
         let true_color = is_truecolor_terminal();
 
         let fields_to_hide: Vec<String> = if let Some(values) = matches.values_of("disable-fields")
@@ -255,7 +256,7 @@ impl Cli {
             excluded,
             print_languages,
             true_color,
-            image_off,
+            art_off,
         })
     }
 

--- a/src/onefetch/info.rs
+++ b/src/onefetch/info.rs
@@ -256,10 +256,8 @@ impl std::fmt::Display for Info {
         let center_pad = "   ";
         let mut info_lines = buf.lines();
 
-        if self.config.image_off {
-            while let Some(line) = info_lines.next() {
-                writeln!(f, "{}", line)?;
-            }
+        if self.config.art_off {
+            writeln!(f, "{}", buf)?;
         } else if let Some(custom_image) = &self.config.image {
             if let Some(image_backend) = &self.config.image_backend {
                 writeln!(

--- a/src/onefetch/info.rs
+++ b/src/onefetch/info.rs
@@ -256,7 +256,11 @@ impl std::fmt::Display for Info {
         let center_pad = "   ";
         let mut info_lines = buf.lines();
 
-        if let Some(custom_image) = &self.config.image {
+        if self.config.image_off {
+            while let Some(line) = info_lines.next() {
+                writeln!(f, "{}", line)?;
+            }
+        } else if let Some(custom_image) = &self.config.image {
             if let Some(image_backend) = &self.config.image_backend {
                 writeln!(
                     f,


### PR DESCRIPTION
Closes #287 

Adds the CLI option `--off` which prevents the image from being displayed. 