### PR TITLE
make build fail on deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build Debug
       run: |
         rustc --version
-        cargo build
+        cargo build --features=fail-on-deprecated
 
     - name: Run tests
       run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,6 @@ base64 = "0.13.0"
 lazy_static = "1.4"
 more-asserts = "0.2"
 paste = "1"
+
+[features]
+fail-on-deprecated = []

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	cargo build --release
+	cargo build --release --features=fail-on-deprecated
 
 install: build
 	sudo cp target/release/onefetch /usr/local/bin

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 // `error_chain!` can recurse deeply
 #![recursion_limit = "1024"]
+#![cfg_attr(feature="fail-on-deprecated", deny(deprecated))]
 
 use onefetch::{cli::Cli, cli_utils, error::*, info};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 // `error_chain!` can recurse deeply
 #![recursion_limit = "1024"]
-#![cfg_attr(feature="fail-on-deprecated", deny(deprecated))]
+#![cfg_attr(feature = "fail-on-deprecated", deny(deprecated))]
 
 use onefetch::{cli::Cli, cli_utils, error::*, info};
 


### PR DESCRIPTION
Following suggestion by @spenserblack in #296 

Tested on dependabot/cargo/image-0.23.11 (after a git reset --hard~1) and got:

```sh
o2sh ~/dev/onefetch (dependabot/cargo/image-0.23.11) > cargo build --features=fail-on-deprecated
   Compiling color_quant v1.1.0
   Compiling miniz_oxide v0.4.3
   Compiling gif v0.11.1
   Compiling backtrace v0.3.51
   Compiling tiff v0.6.0
   Compiling failure v0.1.8
   Compiling error-chain v0.12.4
   Compiling askalono v0.4.3
   Compiling image v0.23.11
   Compiling onefetch v2.5.0 (/home/o2sh/dev/onefetch)
error: use of deprecated item 'image::math::nq::NeuQuant': Use the `color_quant` crate instead
 --> src/onefetch/image_backends/sixel.rs:4:9
  |
4 |         math::nq::NeuQuant,
  |         ^^^^^^^^^^^^^^^^^^
  |
note: the lint level is defined here
 --> src/main.rs:3:48
  |
3 | #![cfg_attr(feature="fail-on-deprecated", deny(deprecated))]
  |                                                ^^^^^^^^^^

error: use of deprecated item 'image::math::nq::NeuQuant': Use the `color_quant` crate instead
   --> src/onefetch/image_backends/sixel.rs:100:14
    |
100 |             &NeuQuant::new(10, colors, flat_samples.image_slice().unwrap()),
    |              ^^^^^^^^^^^^^

error: aborting due to 2 previous errors

error: could not compile `onefetch`.
```
