### PR TITLE
Adding pyproject.toml and Pipfile for pip package manager

### DIFF
--- a/src/onefetch/deps/mod.rs
+++ b/src/onefetch/deps/mod.rs
@@ -34,7 +34,15 @@ impl DependencyDetector {
         );
         package_managers.insert(
             String::from("requirements.txt"),
-            (package_parser::pip, package_manager::PackageManager::Pip),
+            (package_parser::pip_reqs, package_manager::PackageManager::Pip),
+        );
+        package_managers.insert(
+            String::from("pyproject.toml"),
+            (package_parser::pip_pyproject, package_manager::PackageManager::Pip),
+        );
+        package_managers.insert(
+            String::from("Pipfile"),
+            (package_parser::pip_pipfile, package_manager::PackageManager::Pip),
         );
         package_managers.insert(
             String::from("pubspec.yaml"),

--- a/src/onefetch/deps/package_parser.rs
+++ b/src/onefetch/deps/package_parser.rs
@@ -38,10 +38,32 @@ pub fn npm(contents: &str) -> Result<usize> {
     Ok(parsed["dependencies"].len())
 }
 
-pub fn pip(contents: &str) -> Result<usize> {
+pub fn pip_reqs(contents: &str) -> Result<usize> {
     let count = Regex::new(r"(^|\n)[A-z]+")?.find_iter(contents).count();
 
     Ok(count)
+}
+
+pub fn pip_pyproject(contents: &str) -> Result<usize> {
+    let parsed = contents.parse::<Value>()?;
+    let count = parsed
+        .get("tool")
+        .and_then(|tool| tool.get("poetry"))
+        .and_then(|poetry| poetry.get("dependencies"));
+    match count {
+        Some(val) => Ok(val.as_table().unwrap().len()),
+        None => Ok(0),
+    }
+}
+
+pub fn pip_pipfile(contents: &str) -> Result<usize> {
+    let parsed = contents.parse::<Value>()?;
+    let count = parsed.get("packages");
+
+    match count {
+        Some(val) => Ok(val.as_table().unwrap().len()),
+        None => Ok(0),
+    }
 }
 
 pub fn pub_packages(contents: &str) -> Result<usize> {


### PR DESCRIPTION
I am not sure yet how to handle this case. For now `requirements.txt`, `Pipfile`and `pyproject.toml` are parsed and included for dependencies in output. I choose this because it is unlikely to include more then one of them in you python projects and I didnt want to change the logic of package retrieval. 

What are your thoughts? @o2sh @spenserblack 