### PR TITLE
Add `_` as possible color value

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,7 +46,7 @@ impl Config {
         let possible_backends = ["kitty", "iterm", "sixel"];
 
         let color_values = &[
-            "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
+            "_", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
         ];
         let matches = clap::Command::new(crate_name!())
         .version(crate_version!())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,7 +46,8 @@ impl Config {
         let possible_backends = ["kitty", "iterm", "sixel"];
 
         let color_values = &[
-            "_", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
+            "_", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
+            "15",
         ];
         let matches = clap::Command::new(crate_name!())
         .version(crate_version!())


### PR DESCRIPTION
Allows user to disable the color and instead use the default terminal
foreground color, which can be different from the 16 available colors.

Related: https://github.com/o2sh/onefetch/issues/33#issuecomment-1048968541

Ideally, a `Color::None` variant could be added to `colored`, but IDK if the crate is still maintained (last commit was a while ago).

******

While I personally like `_` as the "don't care" value, I'm open to suggestions :slightly_smiling_face: 

Also open to suggestions on best way to document this.

Note that this only works with text colors, since `None` values are ignored for the ASCII art. So this PR probably needs some adjustment: either remove the possible value for `-c`, or add support for disabling colors for the ASCII art.