### PR TITLE
add language bar

### DIFF
--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -351,11 +351,10 @@ impl Info {
 
         for (cnt, language) in languages.iter().enumerate() {
             let formatted_number = format!("{:.*}", 1, language.1);
-            let language_chip = format!("\u{25CF}").color(language.2);
             let language_with_perc =
                 format!("{} ({} %)", language.0, formatted_number).color(self.text_colors.info);
-            let language_str =
-                format!("{} {} ", language_chip, language_with_perc).color(self.text_colors.info);
+            let language_chip = format!("\u{25CF}").color(language.2);
+            let language_str = format!("{} {} ", language_chip, language_with_perc);
             if cnt % 2 == 0 {
                 language_field.push_str(&format!("\n{:<width$}{}", "", language_str, width = pad));
             } else {

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -304,7 +304,7 @@ impl Info {
     }
 
     fn get_language_field(&self, title: &str) -> String {
-        let progress_bar_length = 26;
+        let language_bar_length = 26;
         let pad = title.len() + 2;
         let color_palette = vec![
             Color::Red,
@@ -339,7 +339,7 @@ impl Info {
 
         for (_, language) in languages.iter().enumerate() {
             let bar_width = std::cmp::max(
-                (language.1 / 100. * progress_bar_length as f64).round() as usize,
+                (language.1 / 100. * language_bar_length as f64).round() as usize,
                 1,
             );
             language_field.push_str(&format!(

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -335,23 +335,16 @@ impl Info {
             }
         };
 
-        let mut actual_language_bar_length = 0;
-        let language_bars: Vec<String> = languages
+        let language_bar: String = languages
             .iter()
             .map(|x| {
                 let bar_width = std::cmp::max(
                     (x.1 / 100. * language_bar_length as f64).round() as usize,
                     1,
                 );
-                actual_language_bar_length += bar_width;
                 format!("{:<width$}", "".on_color(x.2), width = bar_width)
             })
             .collect();
-
-        let mut language_bar = String::with_capacity(actual_language_bar_length);
-        for bar in language_bars.iter() {
-            language_bar.push_str(bar);
-        }
 
         language_field.push_str(&language_bar);
 

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -351,13 +351,11 @@ impl Info {
 
         for (cnt, language) in languages.iter().enumerate() {
             let formatted_number = format!("{:.*}", 1, language.1);
-            let language_str = format!(
-                "{} {} ({} %) ",
-                "\u{25CF}".color(language.2),
-                language.0,
-                formatted_number
-            )
-            .color(self.text_colors.info);
+            let language_chip = format!("\u{25CF}").color(language.2);
+            let language_with_perc =
+                format!("{} ({} %)", language.0, formatted_number).color(self.text_colors.info);
+            let language_str =
+                format!("{} {} ", language_chip, language_with_perc).color(self.text_colors.info);
             if cnt % 2 == 0 {
                 language_field.push_str(&format!("\n{:<width$}{}", "", language_str, width = pad));
             } else {


### PR DESCRIPTION
#584 

<img width="763" alt="Screenshot 2022-02-19 at 23 21 45" src="https://user-images.githubusercontent.com/13710835/154821012-ee56db4a-25e1-4170-94e0-1413cd0bbbd0.png">

Remarks:

- The language bar is 26 characters long (arbitrary value). However, in some cases it can be longer. Indeed, if a language's weight in the distribution is too small to account for a whole character, I do a cmp::Max(val, 1) so that, it will still appear in the language bar. This may not be optimal 🤔 

- As discussed before, if the terminal doesn't support true color, we fallback to a default color palette:

<img width="738" alt="Screenshot 2022-02-19 at 23 49 27" src="https://user-images.githubusercontent.com/13710835/154821754-ab089e6f-36c3-4a63-b250-b7df2049183e.png">

