### PR TITLE
Refacto info.fmt()

### DIFF
--- a/src/onefetch/info.rs
+++ b/src/onefetch/info.rs
@@ -668,23 +668,25 @@ impl Info {
 
         let pad = title.len() + 2;
 
-        for (i, author) in self.authors.iter().enumerate() {
+        for (i, (author_name, author_nbr_commits, autor_contribution)) in
+            self.authors.iter().enumerate()
+        {
             if i == 0 {
                 author_field.push_str(&format!(
                     "{}{} {} {}\n",
-                    author.2.to_string().color(self.color_set.info),
+                    autor_contribution.to_string().color(self.color_set.info),
                     "%".color(self.color_set.info),
-                    author.0.to_string().color(self.color_set.info),
-                    author.1.to_string().color(self.color_set.info),
+                    author_name.to_string().color(self.color_set.info),
+                    author_nbr_commits.to_string().color(self.color_set.info),
                 ));
             } else {
                 author_field.push_str(&format!(
                     "{:<width$}{}{} {} {}\n",
                     "",
-                    author.2.to_string().color(self.color_set.info),
+                    autor_contribution.to_string().color(self.color_set.info),
                     "%".color(self.color_set.info),
-                    author.0.to_string().color(self.color_set.info),
-                    author.1.to_string().color(self.color_set.info),
+                    author_name.to_string().color(self.color_set.info),
+                    author_nbr_commits.to_string().color(self.color_set.info),
                     width = pad
                 ));
             }
@@ -747,7 +749,7 @@ impl Info {
         if tags_str.is_empty() && branches_str.is_empty() {
             String::new()
         } else if branches_str.is_empty() || tags_str.is_empty() {
-            format!("({})", format!("{}{}", tags_str, branches_str))
+            format!("({}{})", tags_str, branches_str)
         } else {
             format!("({}, {})", branches_str, tags_str)
         }

--- a/src/onefetch/info.rs
+++ b/src/onefetch/info.rs
@@ -54,11 +54,7 @@ impl std::fmt::Display for Info {
         if !self.config.disabled_fields.project {
             let branches_tags_str = self.get_branches_and_tags_field();
 
-            let project_str = &self.get_formatted_subtitle_label(
-                "Project",
-                self.color_set.subtitle,
-                self.color_set.colon,
-            );
+            let project_str = &self.get_formatted_subtitle_label("Project");
 
             writeln!(
                 f,
@@ -73,11 +69,7 @@ impl std::fmt::Display for Info {
             writeln!(
                 f,
                 "{}{}",
-                &self.get_formatted_subtitle_label(
-                    "HEAD",
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                ),
+                &self.get_formatted_subtitle_label("HEAD"),
                 &self.current_commit.to_string().color(self.color_set.info),
             )?;
         }
@@ -86,11 +78,7 @@ impl std::fmt::Display for Info {
             writeln!(
                 f,
                 "{}{}",
-                &self.get_formatted_subtitle_label(
-                    "Pending",
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                ),
+                &self.get_formatted_subtitle_label("Pending"),
                 &self.pending.color(self.color_set.info),
             )?;
         }
@@ -99,11 +87,7 @@ impl std::fmt::Display for Info {
             writeln!(
                 f,
                 "{}{}",
-                &self.get_formatted_subtitle_label(
-                    "Version",
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                ),
+                &self.get_formatted_subtitle_label("Version"),
                 &self.version.color(self.color_set.info),
             )?;
         }
@@ -112,11 +96,7 @@ impl std::fmt::Display for Info {
             writeln!(
                 f,
                 "{}{}",
-                &self.get_formatted_subtitle_label(
-                    "Created",
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                ),
+                &self.get_formatted_subtitle_label("Created"),
                 &self.creation_date.color(self.color_set.info),
             )?;
         }
@@ -133,11 +113,7 @@ impl std::fmt::Display for Info {
             writeln!(
                 f,
                 "{}{}",
-                &self.get_formatted_subtitle_label(
-                    title,
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                ),
+                &self.get_formatted_subtitle_label(title),
                 languages_str.color(self.color_set.info)
             )?;
         }
@@ -154,11 +130,7 @@ impl std::fmt::Display for Info {
             write!(
                 f,
                 "{}{}",
-                &self.get_formatted_subtitle_label(
-                    title,
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                ),
+                &self.get_formatted_subtitle_label(title),
                 author_str.color(self.color_set.info),
             )?;
         }
@@ -167,11 +139,7 @@ impl std::fmt::Display for Info {
             writeln!(
                 f,
                 "{}{}",
-                &self.get_formatted_subtitle_label(
-                    "Last change",
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                ),
+                &self.get_formatted_subtitle_label("Last change"),
                 &self.last_change.color(self.color_set.info),
             )?;
         }
@@ -180,11 +148,7 @@ impl std::fmt::Display for Info {
             writeln!(
                 f,
                 "{}{}",
-                &self.get_formatted_subtitle_label(
-                    "Repo",
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                ),
+                &self.get_formatted_subtitle_label("Repo"),
                 &self.repo_url.color(self.color_set.info),
             )?;
         }
@@ -193,11 +157,7 @@ impl std::fmt::Display for Info {
             writeln!(
                 f,
                 "{}{}",
-                &self.get_formatted_subtitle_label(
-                    "Commits",
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                ),
+                &self.get_formatted_subtitle_label("Commits"),
                 &self.commits.color(self.color_set.info),
             )?;
         }
@@ -206,11 +166,7 @@ impl std::fmt::Display for Info {
             writeln!(
                 f,
                 "{} {}",
-                &self.get_formatted_subtitle_label(
-                    "Lines of code",
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                ),
+                &self.get_formatted_subtitle_label("Lines of code"),
                 &self.number_of_lines.to_string().color(self.color_set.info),
             )?;
         }
@@ -219,11 +175,7 @@ impl std::fmt::Display for Info {
             writeln!(
                 f,
                 "{}{}",
-                &self.get_formatted_subtitle_label(
-                    "Size",
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                ),
+                &self.get_formatted_subtitle_label("Size"),
                 &self.repo_size.color(self.color_set.info),
             )?;
         }
@@ -232,11 +184,7 @@ impl std::fmt::Display for Info {
             writeln!(
                 f,
                 "{}{}",
-                &self.get_formatted_subtitle_label(
-                    "License",
-                    self.color_set.subtitle,
-                    self.color_set.colon,
-                ),
+                &self.get_formatted_subtitle_label("License"),
                 &self.license.color(self.color_set.info),
             )?;
         }
@@ -698,13 +646,12 @@ impl Info {
         Some(color)
     }
 
-    fn get_formatted_subtitle_label(
-        &self,
-        label: &str,
-        color: Color,
-        colon_clr: Color,
-    ) -> ColoredString {
-        let formatted_label = format!("{}{} ", label.color(color), ":".color(colon_clr));
+    fn get_formatted_subtitle_label(&self, label: &str) -> ColoredString {
+        let formatted_label = format!(
+            "{}{} ",
+            label.color(self.color_set.subtitle),
+            ":".color(self.color_set.colon)
+        );
         self.bold(&formatted_label)
     }
 

--- a/src/onefetch/info.rs
+++ b/src/onefetch/info.rs
@@ -122,34 +122,24 @@ impl std::fmt::Display for Info {
         }
 
         if !self.config.disabled_fields.languages && !self.languages.is_empty() {
-            if self.languages.len() > 1 {
-                let languages_str = self.get_languages_field();
-
-                writeln!(
-                    f,
-                    "{}{}",
-                    &self.get_formatted_subtitle_label(
-                        "Languages",
-                        self.color_set.subtitle,
-                        self.color_set.colon,
-                    ),
-                    languages_str.color(self.color_set.info)
-                )?;
+            let title = if self.languages.len() > 1 {
+                "Languages"
             } else {
-                writeln!(
-                    f,
-                    "{}{}",
-                    &self.get_formatted_subtitle_label(
-                        "Language",
-                        self.color_set.subtitle,
-                        self.color_set.colon,
-                    ),
-                    &self
-                        .dominant_language
-                        .to_string()
-                        .color(self.color_set.info),
-                )?;
+                "Language"
             };
+
+            let languages_str = self.get_language_field(title);
+
+            writeln!(
+                f,
+                "{}{}",
+                &self.get_formatted_subtitle_label(
+                    title,
+                    self.color_set.subtitle,
+                    self.color_set.colon,
+                ),
+                languages_str.color(self.color_set.info)
+            )?;
         }
 
         if !self.config.disabled_fields.authors && !self.authors.is_empty() {
@@ -727,13 +717,13 @@ impl Info {
     }
 
     fn get_author_field(&self, title: &str) -> String {
-        let mut authors_str = String::from("");
+        let mut author_field = String::from("");
 
         let pad = title.len() + 2;
 
         for (i, author) in self.authors.iter().enumerate() {
             if i == 0 {
-                authors_str.push_str(&format!(
+                author_field.push_str(&format!(
                     "{}{} {} {}\n",
                     author.2.to_string().color(self.color_set.info),
                     "%".color(self.color_set.info),
@@ -741,7 +731,7 @@ impl Info {
                     author.1.to_string().color(self.color_set.info),
                 ));
             } else {
-                authors_str.push_str(&format!(
+                author_field.push_str(&format!(
                     "{:<width$}{}{} {} {}\n",
                     "",
                     author.2.to_string().color(self.color_set.info),
@@ -753,13 +743,14 @@ impl Info {
             }
         }
 
-        authors_str
+        author_field
     }
 
-    fn get_languages_field(&self) -> String {
-        let title = "Languages";
-        let pad = " ".repeat(title.len() + 2);
-        let mut languages_str = String::from("");
+    fn get_language_field(&self, title: &str) -> String {
+        let mut language_field = String::from("");
+
+        let pad = title.len() + 2;
+
         let languages: Vec<(String, f64)> = {
             let mut iter = self.languages.iter().map(|x| (format!("{}", x.0), x.1));
             if self.languages.len() > 6 {
@@ -775,21 +766,22 @@ impl Info {
         for (cnt, language) in languages.iter().enumerate() {
             let formatted_number = format!("{:.*}", 1, language.1).color(self.color_set.info);
             if cnt != 0 && cnt % 2 == 0 {
-                languages_str.push_str(&format!(
-                    "\n{}{} ({} %) ",
-                    pad,
+                language_field.push_str(&format!(
+                    "\n{:<width$}{} ({} %) ",
+                    "",
                     language.0.color(self.color_set.info),
-                    formatted_number
+                    formatted_number,
+                    width = pad
                 ));
             } else {
-                languages_str.push_str(&format!(
+                language_field.push_str(&format!(
                     "{} ({} %) ",
                     language.0.color(self.color_set.info),
                     formatted_number
                 ));
             }
         }
-        languages_str
+        language_field
     }
 
     fn get_branches_and_tags_field(&self) -> String {

--- a/src/onefetch/text_color.rs
+++ b/src/onefetch/text_color.rs
@@ -21,7 +21,7 @@ impl TextColor {
         }
     }
 
-    pub fn get_text_color_set(text_colors: &[String], default_colors: &Vec<Color>) -> TextColor {
+    pub fn get_text_color_set(text_colors: &[String], default_colors: &[Color]) -> TextColor {
         let mut text_color_set = TextColor::new(default_colors[0]);
         if !text_colors.is_empty() {
             let custom_color = text_colors


### PR DESCRIPTION
I refactored Info's display implementation by extracting some of the complexity into separate methods and removing `write_buf()` and `get_formatted_info_label()`.