### PR TITLE
Make Ruby logo red

### DIFF
--- a/src/info/langs/language.rs
+++ b/src/info/langs/language.rs
@@ -232,7 +232,7 @@ define_languages! {
         ] ),
         "raku"
     },
-    { Ruby, "ruby.ascii", define_colors!( [Color::Magenta] ) },
+    { Ruby, "ruby.ascii", define_colors!( [Color::Red] : [Color::TrueColor{ r: 204, g: 52, b: 45 }] ) },
     { Rust, "rust.ascii", define_colors!( [Color::Red, Color::White] : [Color::TrueColor{ r:228, g:55 ,b:23}, Color::TrueColor{ r:255, g:255 ,b:255} ] ) },
     { Sass, "sass.ascii", define_colors!( [Color::Magenta] : [Color::TrueColor{ r:205, g:103 ,b:153} ] ) },
     { Scala, "scala.ascii", define_colors!( [Color::Red, Color::Red] : [Color::TrueColor{ r:223, g:63 ,b:61}, Color::TrueColor{ r:127, g:12 ,b:29} ] ) },


### PR DESCRIPTION
This changes the Ruby logo from being Magenta to Red.
This also adds a `TrueColor` from Ruby's primary color, based on their website. `#CC342D`.

***

The color was set to Magenta in e0288045493dda817910dcae5c796c581b3dace2, so I think the color was
originally for testing and wasn't changed.
