### PR TITLE
worktree support via gitoxide 0.17 (up from 0.16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,9 +202,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byte-unit"
-version = "4.0.13"
+version = "4.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ffc5b0ec7d7a6949e3f21fd63ba5af4cffdc2ba1e0b7bf62b481458c4ae7f"
+checksum = "95ebf10dda65f19ff0f42ea15572a359ed60d7fc74fdc984d90310937be0014b"
 dependencies = [
  "utf8-width",
 ]
@@ -711,12 +711,14 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "git-actor"
-version = "0.9.0"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9749c877b770a8c0627d318df1e13cc024cd9a2a70369b9cd1efdd44b6bca108"
 dependencies = [
  "bstr",
  "btoi",
  "git-features",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "nom",
  "quick-error",
  "serde",
@@ -725,6 +727,8 @@ dependencies = [
 [[package]]
 name = "git-attributes"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27e3e42f0bb0f9355529df88abec1d289fa62073e682c08904b8e49c593809c"
 dependencies = [
  "bstr",
  "compact_str",
@@ -740,6 +744,8 @@ dependencies = [
 [[package]]
 name = "git-bitmap"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7715cc94cd761fe92bb5626a332e4886292c7af88984abfdafad82dd56002475"
 dependencies = [
  "quick-error",
 ]
@@ -747,13 +753,17 @@ dependencies = [
 [[package]]
 name = "git-chunk"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c915097c009d7870a27ee62dcadbf1410f07cdc6c510efcfb8c1011917bd4f22"
 dependencies = [
  "quick-error",
 ]
 
 [[package]]
 name = "git-config"
-version = "0.2.1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39ba0374be00805c6dbf1d8e323441988ce7c516193680960026eb46e84d003"
 dependencies = [
  "bstr",
  "dirs 4.0.0",
@@ -770,6 +780,8 @@ dependencies = [
 [[package]]
 name = "git-credentials"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5584df950ad7766feeff5c74fe2159169e88474349fa97a094d49168f4d4121"
 dependencies = [
  "bstr",
  "git-sec",
@@ -778,7 +790,9 @@ dependencies = [
 
 [[package]]
 name = "git-diff"
-version = "0.15.0"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5b5b113893094a2f22fa88f3ec5adbac3e5dbfcc1730cb5865f28e3214f7429"
 dependencies = [
  "git-hash",
  "git-object",
@@ -788,6 +802,8 @@ dependencies = [
 [[package]]
 name = "git-discover"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff5be7cf1987d05f35d0b9cb5e3e0f89febc303b6a7248b859813427dc8034a9"
 dependencies = [
  "bstr",
  "git-hash",
@@ -799,7 +815,9 @@ dependencies = [
 
 [[package]]
 name = "git-features"
-version = "0.20.0"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f48687b14415c11bc037a074ba834c58a16a6ba91dc92086ac9ede4cdaa517"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",
@@ -819,7 +837,9 @@ dependencies = [
 
 [[package]]
 name = "git-glob"
-version = "0.2.0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e875ca336a98dd1d6bffd24042068404c82fe6eeff1912ecbd5bd6438e7488c"
 dependencies = [
  "bitflags",
  "bstr",
@@ -828,7 +848,9 @@ dependencies = [
 
 [[package]]
 name = "git-hash"
-version = "0.9.3"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05d7e760613f4118cdccaf881fc9d1323c3ea596d156aac25a4eb44b428f11e"
 dependencies = [
  "hex",
  "quick-error",
@@ -837,7 +859,9 @@ dependencies = [
 
 [[package]]
 name = "git-index"
-version = "0.2.0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404a6bdc41ea56253026bb5e973e5d7dd5459124acc2d1939705e8dce282aec1"
 dependencies = [
  "atoi",
  "bitflags",
@@ -855,7 +879,9 @@ dependencies = [
 
 [[package]]
 name = "git-lock"
-version = "2.0.0"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee44915b070cde930ecc0e251d53f40d2ad66354546edcfd04720b12e1936e91"
 dependencies = [
  "fastrand",
  "git-tempfile",
@@ -864,7 +890,9 @@ dependencies = [
 
 [[package]]
 name = "git-mailmap"
-version = "0.1.0"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2496f3a9fe326225379b30b4f2362111e61a7e623e3312f6793af11fb0e9121b"
 dependencies = [
  "bstr",
  "git-actor",
@@ -874,7 +902,9 @@ dependencies = [
 
 [[package]]
 name = "git-object"
-version = "0.18.0"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83648a7a66f17b9622c41bb91017bd1355dc9f89dd3b9ae40fe9479bbc4ec63b"
 dependencies = [
  "bstr",
  "btoi",
@@ -883,7 +913,7 @@ dependencies = [
  "git-hash",
  "git-validate",
  "hex",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "nom",
  "quick-error",
  "serde",
@@ -892,7 +922,9 @@ dependencies = [
 
 [[package]]
 name = "git-odb"
-version = "0.28.0"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6996805f1df80392f69a5f1915e9273febe97c5341ea058b1600dd49f3d24d40"
 dependencies = [
  "arc-swap",
  "git-features",
@@ -909,7 +941,9 @@ dependencies = [
 
 [[package]]
 name = "git-pack"
-version = "0.18.0"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec6cbb9074941e0308a22664349fb04c46dac4f374135bb0a24216b4192d064"
 dependencies = [
  "bytesize",
  "clru",
@@ -933,7 +967,9 @@ dependencies = [
 
 [[package]]
 name = "git-packetline"
-version = "0.12.4"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42acbfb60871e96ed09f8c0730020aa4ccfa6ab6bcbb2b64a5150bfc7053773"
 dependencies = [
  "bstr",
  "hex",
@@ -942,14 +978,18 @@ dependencies = [
 
 [[package]]
 name = "git-path"
-version = "0.1.0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2557400d97e5f2aa424f5446d94da6bdd3ee31f42f9d2a0006da3c2e34d6b66"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "git-protocol"
-version = "0.15.0"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fd19c33c4e60d420744a2e231d9fe425216fc9358defc56c2fc3e04c2ff2d0"
 dependencies = [
  "bstr",
  "btoi",
@@ -966,6 +1006,8 @@ dependencies = [
 [[package]]
 name = "git-quote"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec1960fa4f68a1637ce03d8c151ae2f8565d1de119a3eee8b5b9a364a08aacb"
 dependencies = [
  "bstr",
  "btoi",
@@ -974,7 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "git-ref"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48d074985c2c0509df2872c03a189c15945a0b09f0e69a1cbf3e5d18ea2d491"
 dependencies = [
  "git-actor",
  "git-features",
@@ -993,6 +1037,8 @@ dependencies = [
 [[package]]
 name = "git-repository"
 version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7eed033037c74441f29fda883b76ef788adfcc09937ca1eb30a633d5e23150"
 dependencies = [
  "byte-unit",
  "clru",
@@ -1030,7 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "git-revision"
-version = "0.1.0"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ad76054b8b051731d07d9b30959757a6c72ec3162c2d31bcede2edaa3140e"
 dependencies = [
  "git-hash",
  "git-object",
@@ -1041,6 +1089,8 @@ dependencies = [
 [[package]]
 name = "git-sec"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62eedd061c7c27c00baed2b43c8840ee17fa5374e707f7f5d8fd00350d382ae"
 dependencies = [
  "bitflags",
  "libc",
@@ -1051,6 +1101,8 @@ dependencies = [
 [[package]]
 name = "git-tempfile"
 version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeeaa7c09e5503b0a8835872c2801807f636f6a9ef6333c28e28f0b00a660535"
 dependencies = [
  "dashmap 5.3.3",
  "libc",
@@ -1062,7 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "git-transport"
-version = "0.16.0"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9c12ca519c50a38b8869f382315d283f104e7a25d93ac1b0e4613b17f0fcd7"
 dependencies = [
  "bstr",
  "git-features",
@@ -1076,7 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "git-traverse"
-version = "0.14.0"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c295185e78555181b6dcbff65e86c41021760f563e0d4932450ce4e43aafc"
 dependencies = [
  "git-hash",
  "git-object",
@@ -1086,7 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "git-url"
-version = "0.4.0"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5defd652b013a62dca2c5f7a6a38d8c1f48444ed08f8f1a93251e825c3ce61bc"
 dependencies = [
  "bstr",
  "git-features",
@@ -1098,7 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "git-validate"
-version = "0.5.3"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c2c1eaaa942eb3c49ab20f27c0715e79e26e6b156a0f77d7ed7bbb26126a8fa"
 dependencies = [
  "bstr",
  "quick-error",
@@ -1106,7 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "git-worktree"
-version = "0.1.0"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea410ec30fe3d578eb4bd6c442218f8f75f063a0aafabd3501fab681482bb7f"
 dependencies = [
  "bstr",
  "git-attributes",
@@ -1122,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
 dependencies = [
  "bitflags",
  "libc",
@@ -1348,9 +1410,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jobserver"
@@ -1403,15 +1465,15 @@ checksum = "7efd1d698db0759e6ef11a7cd44407407399a910c774dd804c64c032da7826ff"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.2+1.4.2"
+version = "0.13.4+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
 dependencies = [
  "cc",
  "libc",
@@ -1685,9 +1747,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 
 [[package]]
 name = "owo-colors"
@@ -1892,11 +1954,11 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1966,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -1978,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2076,9 +2138,9 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "same-file"
@@ -2127,7 +2189,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -2164,9 +2226,9 @@ checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2250,13 +2312,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2409,7 +2471,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "libc",
  "num_threads",
 ]
@@ -2498,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "uncased"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baeed7327e25054889b9bd4f975f32e5f4c5d434042d59ab6cd4142c0a76ed0"
+checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
 dependencies = [
  "version_check",
 ]
@@ -2568,6 +2630,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63ec69f541d875b783ca40184d655f2927c95f0bffd486faa83cd3ac3529ec32"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "utf8-width"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
 name = "vcpkg"
@@ -2738,11 +2806,11 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e53b97a83176b369b0eb2fd8158d4ae215357d02df9d40c1e1bf1879c5482c80"
 dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2751,11 +2819,11 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc 0.34.0",
- "windows_i686_gnu 0.34.0",
- "windows_i686_msvc 0.34.0",
- "windows_x86_64_gnu 0.34.0",
- "windows_x86_64_msvc 0.34.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2765,18 +2833,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,28 +2845,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "compact_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e60dedcb8b23cedf6f23ee35ecf5c7889961e99f26f79ab196aaf4a8b48608"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,8 +712,6 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 [[package]]
 name = "git-actor"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da34835e5f98530fa2c13d3b1538589b2d3d37e903c4cfc652dd30a2968bdc5"
 dependencies = [
  "bstr",
  "btoi",
@@ -716,10 +723,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-attributes"
+version = "0.1.0"
+dependencies = [
+ "bstr",
+ "compact_str",
+ "git-features",
+ "git-glob",
+ "git-path",
+ "git-quote",
+ "quick-error",
+ "serde",
+ "unicode-bom",
+]
+
+[[package]]
 name = "git-bitmap"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7715cc94cd761fe92bb5626a332e4886292c7af88984abfdafad82dd56002475"
 dependencies = [
  "quick-error",
 ]
@@ -727,8 +747,6 @@ dependencies = [
 [[package]]
 name = "git-chunk"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c915097c009d7870a27ee62dcadbf1410f07cdc6c510efcfb8c1011917bd4f22"
 dependencies = [
  "quick-error",
 ]
@@ -736,24 +754,31 @@ dependencies = [
 [[package]]
 name = "git-config"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a552e3de993c389623e23b71a888c8356acfcb6e4232ce8420fba4710a44921b"
 dependencies = [
  "bstr",
  "dirs 4.0.0",
  "git-features",
+ "git-path",
+ "git-sec",
  "memchr",
  "nom",
  "pwd",
- "quick-error",
+ "thiserror",
  "unicode-bom",
+]
+
+[[package]]
+name = "git-credentials"
+version = "0.1.0"
+dependencies = [
+ "bstr",
+ "git-sec",
+ "quick-error",
 ]
 
 [[package]]
 name = "git-diff"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78a4f847cf6944063d49c933bc854da7e3ddeca63632e801bbd7e11139eec51"
 dependencies = [
  "git-hash",
  "git-object",
@@ -761,12 +786,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-features"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebc06d6b83be53d9c7a00937a6baed4566aad7dba12af11ac830ea72c080af0"
+name = "git-discover"
+version = "0.1.0"
 dependencies = [
  "bstr",
+ "git-hash",
+ "git-path",
+ "git-ref",
+ "git-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "git-features"
+version = "0.20.0"
+dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "crossbeam-utils",
@@ -784,10 +818,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-glob"
+version = "0.2.0"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "serde",
+]
+
+[[package]]
 name = "git-hash"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106e7c3a08b97285bf0bca7f109e67d286e7fbf34b222faf742443b021de2bb4"
 dependencies = [
  "hex",
  "quick-error",
@@ -797,8 +838,6 @@ dependencies = [
 [[package]]
 name = "git-index"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5f876a2eee84018c41c515e982ddf451d1da8b058ba2298f9458b9b55ff8c8"
 dependencies = [
  "atoi",
  "bitflags",
@@ -817,8 +856,6 @@ dependencies = [
 [[package]]
 name = "git-lock"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade7bf16268f52cf544dd5109c6ee6cad4d524635215b3479ba06bad2eef6e9a"
 dependencies = [
  "fastrand",
  "git-tempfile",
@@ -828,8 +865,6 @@ dependencies = [
 [[package]]
 name = "git-mailmap"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd3e458fb3f0cda4510169f1f1afb7f4769641151999da0133d2a082b3638f6"
 dependencies = [
  "bstr",
  "git-actor",
@@ -840,8 +875,6 @@ dependencies = [
 [[package]]
 name = "git-object"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed579fcef038a366a6146acfe61ea74945d137d56366ff50dfe90b1227f6a370"
 dependencies = [
  "bstr",
  "btoi",
@@ -860,14 +893,13 @@ dependencies = [
 [[package]]
 name = "git-odb"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb433030c597a0824848d2843ecd6cd087dc6dbc8a718f98f90851031c066f5c"
 dependencies = [
  "arc-swap",
  "git-features",
  "git-hash",
  "git-object",
  "git-pack",
+ "git-path",
  "git-quote",
  "parking_lot 0.12.0",
  "serde",
@@ -878,8 +910,6 @@ dependencies = [
 [[package]]
 name = "git-pack"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd5ed76cae495f77752a37b863843f13f7e95b6dbf946fae86ac81050ae2fb4"
 dependencies = [
  "bytesize",
  "clru",
@@ -889,6 +919,7 @@ dependencies = [
  "git-features",
  "git-hash",
  "git-object",
+ "git-path",
  "git-tempfile",
  "git-traverse",
  "hash_hasher",
@@ -903,8 +934,6 @@ dependencies = [
 [[package]]
 name = "git-packetline"
 version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd72d1851a70ec9dbffb5e70bf59848ae0a5d86bfc3f1d764c65bbf958a881d"
 dependencies = [
  "bstr",
  "hex",
@@ -912,13 +941,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-path"
+version = "0.1.0"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
 name = "git-protocol"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc884ae8963cc6624199c68730da42457cb6cb98e27e6bfae69110bc67cd774e"
 dependencies = [
  "bstr",
  "btoi",
+ "git-credentials",
  "git-features",
  "git-hash",
  "git-transport",
@@ -931,8 +966,6 @@ dependencies = [
 [[package]]
 name = "git-quote"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec1960fa4f68a1637ce03d8c151ae2f8565d1de119a3eee8b5b9a364a08aacb"
 dependencies = [
  "bstr",
  "btoi",
@@ -942,14 +975,13 @@ dependencies = [
 [[package]]
 name = "git-ref"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514f84806f6d5f98b6fe446eb3b1a5a67d7da9cb8d1389e55def6b53456484bf"
 dependencies = [
  "git-actor",
  "git-features",
  "git-hash",
  "git-lock",
  "git-object",
+ "git-path",
  "git-tempfile",
  "git-validate",
  "memmap2 0.5.3",
@@ -960,16 +992,18 @@ dependencies = [
 
 [[package]]
 name = "git-repository"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274f3d9404ff2dc56fdd6fd17f9740f73d559c87f7a34007ffeb456f8b4003c2"
+version = "0.17.0"
 dependencies = [
  "byte-unit",
  "clru",
  "git-actor",
+ "git-attributes",
  "git-config",
+ "git-credentials",
  "git-diff",
+ "git-discover",
  "git-features",
+ "git-glob",
  "git-hash",
  "git-index",
  "git-lock",
@@ -977,9 +1011,11 @@ dependencies = [
  "git-object",
  "git-odb",
  "git-pack",
+ "git-path",
  "git-protocol",
  "git-ref",
  "git-revision",
+ "git-sec",
  "git-tempfile",
  "git-transport",
  "git-traverse",
@@ -990,14 +1026,11 @@ dependencies = [
  "signal-hook",
  "thiserror",
  "unicode-normalization",
- "utf8-width",
 ]
 
 [[package]]
 name = "git-revision"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a1dd6d23511fb7d186b1fac333a4949baec311df21ba103238728617fb3781"
 dependencies = [
  "git-hash",
  "git-object",
@@ -1006,10 +1039,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-sec"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "thiserror",
+ "windows",
+]
+
+[[package]]
 name = "git-tempfile"
 version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeeaa7c09e5503b0a8835872c2801807f636f6a9ef6333c28e28f0b00a660535"
 dependencies = [
  "dashmap 5.3.3",
  "libc",
@@ -1022,12 +1063,11 @@ dependencies = [
 [[package]]
 name = "git-transport"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785add28a93f13f8bf1637744bcf40f0d9129f80344e3dd15fca44d1fe42c265"
 dependencies = [
  "bstr",
  "git-features",
  "git-packetline",
+ "git-sec",
  "git-url",
  "quick-error",
  "serde",
@@ -1037,8 +1077,6 @@ dependencies = [
 [[package]]
 name = "git-traverse"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0145f0ccea350d92d063e1efecb43dd75ba98f1ec97c8f9ba774ef0d32ab8732"
 dependencies = [
  "git-hash",
  "git-object",
@@ -1049,11 +1087,10 @@ dependencies = [
 [[package]]
 name = "git-url"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9766368c3a6c58f5c64e1cb514708a355c92cb654dff20127b76b69a475b15d6"
 dependencies = [
  "bstr",
  "git-features",
+ "git-path",
  "home",
  "quick-error",
  "url",
@@ -1062,8 +1099,6 @@ dependencies = [
 [[package]]
 name = "git-validate"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58bafc6cd6f455a95997c47823182dd62cdb47f03564c44c6b6d910221801dc"
 dependencies = [
  "bstr",
  "quick-error",
@@ -1072,14 +1107,15 @@ dependencies = [
 [[package]]
 name = "git-worktree"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057b77dc725bd6e55c6c844bacc0f68e7839917a7c7808caab3fcbf010f47d20"
 dependencies = [
  "bstr",
+ "git-attributes",
  "git-features",
+ "git-glob",
  "git-hash",
  "git-index",
  "git-object",
+ "git-path",
  "io-close",
  "thiserror",
 ]
@@ -2697,17 +2733,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53b97a83176b369b0eb2fd8158d4ae215357d02df9d40c1e1bf1879c5482c80"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.34.0",
+ "windows_i686_gnu 0.34.0",
+ "windows_i686_msvc 0.34.0",
+ "windows_x86_64_gnu 0.34.0",
+ "windows_x86_64_msvc 0.34.0",
 ]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2722,6 +2777,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,6 +2799,18 @@ name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,13 @@ section = "utility"
 [dependencies]
 anyhow = "1.0"
 askalono = "0.4.5"
-byte-unit = "4.0" # to match git-repository's lower requirement, which it needs for MSRV
+byte-unit = "4.0" 
 bytecount = "0.6.2"
 clap = {version = "3.1.17", features = ["cargo", "wrap_help"]}
 clap_complete = "3.1"
 color_quant = "1.1.0"
 git2 = {version = "0.14.2", default-features = false}
-git-repository = { version = "0.16.0", features = ["max-performance", "unstable", "serde1"] }
+git-repository = { version = "0.17.0", features = ["max-performance", "unstable", "serde1"] }
 image = "0.24.2"
 owo-colors = "3.4.0"
 regex = "1.5.5"

--- a/src/info/repo.rs
+++ b/src/info/repo.rs
@@ -155,7 +155,7 @@ impl Commits {
 
 impl Repo {
     pub fn new(git2_repo: Repository) -> Result<Self> {
-        let repo = git::open(git2_repo.workdir().unwrap_or(git2_repo.path()))?;
+        let repo = git::open(git2_repo.path())?;
 
         Ok(Self { repo, git2_repo })
     }

--- a/src/info/repo.rs
+++ b/src/info/repo.rs
@@ -155,7 +155,7 @@ impl Commits {
 
 impl Repo {
     pub fn new(git2_repo: Repository) -> Result<Self> {
-        let repo = git::open(git2_repo.path())?;
+        let repo = git::open(git2_repo.workdir().unwrap_or(git2_repo.path()))?;
 
         Ok(Self { repo, git2_repo })
     }


### PR DESCRIPTION
Fixes #651 .