### PR TITLE
Fix "other" language block hidden in background

### DIFF
--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -335,7 +335,7 @@ impl Info {
                 languages.push((
                     "Other".to_string(),
                     other_perc,
-                    DynColors::Ansi(AnsiColors::Default),
+                    DynColors::Ansi(AnsiColors::White),
                 ));
                 languages
             } else {


### PR DESCRIPTION
This reverts the change introduced in #625 to use `Default` instead of `White` for the "other"
block.

See https://github.com/o2sh/onefetch/pull/625#discussion_r832237395
