### PR TITLE
Default to terminal foreground color for tilde, underline, colon and info

### DIFF
--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -1,6 +1,6 @@
 use crate::cli::{self, Config};
 use crate::ui::get_ascii_colors;
-use crate::ui::text_color::{color_if_some, TextColor};
+use crate::ui::{text_color::TextColor, ColorizeOption};
 use anyhow::Result;
 use author::Author;
 use colored::{Color, ColoredString, Colorize};
@@ -56,11 +56,7 @@ impl std::fmt::Display for Info {
             let (git_info_field_str, git_info_field_len) = self.get_git_info_field();
             writeln!(f, "{}", git_info_field_str)?;
             let separator = "-".repeat(git_info_field_len);
-            writeln!(
-                f,
-                "{}",
-                color_if_some(&separator, self.text_colors.underline)
-            )?;
+            writeln!(f, "{}", separator.try_color(self.text_colors.underline))?;
         }
 
         if !self.config.disabled_fields.project && !self.repo_name.is_empty() {
@@ -229,7 +225,7 @@ impl Info {
         info: &str,
         f: &mut std::fmt::Formatter,
     ) -> std::fmt::Result {
-        let info_colored = color_if_some(info, self.text_colors.info);
+        let info_colored = info.try_color(self.text_colors.info);
         writeln!(
             f,
             "{} {}",
@@ -251,7 +247,7 @@ impl Info {
         let formatted_label = format!(
             "{}{}",
             label.color(self.text_colors.subtitle),
-            color_if_some(":", self.text_colors.colon)
+            ":".try_color(self.text_colors.colon)
         );
         self.bold(&formatted_label)
     }
@@ -272,7 +268,7 @@ impl Info {
                 format!(
                     "{} {} {}",
                     &self.bold(&self.git_username).color(self.text_colors.title),
-                    color_if_some(&self.bold("~"), self.text_colors.tilde),
+                    &self.bold("~").try_color(self.text_colors.tilde),
                     &self.bold(&self.git_version).color(self.text_colors.title)
                 ),
                 git_info_length + 3,
@@ -295,7 +291,7 @@ impl Info {
         let pad = title.len() + 2;
 
         for (i, author) in self.authors.iter().enumerate() {
-            let author_str = color_if_some(&format!("{}", author), self.text_colors.info);
+            let author_str = format!("{}", author).try_color(self.text_colors.info);
 
             if i == 0 {
                 author_field.push_str(&format!("{}", author_str));
@@ -354,10 +350,8 @@ impl Info {
 
         for (i, language) in languages.iter().enumerate() {
             let formatted_number = format!("{:.*}", 1, language.1);
-            let language_with_perc = color_if_some(
-                &format!("{} ({} %)", language.0, formatted_number),
-                self.text_colors.info,
-            );
+            let language_with_perc =
+                format!("{} ({} %)", language.0, formatted_number).try_color(self.text_colors.info);
             let language_chip = "\u{25CF}".color(language.2);
             let language_str = format!("{} {} ", language_chip, language_with_perc);
             if i % 2 == 0 {

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -1,6 +1,6 @@
 use crate::cli::{self, Config};
 use crate::ui::get_ascii_colors;
-use crate::ui::text_color::TextColor;
+use crate::ui::text_color::{color_if_some, TextColor};
 use anyhow::Result;
 use author::Author;
 use colored::{Color, ColoredString, Colorize};
@@ -56,7 +56,11 @@ impl std::fmt::Display for Info {
             let (git_info_field_str, git_info_field_len) = self.get_git_info_field();
             writeln!(f, "{}", git_info_field_str)?;
             let separator = "-".repeat(git_info_field_len);
-            writeln!(f, "{}", separator.color(self.text_colors.underline))?;
+            writeln!(
+                f,
+                "{}",
+                color_if_some(&separator, self.text_colors.underline)
+            )?;
         }
 
         if !self.config.disabled_fields.project && !self.repo_name.is_empty() {
@@ -225,7 +229,7 @@ impl Info {
         info: &str,
         f: &mut std::fmt::Formatter,
     ) -> std::fmt::Result {
-        let info_colored = info.color(self.text_colors.info);
+        let info_colored = color_if_some(info, self.text_colors.info);
         writeln!(
             f,
             "{} {}",
@@ -247,7 +251,7 @@ impl Info {
         let formatted_label = format!(
             "{}{}",
             label.color(self.text_colors.subtitle),
-            ":".color(self.text_colors.colon)
+            color_if_some(":", self.text_colors.colon)
         );
         self.bold(&formatted_label)
     }
@@ -268,7 +272,7 @@ impl Info {
                 format!(
                     "{} {} {}",
                     &self.bold(&self.git_username).color(self.text_colors.title),
-                    &self.bold("~").color(self.text_colors.tilde),
+                    color_if_some(&self.bold("~"), self.text_colors.tilde),
                     &self.bold(&self.git_version).color(self.text_colors.title)
                 ),
                 git_info_length + 3,
@@ -291,7 +295,7 @@ impl Info {
         let pad = title.len() + 2;
 
         for (i, author) in self.authors.iter().enumerate() {
-            let author_str = format!("{}", author).color(self.text_colors.info);
+            let author_str = color_if_some(&format!("{}", author), self.text_colors.info);
 
             if i == 0 {
                 author_field.push_str(&format!("{}", author_str));
@@ -350,8 +354,10 @@ impl Info {
 
         for (i, language) in languages.iter().enumerate() {
             let formatted_number = format!("{:.*}", 1, language.1);
-            let language_with_perc =
-                format!("{} ({} %)", language.0, formatted_number).color(self.text_colors.info);
+            let language_with_perc = color_if_some(
+                &format!("{} ({} %)", language.0, formatted_number),
+                self.text_colors.info,
+            );
             let language_chip = "\u{25CF}".color(language.2);
             let language_str = format!("{} {} ", language_chip, language_with_perc);
             if i % 2 == 0 {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,10 +1,27 @@
 use crate::info::langs::language::Language;
-use colored::Color;
+use colored::{Color, ColoredString, Colorize};
 
 pub mod ascii_art;
 pub mod image_backends;
 pub mod printer;
 pub mod text_color;
+
+pub trait ColorizeOption {
+    fn try_color<S: Into<Color>>(self, color: Option<S>) -> ColoredString;
+}
+
+impl<T> ColorizeOption for T
+where
+    T: Colorize,
+    T: Into<ColoredString>,
+{
+    fn try_color<S: Into<Color>>(self, color: Option<S>) -> ColoredString {
+        match color {
+            Some(color) => Colorize::color(self, color),
+            None => self.into(),
+        }
+    }
+}
 
 pub fn get_ascii_colors(
     ascii_language: &Option<Language>,

--- a/src/ui/text_color.rs
+++ b/src/ui/text_color.rs
@@ -1,5 +1,5 @@
 use crate::ui::num_to_color;
-use colored::{Color, ColoredString, Colorize};
+use colored::Color;
 
 pub struct TextColor {
     pub title: Color,
@@ -45,13 +45,5 @@ impl TextColor {
         }
 
         text_color_set
-    }
-}
-
-pub fn color_if_some(s: &str, color: Option<Color>) -> ColoredString {
-    if let Some(c) = color {
-        s.color(c)
-    } else {
-        s.into()
     }
 }

--- a/src/ui/text_color.rs
+++ b/src/ui/text_color.rs
@@ -1,24 +1,24 @@
 use crate::ui::num_to_color;
-use colored::Color;
+use colored::{Color, ColoredString, Colorize};
 
 pub struct TextColor {
     pub title: Color,
-    pub tilde: Color,
-    pub underline: Color,
+    pub tilde: Option<Color>,
+    pub underline: Option<Color>,
     pub subtitle: Color,
-    pub colon: Color,
-    pub info: Color,
+    pub colon: Option<Color>,
+    pub info: Option<Color>,
 }
 
 impl TextColor {
     fn new(color: Color) -> TextColor {
         TextColor {
             title: color,
-            tilde: Color::White,
-            underline: Color::White,
+            tilde: None,
+            underline: None,
             subtitle: color,
-            colon: Color::White,
-            info: Color::White,
+            colon: None,
+            info: None,
         }
     }
 
@@ -37,13 +37,21 @@ impl TextColor {
                 .collect::<Vec<Color>>();
 
             text_color_set.title = *custom_color.get(0).unwrap_or(&default_colors[0]);
-            text_color_set.tilde = *custom_color.get(1).unwrap_or(&Color::White);
-            text_color_set.underline = *custom_color.get(2).unwrap_or(&Color::White);
+            text_color_set.tilde = custom_color.get(1).cloned();
+            text_color_set.underline = custom_color.get(2).cloned();
             text_color_set.subtitle = *custom_color.get(3).unwrap_or(&default_colors[0]);
-            text_color_set.colon = *custom_color.get(4).unwrap_or(&Color::White);
-            text_color_set.info = *custom_color.get(5).unwrap_or(&Color::White);
+            text_color_set.colon = custom_color.get(4).cloned();
+            text_color_set.info = custom_color.get(5).cloned();
         }
 
         text_color_set
+    }
+}
+
+pub fn color_if_some(s: &str, color: Option<Color>) -> ColoredString {
+    if let Some(c) = color {
+        s.color(c)
+    } else {
+        s.into()
     }
 }


### PR DESCRIPTION
As suggested [here](https://github.com/o2sh/onefetch/pull/593#issuecomment-1049336777)