### PR TITLE
return Err when image but no image backend

### DIFF
--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -132,6 +132,7 @@ impl Cli {
                 .long("image-backend")
                 .value_name("BACKEND")
                 .takes_value(true)
+                .requires("image")
                 .max_values(1)
                 .possible_values(&possible_backends)
                 .help("Which image BACKEND to use."),
@@ -195,6 +196,7 @@ impl Cli {
 
         let image_backend = if image.is_some() {
             if let Some(backend_name) = matches.value_of("image-backend") {
+                image_backends::check_if_supported(backend_name)?;
                 image_backends::get_image_backend(backend_name)
             } else {
                 image_backends::get_best_backend()
@@ -202,6 +204,10 @@ impl Cli {
         } else {
             None
         };
+
+        if image.is_some() && image_backend.is_none() {
+            return Err("Could not detect a supported image backend".into());
+        }
 
         let path = String::from(matches.value_of("input").unwrap());
 

--- a/src/onefetch/image_backends/mod.rs
+++ b/src/onefetch/image_backends/mod.rs
@@ -22,6 +22,10 @@ pub fn get_best_backend() -> Option<Box<dyn ImageBackend>> {
 }
 
 pub fn check_if_supported(backend_name: &str) -> Result<()> {
+
+    #[cfg(windows)]
+    return Err(format!("{} image backend is not supported", backend_name));
+
     match backend_name {
         "kitty" => {
             if !kitty::KittyBackend::supported() {

--- a/src/onefetch/image_backends/mod.rs
+++ b/src/onefetch/image_backends/mod.rs
@@ -22,7 +22,6 @@ pub fn get_best_backend() -> Option<Box<dyn ImageBackend>> {
 }
 
 pub fn check_if_supported(backend_name: &str) -> Result<()> {
-
     #[cfg(windows)]
     return Err(format!("{} image backend is not supported", backend_name));
 

--- a/src/onefetch/image_backends/mod.rs
+++ b/src/onefetch/image_backends/mod.rs
@@ -23,8 +23,9 @@ pub fn get_best_backend() -> Option<Box<dyn ImageBackend>> {
 
 pub fn check_if_supported(backend_name: &str) -> Result<()> {
     #[cfg(windows)]
-    return Err(format!("{} image backend is not supported", backend_name));
+    return Err(format!("{} image backend is not supported", backend_name).into());
 
+    #[cfg(not(windows))]
     match backend_name {
         "kitty" => {
             if !kitty::KittyBackend::supported() {

--- a/src/onefetch/image_backends/mod.rs
+++ b/src/onefetch/image_backends/mod.rs
@@ -1,3 +1,4 @@
+use crate::onefetch::error::*;
 use image::DynamicImage;
 
 #[cfg(not(windows))]
@@ -18,6 +19,24 @@ pub fn get_best_backend() -> Option<Box<dyn ImageBackend>> {
     } else {
         None
     }
+}
+
+pub fn check_if_supported(backend_name: &str) -> Result<()> {
+    match backend_name {
+        "kitty" => {
+            if !kitty::KittyBackend::supported() {
+                return Err("Kitty image backend is not supported".into());
+            }
+        }
+        "sixel" => {
+            if !sixel::SixelBackend::supported() {
+                return Err("Sixel image backend is not supported".into());
+            }
+        }
+        _ => unreachable!(),
+    };
+
+    Ok(())
 }
 
 pub fn get_image_backend(backend_name: &str) -> Option<Box<dyn ImageBackend>> {

--- a/src/onefetch/info.rs
+++ b/src/onefetch/info.rs
@@ -257,18 +257,14 @@ impl std::fmt::Display for Info {
         let mut info_lines = buf.lines();
 
         if let Some(custom_image) = &self.config.image {
-            if let Some(image_backend) = &self.config.image_backend {
-                writeln!(
-                    f,
-                    "{}",
-                    image_backend.add_image(
-                        info_lines.map(|s| format!("{}{}", center_pad, s)).collect(),
-                        custom_image
-                    )
-                )?;
-            } else {
-                panic!("No image backend found")
-            }
+            writeln!(
+                f,
+                "{}",
+                self.config.image_backend.as_ref().unwrap().add_image(
+                    info_lines.map(|s| format!("{}{}", center_pad, s)).collect(),
+                    custom_image
+                )
+            )?;
         } else {
             let mut logo_lines = if let Some(custom_ascii) = &self.config.ascii_input {
                 AsciiArt::new(custom_ascii, Vec::new(), !self.config.no_bold)


### PR DESCRIPTION
I removed the `panic!("No image backend found")` from Info.fmt() and I added a check in case the user chose an image-backend not supported by his terminal.

------
By the way, I noticed that `kitty::KittyBackend::supported()` and `sixel::SixelBackend::supported()` need to `println!()` a sequence of characters in order to check if the corresponding backend is supported, resulting in two empty lines if both check fail:

![out](https://user-images.githubusercontent.com/13710835/96910543-f0f6e500-149f-11eb-8724-123f255aa8cf.png)

I tried wrapping both methods into smth like (+ replace println! by print!):

```rust
    pub fn supported() -> bool {
        let is_supported = KittyBackend::is_supported();
        print!("\r");
        is_supported
    }
```
but it broke everything :sob:

