### PR TITLE
Feature/text coloring

### DIFF
--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -29,6 +29,7 @@ pub struct Cli {
     pub print_languages: bool,
     pub true_color: bool,
     pub art_off: bool,
+    pub text_colors: Vec<String>,
 }
 
 impl Cli {
@@ -112,6 +113,23 @@ impl Cli {
                     "15",
                 ])
                 .help("Colors (X X X...) to print the ascii art."),
+        )
+        .arg(
+            Arg::with_name("text-colors")
+                .short("t")
+                .long("text-colors")
+                .value_name("X")
+                .multiple(true)
+                .takes_value(true)
+                .max_values(6)
+                .possible_values(&[
+                    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
+                    "15",
+                ])
+                .help("Allows you to customize color of info lines (X X X...)")
+                .long_help("Allows you to customize color of info lines. \
+                Goes in order of title, ~, underline, title, colon, and info. \
+                Example: onefetch --text-color 9 10 11 12 13 14")
         )
         .arg(
             Arg::with_name("no-bold")
@@ -254,6 +272,12 @@ impl Cli {
             Vec::new()
         };
 
+        let text_colors = if let Some(values) = matches.values_of("text-colors") {
+            values.map(String::from).collect()
+        } else {
+            Vec::new()
+        };
+
         let disabled_fields = info_fields::get_disabled_fields(fields_to_hide)?;
 
         let number_of_authors: usize = matches.value_of("authors-number").unwrap().parse().unwrap();
@@ -280,6 +304,7 @@ impl Cli {
             excluded,
             print_languages,
             true_color,
+            text_colors,
             art_off,
         })
     }

--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -39,7 +39,9 @@ impl Cli {
         let possible_backends = ["kitty", "sixel"];
         #[cfg(windows)]
         let possible_backends = [];
-
+        let color_values = &[
+            "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
+        ];
         let matches = App::new(crate_name!())
         .version(crate_version!())
         .about(crate_description!())
@@ -108,10 +110,7 @@ impl Cli {
                 .value_name("X")
                 .multiple(true)
                 .takes_value(true)
-                .possible_values(&[
-                    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
-                    "15",
-                ])
+                .possible_values(color_values)
                 .help("Colors (X X X...) to print the ascii art."),
         )
         .arg(
@@ -122,14 +121,11 @@ impl Cli {
                 .multiple(true)
                 .takes_value(true)
                 .max_values(6)
-                .possible_values(&[
-                    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
-                    "15",
-                ])
+                .possible_values(color_values)
                 .help("Allows you to customize color of info lines (X X X...)")
                 .long_help("Allows you to customize color of info lines. \
-                Goes in order of title, ~, underline, title, colon, and info. \
-                Example: onefetch --text-color 9 10 11 12 13 14")
+                Goes in order of title, ~, underline, subtitle, colon, and info. \
+                Example: onefetch --text-colors 9 10 11 12 13 14")
         )
         .arg(
             Arg::with_name("no-bold")

--- a/src/onefetch/info.rs
+++ b/src/onefetch/info.rs
@@ -160,12 +160,8 @@ impl std::fmt::Display for Info {
 
         if !self.config.disabled_fields.languages && !self.languages.is_empty() {
             if self.languages.len() > 1 {
-                let title = &self.get_formatted_subtitle_label(
-                    "Languages",
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                );
-                let pad = " ".repeat(title.len());
+                let title = "Languages";
+                let pad = " ".repeat(title.len() + 2);
                 let mut s = String::from("");
                 let languages: Vec<(String, f64)> = {
                     let mut iter = self.languages.iter().map(|x| (format!("{}", x.0), x.1));
@@ -180,14 +176,33 @@ impl std::fmt::Display for Info {
                 };
 
                 for (cnt, language) in languages.iter().enumerate() {
-                    let formatted_number = format!("{:.*}", 1, language.1);
+                    let formatted_number =
+                        format!("{:.*}", 1, language.1).color(self.color_set.info);
                     if cnt != 0 && cnt % 2 == 0 {
-                        s = s + &format!("\n{}{} ({} %) ", pad, language.0, formatted_number);
+                        s = s + &format!(
+                            "\n{}{} ({} %) ",
+                            pad,
+                            language.0.color(self.color_set.info),
+                            formatted_number
+                        );
                     } else {
-                        s = s + &format!("{} ({} %) ", language.0, formatted_number);
+                        s = s + &format!(
+                            "{} ({} %) ",
+                            language.0.color(self.color_set.info),
+                            formatted_number
+                        );
                     }
                 }
-                writeln!(f, "{}{}", title, s.color(self.color_set.info))?;
+                writeln!(
+                    f,
+                    "{}{}",
+                    &self.get_formatted_subtitle_label(
+                        title,
+                        self.color_set.subtitle,
+                        self.color_set.colon,
+                    ),
+                    s.color(self.color_set.info)
+                )?;
             } else {
                 write_buf(
                     f,

--- a/src/onefetch/info.rs
+++ b/src/onefetch/info.rs
@@ -388,7 +388,7 @@ impl Info {
             &config.ascii_colors,
             config.true_color,
         );
-        let color_set = Info::get_color_set(&config.text_colors);
+        let color_set = Info::get_color_set(&config.text_colors, &colors);
 
         Ok(Info {
             git_version: git_v,
@@ -807,26 +807,36 @@ impl Info {
         }
     }
 
-    fn get_color_set(text_colors: &[String]) -> TextColor {
-        let mut custom_color: Vec<Color> = text_colors
-            .iter()
-            .map(|color_num| {
-                let custom = Info::num_to_color(color_num);
-                match custom {
-                    Some(custom) => custom,
-                    None => Color::White,
+    fn get_color_set(text_colors: &[String], default_colors: &Vec<Color>) -> TextColor {
+        let mut custom_color: Vec<Color> = Vec::<Color>::new();
+        if text_colors.is_empty() {
+            custom_color.insert(0, default_colors[0]);
+            custom_color.insert(1, Color::White);
+            custom_color.insert(2, Color::White);
+            custom_color.insert(3, default_colors[0]);
+            custom_color.insert(4, default_colors[0]);
+            custom_color.insert(5, Color::White);
+        } else {
+            let mut custom_color: Vec<Color> = text_colors
+                .iter()
+                .map(|color_num| {
+                    let custom = Info::num_to_color(color_num);
+                    match custom {
+                        Some(custom) => custom,
+                        None => Color::White,
+                    }
+                })
+                .collect();
+            if custom_color.len() < 6 {
+                for i in 0..6 {
+                    if i < custom_color.len() {
+                        continue;
+                    }
+                    custom_color.insert(i, Color::White);
                 }
-            })
-            .collect();
-        if custom_color.len() < 6 {
-            for i in 0..6 {
-                if i < custom_color.len() {
-                    continue;
-                }
-                custom_color.insert(i, Color::White);
             }
         }
-
+        
         let color_set: TextColor = TextColor {
             title: custom_color[0],
             tilde: custom_color[1],

--- a/src/onefetch/info.rs
+++ b/src/onefetch/info.rs
@@ -1,6 +1,7 @@
 use {
     crate::onefetch::{
         cli::Cli, commit_info::CommitInfo, error::*, language::Language, license::Detector,
+        text_color::TextColor,
     },
     colored::{Color, ColoredString, Colorize},
     git2::Repository,
@@ -32,22 +33,8 @@ pub struct Info {
     pub config: Cli,
 }
 
-pub struct TextColor {
-    title: Color,
-    tilde: Color,
-    underline: Color,
-    subtitle: Color,
-    colon: Color,
-    info: Color,
-}
-
 impl std::fmt::Display for Info {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let color = match self.colors.get(0) {
-            Some(&c) => c,
-            None => Color::White,
-        };
-
         if !self.config.disabled_fields.git_info {
             let git_info_length;
             if self.git_username != "" {
@@ -69,7 +56,7 @@ impl std::fmt::Display for Info {
             let separator = "-".repeat(git_info_length);
             write_buf(
                 f,
-                &self.get_formatted_info_label("", color),
+                &self.get_formatted_info_label("", self.color_set.underline),
                 &self.get_formatted_info_label(&separator, self.color_set.underline),
             )?;
         }
@@ -388,7 +375,7 @@ impl Info {
             &config.ascii_colors,
             config.true_color,
         );
-        let color_set = Info::get_color_set(&config.text_colors, &colors);
+        let color_set = TextColor::get_text_color_set(&config.text_colors, &colors);
 
         Ok(Info {
             git_version: git_v,
@@ -770,7 +757,7 @@ impl Info {
         colors
     }
 
-    fn num_to_color(num: &str) -> Option<Color> {
+    pub fn num_to_color(num: &str) -> Option<Color> {
         let color = match num {
             "0" => Color::Black,
             "1" => Color::Red,
@@ -805,47 +792,6 @@ impl Info {
         } else {
             formatted_label.bold()
         }
-    }
-
-    fn get_color_set(text_colors: &[String], default_colors: &Vec<Color>) -> TextColor {
-        let mut custom_color: Vec<Color> = Vec::<Color>::new();
-        if text_colors.is_empty() {
-            custom_color.insert(0, default_colors[0]);
-            custom_color.insert(1, Color::White);
-            custom_color.insert(2, Color::White);
-            custom_color.insert(3, default_colors[0]);
-            custom_color.insert(4, default_colors[0]);
-            custom_color.insert(5, Color::White);
-        } else {
-            custom_color = text_colors
-                .iter()
-                .map(|color_num| {
-                    let custom = Info::num_to_color(color_num);
-                    match custom {
-                        Some(custom) => custom,
-                        None => Color::White,
-                    }
-                })
-                .collect();
-            if custom_color.len() < 6 {
-                for i in 0..6 {
-                    if i < custom_color.len() {
-                        continue;
-                    }
-                    custom_color.insert(i, Color::White);
-                }
-            }
-        }
-        
-        let color_set: TextColor = TextColor {
-            title: custom_color[0],
-            tilde: custom_color[1],
-            underline: custom_color[2],
-            subtitle: custom_color[3],
-            colon: custom_color[4],
-            info: custom_color[5],
-        };
-        color_set
     }
 }
 

--- a/src/onefetch/info.rs
+++ b/src/onefetch/info.rs
@@ -817,7 +817,7 @@ impl Info {
             custom_color.insert(4, default_colors[0]);
             custom_color.insert(5, Color::White);
         } else {
-            let mut custom_color: Vec<Color> = text_colors
+            custom_color = text_colors
                 .iter()
                 .map(|color_num| {
                     let custom = Info::num_to_color(color_num);

--- a/src/onefetch/mod.rs
+++ b/src/onefetch/mod.rs
@@ -8,3 +8,4 @@ pub mod info;
 pub mod info_fields;
 pub mod language;
 pub mod license;
+pub mod text_color;

--- a/src/onefetch/text_color.rs
+++ b/src/onefetch/text_color.rs
@@ -1,0 +1,48 @@
+use {crate::onefetch::info::Info, colored::Color};
+
+pub struct TextColor {
+    pub title: Color,
+    pub tilde: Color,
+    pub underline: Color,
+    pub subtitle: Color,
+    pub colon: Color,
+    pub info: Color,
+}
+
+impl TextColor {
+    fn new(color: Color) -> TextColor {
+        TextColor {
+            title: color,
+            tilde: Color::White,
+            underline: Color::White,
+            subtitle: color,
+            colon: color,
+            info: Color::White,
+        }
+    }
+
+    pub fn get_text_color_set(text_colors: &[String], default_colors: &Vec<Color>) -> TextColor {
+        let mut text_color_set = TextColor::new(default_colors[0]);
+        if !text_colors.is_empty() {
+            let custom_color = text_colors
+                .iter()
+                .map(|color_num| {
+                    let custom = Info::num_to_color(color_num);
+                    match custom {
+                        Some(custom) => custom,
+                        None => Color::White,
+                    }
+                })
+                .collect::<Vec<Color>>();
+
+            text_color_set.title = *custom_color.get(0).unwrap_or(&default_colors[0]);
+            text_color_set.tilde = *custom_color.get(1).unwrap_or(&Color::White);
+            text_color_set.underline = *custom_color.get(2).unwrap_or(&Color::White);
+            text_color_set.subtitle = *custom_color.get(3).unwrap_or(&default_colors[0]);
+            text_color_set.colon = *custom_color.get(4).unwrap_or(&default_colors[0]);
+            text_color_set.info = *custom_color.get(5).unwrap_or(&Color::White);
+        }
+
+        text_color_set
+    }
+}


### PR DESCRIPTION
This PR is for [issue-290](https://github.com/o2sh/onefetch/issues/290). It adds text-coloring to the information screen as seen in the attached picture. Text-coloring can be applied by running `-t X X X X X X` or `--text-coloring X X X X X X` with numbers 0 - 15. If number(s) is missing, the default color is white. Goes in order of title, ~, underline, title, colon, and info. Please review and any suggestions are appreciated. Thank you. 

![image](https://user-images.githubusercontent.com/45835736/97122997-eaff3f00-16ff-11eb-9216-2b2410f25aec.png)
