### PR TITLE
Add `--completion` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7ca9141e27e6ebc52e3c378b0c07f3cea52db46ed1cc5861735fb697b56356"
+dependencies = [
+ "clap 3.1.15",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1629,7 @@ dependencies = [
  "byte-unit",
  "bytecount",
  "clap 3.1.15",
+ "clap_complete",
  "color_quant",
  "git-repository",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ askalono = "0.4.5"
 byte-unit = "4.0" # to match git-repository's lower requirement, which it needs for MSRV
 bytecount = "0.6.2"
 clap = {version = "3.1.15", features = ["cargo", "wrap_help"]}
+clap_complete = "3.1"
 color_quant = "1.1.0"
 git2 = {version = "0.14.2", default-features = false}
 git-repository = { version = "0.16.0", features = ["max-performance", "unstable", "serde1"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -235,7 +235,6 @@ pub fn print_completions<G: Generator>(gen: G) {
 
 pub(crate) fn build_cli() -> clap::Command<'static> {
     let possible_backends = ["kitty", "iterm", "sixel"];
-    let possible_shells = Shell::possible_values();
 
     let color_values = &[
         "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
@@ -492,7 +491,7 @@ pub(crate) fn build_cli() -> clap::Command<'static> {
         .arg(
             Arg::new("completion")
                 .long("completion")
-                .possible_values(possible_shells)
+                .possible_values(Shell::possible_values())
                 .value_name("SHELL")
                 .help("Print shell completions to STDOUT and exit")
         )

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use crate::ui::image_backends;
 use crate::ui::image_backends::ImageBackend;
 use crate::ui::printer::SerializationFormat;
 use anyhow::{Context, Result};
-use clap::{crate_description, crate_name, crate_version, AppSettings, Arg};
+use clap::{crate_description, crate_name, crate_version, AppSettings, Arg, ValueHint};
 use image::DynamicImage;
 use regex::Regex;
 use std::process::Command;
@@ -58,6 +58,7 @@ impl Config {
             .default_value(".")
             .hide_default_value(true)
             .help("Run as if onefetch was started in <input> instead of the current working directory.")
+            .value_hint(ValueHint::DirPath)
         )
         .arg(
             Arg::new("output")
@@ -102,7 +103,8 @@ impl Config {
             .long("image")
             .value_name("IMAGE")
             .takes_value(true)
-            .help("Path to the IMAGE file."),
+            .help("Path to the IMAGE file.")
+            .value_hint(ValueHint::FilePath)
         )
         .arg(
             Arg::new("image-backend")
@@ -275,7 +277,8 @@ impl Config {
             .value_name("EXCLUDE")
             .multiple_values(true)
             .takes_value(true)
-            .help("Ignore all files & directories matching EXCLUDE."),
+            .help("Ignore all files & directories matching EXCLUDE.")
+            .value_hint(ValueHint::AnyPath)
         )
         .arg(
             Arg::new("type")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -233,7 +233,7 @@ pub fn print_completions<G: Generator>(gen: G) {
     generate(gen, &mut cmd, name, &mut io::stdout());
 }
 
-pub(crate) fn build_cli() -> clap::Command<'static> {
+pub fn build_cli() -> clap::Command<'static> {
     let possible_backends = ["kitty", "iterm", "sixel"];
 
     let color_values = &[

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -229,7 +229,7 @@ pub fn get_git_version() -> String {
 
 pub fn print_completions<G: Generator>(gen: G) {
     let mut cmd = build_cli();
-    let name = crate_name!();
+    let name = cmd.get_name().to_string();
     generate(gen, &mut cmd, name, &mut io::stdout());
 }
 
@@ -493,6 +493,6 @@ pub fn build_cli() -> clap::Command<'static> {
                 .long("completion")
                 .possible_values(Shell::possible_values())
                 .value_name("SHELL")
-                .help("Print shell completion to STDOUT and exit.")
+                .help("Prints out SHELL completion script.")
         )
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -493,6 +493,6 @@ pub(crate) fn build_cli() -> clap::Command<'static> {
                 .long("completion")
                 .possible_values(Shell::possible_values())
                 .value_name("SHELL")
-                .help("Print shell completions to STDOUT and exit")
+                .help("Print shell completion to STDOUT and exit.")
         )
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,8 +6,10 @@ use crate::ui::image_backends::ImageBackend;
 use crate::ui::printer::SerializationFormat;
 use anyhow::{Context, Result};
 use clap::{crate_description, crate_name, crate_version, AppSettings, Arg, ValueHint};
+use clap_complete::{generate, Generator, Shell};
 use image::DynamicImage;
 use regex::Regex;
+use std::io;
 use std::process::Command;
 use std::{convert::From, env, str::FromStr};
 use strum::IntoEnumIterator;
@@ -39,264 +41,12 @@ pub struct Config {
     pub show_email: bool,
     pub include_hidden: bool,
     pub language_types: Vec<LanguageType>,
+    pub completion: Option<Shell>,
 }
 
 impl Config {
     pub fn new() -> Result<Self> {
-        let possible_backends = ["kitty", "iterm", "sixel"];
-
-        let color_values = &[
-            "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
-        ];
-        let matches = clap::Command::new(crate_name!())
-        .version(crate_version!())
-        .about(crate_description!())
-        .setting(AppSettings::DeriveDisplayOrder)
-        .hide_possible_values(true)
-        .arg(
-            Arg::new("input")
-            .default_value(".")
-            .hide_default_value(true)
-            .help("Run as if onefetch was started in <input> instead of the current working directory.")
-            .value_hint(ValueHint::DirPath)
-        )
-        .arg(
-            Arg::new("output")
-            .short('o')
-            .long("output")
-            .value_name("FORMAT")
-            .help("Outputs Onefetch in a specific format (json, yaml).")
-            .takes_value(true)
-            .possible_values(
-                &SerializationFormat::iter()
-                .map(|format| format.into())
-                .collect::<Vec<&str>>())
-        )
-        .arg(
-            Arg::new("languages")
-            .short('l')
-            .long("languages")
-            .help("Prints out supported languages."),
-        )
-        .arg(
-            Arg::new("package-managers")
-            .short('p')
-            .long("package-managers")
-            .help("Prints out supported package managers."),
-        )
-        .arg(
-            Arg::new("show-logo")
-            .long("show-logo")
-            .value_name("WHEN")
-            .takes_value(true)
-            .possible_values(&["auto", "never", "always"])
-            .default_value("always")
-            .hide_default_value(true)
-            .help("Specify when to show the logo (auto, never, *always*).")
-            .long_help(
-                "Specify when to show the logo (auto, never, *always*). \n\
-                If set to auto: the logo will be hidden if the terminal's width < 95.")
-        )
-        .arg(
-            Arg::new("image")
-            .short('i')
-            .long("image")
-            .value_name("IMAGE")
-            .takes_value(true)
-            .help("Path to the IMAGE file.")
-            .value_hint(ValueHint::FilePath)
-        )
-        .arg(
-            Arg::new("image-backend")
-            .long("image-backend")
-            .value_name("BACKEND")
-            .takes_value(true)
-            .requires("image")
-            .possible_values(&possible_backends)
-            .help("Which image BACKEND to use."),
-        )
-        .arg(
-            Arg::new("color-resolution")
-            .long("color-resolution")
-            .value_name("VALUE")
-            .requires("image")
-            .takes_value(true)
-            .possible_values(&["16", "32", "64", "128", "256"])
-            .help("VALUE of color resolution to use with SIXEL backend."),
-        )
-        .arg(
-            Arg::new("ascii-language")
-           .short('a')
-           .value_name("LANGUAGE")
-           .long("ascii-language")
-           .takes_value(true)
-           .ignore_case(true)
-           .help("Which LANGUAGE's ascii art to print.")
-           .possible_values(
-               &Language::iter()
-               .map(|language| language.into())
-               .collect::<Vec<&str>>())
-        )
-        .arg(
-            Arg::new("ascii-input")
-            .long("ascii-input")
-            .value_name("STRING")
-            .takes_value(true)
-            .help("Takes a non-empty STRING as input to replace the ASCII logo.")
-            .long_help(
-                "Takes a non-empty STRING as input to replace the ASCII logo. \
-                It is possible to pass a generated STRING by command substitution. \n\
-                For example:\n \
-                '--ascii-input \"$(fortune | cowsay -W 25)\"'")
-            .validator(|t| {
-                if t.is_empty() {
-                    Err(String::from("must not be empty"))
-                } else {
-                    Ok(())
-                }
-            }),
-        )
-        .arg(
-            Arg::new("true-color")
-            .long("true-color")
-            .value_name("WHEN")
-            .takes_value(true)
-            .possible_values(&["auto", "never", "always"])
-            .default_value("auto")
-            .hide_default_value(true)
-            .help("Specify when to use true color (*auto*, never, always).")
-            .long_help(
-                "Specify when to use true color (*auto*, never, always). \n\
-                If set to auto: true color will be enabled if supported by the terminal.")
-        )
-        .arg(
-            Arg::new("ascii-colors")
-            .short('c')
-            .long("ascii-colors")
-            .value_name("X")
-            .multiple_values(true)
-            .takes_value(true)
-            .possible_values(color_values)
-            .help("Colors (X X X...) to print the ascii art."),
-        )
-        .arg(
-            Arg::new("text-colors")
-            .short('t')
-            .long("text-colors")
-            .value_name("X")
-            .multiple_values(true)
-            .takes_value(true)
-            .max_values(6)
-            .possible_values(color_values)
-            .help("Changes the text colors (X X X...).")
-            .long_help(
-                "Changes the text colors (X X X...). \
-                Goes in order of title, ~, underline, subtitle, colon, and info. \n\
-                For example:\n \
-                '--text-colors 9 10 11 12 13 14'")
-        )
-        .arg(
-            Arg::new("no-bold")
-            .long("no-bold")
-            .help("Turns off bold formatting."),
-        )
-        .arg(
-            Arg::new("no-palette")
-            .long("no-palette")
-            .help("Hides the color palette."),
-        )
-        .arg(
-            Arg::new("no-merges")
-            .long("no-merges")
-            .help("Ignores merge commits."),
-        )
-        .arg(
-            Arg::new("no-bots")
-            .long("no-bots")
-            .min_values(0)
-            .max_values(1)
-            .value_name("REGEX")
-            .help("Exclude [bot] commits. Use <REGEX> to override the default pattern.")
-            .validator(|p| {
-                match Regex::from_str(p) {
-                    Ok(_) => Ok(()),
-                    Err(_) => Err(String::from("must be a valid regex pattern"))
-                }
-            }),
-        )
-        .arg(
-            Arg::new("isotime")
-            .short('z')
-            .long("isotime")
-            .help("Use ISO 8601 formatted timestamps.")
-        )
-        .arg(
-            Arg::new("disable-fields")
-            .long("disable-fields")
-            .short('d')
-            .value_name("FIELD")
-            .multiple_values(true)
-            .takes_value(true)
-            .ignore_case(true)
-            .help("Allows you to disable FIELD(s) from appearing in the output.")
-            .possible_values(
-                &InfoField::iter()
-                    .map(|field| field.into())
-                    .collect::<Vec<&str>>())
-        )
-        .arg(
-            Arg::new("authors-number")
-            .short('A')
-            .long("authors-number")
-            .value_name("NUM")
-            .takes_value(true)
-            .default_value("3")
-            .help("NUM of authors to be shown.")
-            .validator(|t| {
-                match t.parse::<u32>() {
-                    Ok(_) => Ok(()),
-                    Err(_) => Err(String::from("must be a number"))
-                }
-            })
-        )
-        .arg(
-            Arg::new("email")
-            .short('E')
-            .long("email")
-            .help("show the email address of each author.")
-        )
-        .arg(
-            Arg::new("hidden")
-            .long("hidden")
-            .help("Count hidden files and directories.")
-        )
-        .arg(
-            Arg::new("exclude")
-            .short('e')
-            .long("exclude")
-            .value_name("EXCLUDE")
-            .multiple_values(true)
-            .takes_value(true)
-            .help("Ignore all files & directories matching EXCLUDE.")
-            .value_hint(ValueHint::AnyPath)
-        )
-        .arg(
-            Arg::new("type")
-            .short('T')
-            .long("type")
-            .value_name("TYPE")
-            .multiple_values(true)
-            .takes_value(true)
-            .ignore_case(true)
-            .default_values(&["programming", "markup"])
-            .hide_default_value(true)
-            .help("Filters output by language type (*programming*, *markup*, prose, data).")
-            .possible_values(
-                &LanguageType::iter()
-                    .map(|t| t.into())
-                    .collect::<Vec<&str>>())
-        )
-        .get_matches();
+        let matches = build_cli().get_matches();
 
         let true_color = match matches.value_of("true-color") {
             Some("always") => true,
@@ -409,6 +159,13 @@ impl Config {
             .map(|t| LanguageType::from_str(t).unwrap())
             .collect();
 
+        let completion = matches
+            .value_of("completion")
+            .map(Shell::from_str)
+            .transpose()
+            .map_err(anyhow::Error::msg)
+            .context("Could not parse shell")?;
+
         Ok(Config {
             repo_path,
             ascii_input,
@@ -434,6 +191,7 @@ impl Config {
             show_email,
             include_hidden,
             language_types,
+            completion,
         })
     }
 }
@@ -467,4 +225,275 @@ pub fn get_git_version() -> String {
         Ok(v) => String::from_utf8_lossy(&v.stdout).replace('\n', ""),
         Err(_) => String::new(),
     }
+}
+
+pub fn print_completions<G: Generator>(gen: G) {
+    let mut cmd = build_cli();
+    let name = cmd.get_name().to_string();
+    generate(gen, &mut cmd, name, &mut io::stdout());
+}
+
+pub(crate) fn build_cli() -> clap::Command<'static> {
+    let possible_backends = ["kitty", "iterm", "sixel"];
+    let possible_shells = Shell::possible_values();
+
+    let color_values = &[
+        "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
+    ];
+
+    clap::Command::new(crate_name!())
+        .version(crate_version!())
+        .about(crate_description!())
+        .setting(AppSettings::DeriveDisplayOrder)
+        .hide_possible_values(true)
+        .arg(
+            Arg::new("input")
+            .default_value(".")
+            .hide_default_value(true)
+            .help("Run as if onefetch was started in <input> instead of the current working directory.")
+            .value_hint(ValueHint::DirPath)
+        )
+        .arg(
+            Arg::new("output")
+            .short('o')
+            .long("output")
+            .value_name("FORMAT")
+            .help("Outputs Onefetch in a specific format (json, yaml).")
+            .takes_value(true)
+            .possible_values(
+                SerializationFormat::iter()
+                .map(|format| format.into())
+                .collect::<Vec<&str>>())
+        )
+        .arg(
+            Arg::new("languages")
+            .short('l')
+            .long("languages")
+            .help("Prints out supported languages."),
+        )
+        .arg(
+            Arg::new("package-managers")
+            .short('p')
+            .long("package-managers")
+            .help("Prints out supported package managers."),
+        )
+        .arg(
+            Arg::new("show-logo")
+            .long("show-logo")
+            .value_name("WHEN")
+            .takes_value(true)
+            .possible_values(&["auto", "never", "always"])
+            .default_value("always")
+            .hide_default_value(true)
+            .help("Specify when to show the logo (auto, never, *always*).")
+            .long_help(
+                "Specify when to show the logo (auto, never, *always*). \n\
+                If set to auto: the logo will be hidden if the terminal's width < 95.")
+        )
+        .arg(
+            Arg::new("image")
+            .short('i')
+            .long("image")
+            .value_name("IMAGE")
+            .takes_value(true)
+            .help("Path to the IMAGE file.")
+            .value_hint(ValueHint::FilePath)
+        )
+        .arg(
+            Arg::new("image-backend")
+            .long("image-backend")
+            .value_name("BACKEND")
+            .takes_value(true)
+            .requires("image")
+            .possible_values(possible_backends)
+            .help("Which image BACKEND to use."),
+        )
+        .arg(
+            Arg::new("color-resolution")
+            .long("color-resolution")
+            .value_name("VALUE")
+            .requires("image")
+            .takes_value(true)
+            .possible_values(&["16", "32", "64", "128", "256"])
+            .help("VALUE of color resolution to use with SIXEL backend."),
+        )
+        .arg(
+            Arg::new("ascii-language")
+           .short('a')
+           .value_name("LANGUAGE")
+           .long("ascii-language")
+           .takes_value(true)
+           .ignore_case(true)
+           .help("Which LANGUAGE's ascii art to print.")
+           .possible_values(
+               Language::iter()
+               .map(|language| language.into())
+               .collect::<Vec<&str>>())
+        )
+        .arg(
+            Arg::new("ascii-input")
+            .long("ascii-input")
+            .value_name("STRING")
+            .takes_value(true)
+            .help("Takes a non-empty STRING as input to replace the ASCII logo.")
+            .long_help(
+                "Takes a non-empty STRING as input to replace the ASCII logo. \
+                It is possible to pass a generated STRING by command substitution. \n\
+                For example:\n \
+                '--ascii-input \"$(fortune | cowsay -W 25)\"'")
+            .validator(|t| {
+                if t.is_empty() {
+                    Err(String::from("must not be empty"))
+                } else {
+                    Ok(())
+                }
+            }),
+        )
+        .arg(
+            Arg::new("true-color")
+            .long("true-color")
+            .value_name("WHEN")
+            .takes_value(true)
+            .possible_values(&["auto", "never", "always"])
+            .default_value("auto")
+            .hide_default_value(true)
+            .help("Specify when to use true color (*auto*, never, always).")
+            .long_help(
+                "Specify when to use true color (*auto*, never, always). \n\
+                If set to auto: true color will be enabled if supported by the terminal.")
+        )
+        .arg(
+            Arg::new("ascii-colors")
+            .short('c')
+            .long("ascii-colors")
+            .value_name("X")
+            .multiple_values(true)
+            .takes_value(true)
+            .possible_values(color_values)
+            .help("Colors (X X X...) to print the ascii art."),
+        )
+        .arg(
+            Arg::new("text-colors")
+            .short('t')
+            .long("text-colors")
+            .value_name("X")
+            .multiple_values(true)
+            .takes_value(true)
+            .max_values(6)
+            .possible_values(color_values)
+            .help("Changes the text colors (X X X...).")
+            .long_help(
+                "Changes the text colors (X X X...). \
+                Goes in order of title, ~, underline, subtitle, colon, and info. \n\
+                For example:\n \
+                '--text-colors 9 10 11 12 13 14'")
+        )
+        .arg(
+            Arg::new("no-bold")
+            .long("no-bold")
+            .help("Turns off bold formatting."),
+        )
+        .arg(
+            Arg::new("no-palette")
+            .long("no-palette")
+            .help("Hides the color palette."),
+        )
+        .arg(
+            Arg::new("no-merges")
+            .long("no-merges")
+            .help("Ignores merge commits."),
+        )
+        .arg(
+            Arg::new("no-bots")
+            .long("no-bots")
+            .min_values(0)
+            .max_values(1)
+            .value_name("REGEX")
+            .help("Exclude [bot] commits. Use <REGEX> to override the default pattern.")
+            .validator(|p| {
+                match Regex::from_str(p) {
+                    Ok(_) => Ok(()),
+                    Err(_) => Err(String::from("must be a valid regex pattern"))
+                }
+            }),
+        )
+        .arg(
+            Arg::new("isotime")
+            .short('z')
+            .long("isotime")
+            .help("Use ISO 8601 formatted timestamps.")
+        )
+        .arg(
+            Arg::new("disable-fields")
+            .long("disable-fields")
+            .short('d')
+            .value_name("FIELD")
+            .multiple_values(true)
+            .takes_value(true)
+            .ignore_case(true)
+            .help("Allows you to disable FIELD(s) from appearing in the output.")
+            .possible_values(
+                InfoField::iter()
+                    .map(|field| field.into())
+                    .collect::<Vec<&str>>())
+        )
+        .arg(
+            Arg::new("authors-number")
+            .short('A')
+            .long("authors-number")
+            .value_name("NUM")
+            .takes_value(true)
+            .default_value("3")
+            .help("NUM of authors to be shown.")
+            .validator(|t| {
+                match t.parse::<u32>() {
+                    Ok(_) => Ok(()),
+                    Err(_) => Err(String::from("must be a number"))
+                }
+            })
+        )
+        .arg(
+            Arg::new("email")
+            .short('E')
+            .long("email")
+            .help("show the email address of each author.")
+        )
+        .arg(
+            Arg::new("hidden")
+            .long("hidden")
+            .help("Count hidden files and directories.")
+        )
+        .arg(
+            Arg::new("exclude")
+            .short('e')
+            .long("exclude")
+            .value_name("EXCLUDE")
+            .multiple_values(true)
+            .takes_value(true)
+            .help("Ignore all files & directories matching EXCLUDE.")
+            .value_hint(ValueHint::AnyPath)
+        )
+        .arg(
+            Arg::new("type")
+            .short('T')
+            .long("type")
+            .value_name("TYPE")
+            .multiple_values(true)
+            .takes_value(true)
+            .ignore_case(true)
+            .default_values(&["programming", "markup"])
+            .hide_default_value(true)
+            .help("Filters output by language type (*programming*, *markup*, prose, data).")
+            .possible_values(
+                LanguageType::iter()
+                    .map(|t| t.into())
+                    .collect::<Vec<&str>>())
+        )
+        .arg(
+            Arg::new("completion")
+                .long("completion")
+                .possible_values(possible_shells)
+                .value_name("SHELL")
+                .help("Print shell completions to STDOUT and exit")
+        )
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -229,7 +229,7 @@ pub fn get_git_version() -> String {
 
 pub fn print_completions<G: Generator>(gen: G) {
     let mut cmd = build_cli();
-    let name = cmd.get_name().to_string();
+    let name = crate_name!();
     generate(gen, &mut cmd, name, &mut io::stdout());
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,11 @@ fn main() -> Result<()> {
         return cli::print_supported_package_managers();
     }
 
+    if let Some(generator) = config.completion {
+        cli::print_completions(generator);
+        return Ok(());
+    }
+
     if !repo::is_valid(&config.repo_path)? {
         bail!("please run onefetch inside of a non-bare git repository");
     }


### PR DESCRIPTION
This allows the user to generate completions by passing `--completion <SHELL>`. This PR also

- Moves the CLI App creation to a separate `build_cli` function. This was necessary as the
  `clap_generate` docs seem to imply that a separate instance of the CLI app struct is necessary
  for generating completions. For the purposes of the App struct's lifetime, a few borrowed
  iterators had to be changed to be taken by the app struct.
