### PR TITLE
feat: hide logo if terminal size is too wide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,7 @@ dependencies = [
  "paste",
  "regex",
  "strum",
+ "term_size",
  "tokei",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ askalono = "0.4.3"
 bytecount = "0.6.1"
 clap = "2.33.3"
 strum = { version = "0.20.0", features = ["derive"] }
+term_size = "0.3.2"
 image = "0.23.12"
 regex = "1"
 error-chain = "0.12"

--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -222,7 +222,7 @@ impl Cli {
         .arg(
             Arg::with_name("off")
                 .long("off")
-                .help("Only shows the info lines. DEPRECATED: use \"--hide-logo\" true instead.")
+                .help("Only shows the info lines. DEPRECATED: use \"--hide-logo true\" instead.")
                 .conflicts_with_all(&["image", "ascii-language", "ascii-input", "hide-logo"]),
             )
         .arg(

--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -225,12 +225,12 @@ impl Cli {
                 .long("hide-logo")
                 .value_name("WHEN")
                 .takes_value(true)
-                .possible_values(&["auto", "never", "always"])
+                .possible_values(&["auto", "always"])
                 .default_value("always")
                 .hide_default_value(true)
-                .help("Specify when to hide the logo (auto, never, *always*).")
+                .help("Specify when to hide the logo (auto, *always*).")
                 .long_help(
-                    "Specify when to hide the logo (auto, never, *always*). \n\
+                    "Specify when to hide the logo (auto, *always*). \n\
                     If set to auto, the logo will be hidden if the terminal's width < 95."
                 )
         ).get_matches();
@@ -251,7 +251,6 @@ impl Cli {
 
         let art_off = match matches.value_of("hide-logo") {
             Some("always") => true,
-            Some("never") => false,
             Some("auto") => {
                 if let Some((width, _)) = term_size::dimensions_stdout() {
                     width < MAX_TERM_WIDTH

--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -286,9 +286,9 @@ impl Cli {
                 if let Some((width, _)) = term_size::dimensions_stdout() {
                     art_off = width <= max_term_size;
                 } else {
-                    std::println!(
+                    std::eprintln!(
                         "{}",
-                        ("Coult not get terminal width. ASCII art will be displayed.").yellow(),
+                        ("Could not get terminal width. ASCII art will be displayed."),
                     );
 
                     art_off = false;

--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -232,7 +232,6 @@ impl Cli {
                 .takes_value(true)
                 .max_values(1)
                 .multiple(false)
-                .default_value("auto")
                 .possible_values(&["auto", "true", "false"])
                 .help("Will hide the logo if true. If set to auto, the logo will be hidden if the terminal size is too small. If set to false, the logo will be shown no matter what.")
                 .conflicts_with("off")
@@ -294,6 +293,18 @@ impl Cli {
 
                     art_off = false;
                 }
+            }
+        } else if !art_off {
+            // Default to auto without setting it in the CLI args
+            if let Some((width, _)) = term_size::dimensions_stdout() {
+                art_off = width <= max_term_size;
+            } else {
+                std::println!(
+                    "{}",
+                    ("Coult not get terminal width. ASCII art will be displayed.").yellow(),
+                );
+
+                art_off = false;
             }
         }
 

--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -277,12 +277,12 @@ impl Cli {
             None
         };
 
-        if let Some(should_hide_logo) = matches.value_of("hide-logo") {
+        if let Some(should_hide_logo) = matches.value_of("hide-logo").or(Some("auto")) {
             if should_hide_logo == "true" {
                 art_off = true;
             } else if should_hide_logo == "false" {
                 art_off = false;
-            } else {
+            } else if !art_off {
                 if let Some((width, _)) = term_size::dimensions_stdout() {
                     art_off = width <= max_term_size;
                 } else {
@@ -293,18 +293,6 @@ impl Cli {
 
                     art_off = false;
                 }
-            }
-        } else if !art_off {
-            // Default to auto without setting it in the CLI args
-            if let Some((width, _)) = term_size::dimensions_stdout() {
-                art_off = width <= max_term_size;
-            } else {
-                std::println!(
-                    "{}",
-                    ("Coult not get terminal width. ASCII art will be displayed.").yellow(),
-                );
-
-                art_off = false;
             }
         }
 

--- a/src/onefetch/cli.rs
+++ b/src/onefetch/cli.rs
@@ -272,10 +272,7 @@ impl Cli {
         if let Some((width, _)) = term_size::dimensions_stdout() {
             art_off = width <= max_term_size && matches.is_present("hide-logo");
         } else {
-            std::eprintln!(
-                "{}",
-                ("Could not get terminal width. ASCII art will be displayed."),
-            );
+            std::eprintln!("{}", ("Could not get terminal width. ASCII art will be displayed."));
         }
 
         if image.is_some() && image_backend.is_none() {


### PR DESCRIPTION
a new CLI option to configure whether the logo should be shown
if configued to auto, Onefetch will detect the terminal size and
hide/show the logo based off that.