### PR TITLE
Make audit scheduled and manually runnable

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,7 +11,7 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
   schedule:
-    - cron: '59 23 * * *'
+    - cron: '0 0 * * 0'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,19 @@
+name: Security Audit
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '59 23 * * *'
+  workflow_dispatch:
+
+jobs:
+  sec:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/audit-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,8 +2,14 @@ name: Security Audit
 on:
   push:
     branches: [ master ]
+    paths: 
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
   pull_request:
     branches: [ master ]
+    paths: 
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
   schedule:
     - cron: '59 23 * * *'
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,3 @@ jobs:
         toolchain: stable
         components: rustfmt
     - run: cargo fmt -- --check
-
-  sec:
-    name: Security audit
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/audit-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Moves the security audit into a separate workflow so that it can be run
on a schedule, and also dispatched manually.

***

Since a new security issue could be found and reported for an existing dependency even if that dependency doesn't change, I thought it could be helpful to regularly check the audit.
I scheduled it to be run once daily at 23:59 GMT, but it can be set for a different time/frequency :slightly_smiling_face: 