### PR TITLE
Use `Default` color instead of `White`

### DIFF
--- a/src/info/langs/language.rs
+++ b/src/info/langs/language.rs
@@ -8,9 +8,20 @@ pub struct Colors {
     true_colors: Option<Vec<DynColors>>,
 }
 
+/// Maps colors to preferred versions. Used to allow contributors to include
+/// colors with minimal confusion.
+macro_rules! clean_color {
+    ( White ) => {
+        clean_color!(Default)
+    };
+    ( $color:ident ) => {
+        DynColors::Ansi(AnsiColors::$color)
+    };
+}
+
 macro_rules! define_colors {
-    ( [ $($color:ident),+ ] ) => { Colors { basic_colors: vec![$(DynColors::Ansi(AnsiColors::$color)),+], true_colors: None } };
-    ( [ $($bc:ident),+ ] : [ $($c:ident($r:expr, $g:expr, $b:expr)),+ ] ) => { Colors { basic_colors: vec![$(DynColors::Ansi(AnsiColors::$bc)),+], true_colors: Some(vec![$(DynColors::$c($r, $g, $b)),+]) } };
+    ( [ $($color:ident),+ ] ) => { Colors { basic_colors: vec![$( clean_color!($color) ),+], true_colors: None } };
+    ( [ $($bc:ident),+ ] : [ $($c:ident($r:expr, $g:expr, $b:expr)),+ ] ) => { Colors { basic_colors: vec![$(clean_color!($bc)),+], true_colors: Some(vec![$(DynColors::$c($r, $g, $b)),+]) } };
 }
 
 #[derive(PartialEq, EnumString, EnumIter, IntoStaticStr)]

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -335,7 +335,7 @@ impl Info {
                 languages.push((
                     "Other".to_string(),
                     other_perc,
-                    DynColors::Ansi(AnsiColors::White),
+                    DynColors::Ansi(AnsiColors::Default),
                 ));
                 languages
             } else {

--- a/src/ui/ascii_art.rs
+++ b/src/ui/ascii_art.rs
@@ -155,7 +155,7 @@ impl<'a> Tokens<'a> {
         let mut width = end - start;
         let mut colored_segment = String::new();
         let mut whole_string = String::new();
-        let mut color = &DynColors::Ansi(AnsiColors::White);
+        let mut color = &DynColors::Ansi(AnsiColors::Default);
 
         self.truncate(start, end).for_each(|token| {
             match token {
@@ -168,7 +168,7 @@ impl<'a> Tokens<'a> {
                     colored_segment = String::new();
                     color = colors
                         .get(col as usize)
-                        .unwrap_or(&DynColors::Ansi(AnsiColors::White));
+                        .unwrap_or(&DynColors::Ansi(AnsiColors::Default));
                 }
                 Token::Space => {
                     width = width.saturating_sub(1);
@@ -266,52 +266,52 @@ mod test {
 
         assert_eq!(
             Tokens("").render(&colors_shim, 0, 0, true),
-            "\u{1b}[37;1m\u{1b}[0m"
+            "\u{1b}[39;1m\u{1b}[0m"
         );
 
         assert_eq!(
             Tokens("     ").render(&colors_shim, 0, 0, true),
-            "\u{1b}[37;1m\u{1b}[0m"
+            "\u{1b}[39;1m\u{1b}[0m"
         );
 
         assert_eq!(
             Tokens("     ").render(&colors_shim, 0, 5, true),
-            "\u{1b}[37;1m     \u{1b}[0m"
+            "\u{1b}[39;1m     \u{1b}[0m"
         );
 
         assert_eq!(
             Tokens("     ").render(&colors_shim, 1, 5, true),
-            "\u{1b}[37;1m    \u{1b}[0m"
+            "\u{1b}[39;1m    \u{1b}[0m"
         );
 
         assert_eq!(
             Tokens("     ").render(&colors_shim, 3, 5, true),
-            "\u{1b}[37;1m  \u{1b}[0m"
+            "\u{1b}[39;1m  \u{1b}[0m"
         );
 
         assert_eq!(
             Tokens("     ").render(&colors_shim, 0, 4, true),
-            "\u{1b}[37;1m    \u{1b}[0m"
+            "\u{1b}[39;1m    \u{1b}[0m"
         );
 
         assert_eq!(
             Tokens("     ").render(&colors_shim, 0, 3, true),
-            "\u{1b}[37;1m   \u{1b}[0m"
+            "\u{1b}[39;1m   \u{1b}[0m"
         );
 
         assert_eq!(
             Tokens("  {1} {5}  {9} a").render(&colors_shim, 4, 10, true),
-            "\u{1b}[37;1m\u{1b}[0m\u{1b}[37;1m\u{1b}[0m\u{1b}[37;1m \u{1b}[0m\u{1b}[37;1m a\u{1b}[0m   "
+            "\u{1b}[39;1m\u{1b}[0m\u{1b}[39;1m\u{1b}[0m\u{1b}[39;1m \u{1b}[0m\u{1b}[39;1m a\u{1b}[0m   "
         );
 
         // Tests for bold disabled
         assert_eq!(
             Tokens("     ").render(&colors_shim, 0, 0, false),
-            "\u{1b}[37m\u{1b}[0m"
+            "\u{1b}[39m\u{1b}[0m"
         );
         assert_eq!(
             Tokens("     ").render(&colors_shim, 0, 5, false),
-            "\u{1b}[37m     \u{1b}[0m"
+            "\u{1b}[39m     \u{1b}[0m"
         );
     }
 


### PR DESCRIPTION
Allows the "white" color to have the greatest chance of being a dark,
visible color for light terminal themes. A macro is used to remap
`White` to `Default` to minimize size of the diff and prevent
contributors from needing to be familiar with the `Default` color on top
of the 8 standard colors.

For #33
Supersedes #611

### TODO

- [x] Review other uses of `White` where `Default` should be used