### PR TITLE
fix for --ascii-colors and --ascii-input

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -18,18 +18,14 @@ pub fn get_ascii_colors(
         dominant_language
     };
 
-    let colors = language.get_colors(true_color);
+    let mut colors: Vec<DynColors> = ascii_colors.iter().map(|s| num_to_color(s)).collect();
 
-    let colors: Vec<DynColors> = colors
-        .iter()
-        .enumerate()
-        .map(|(index, default_color)| {
-            if let Some(color_num) = ascii_colors.get(index) {
-                return num_to_color(color_num);
-            }
-            *default_color
-        })
-        .collect();
+    let mut language_colors: Vec<DynColors> = language.get_colors(true_color);
+
+    if language_colors.len() > colors.len() {
+        let mut missing = language_colors.drain(colors.len()..).collect();
+        colors.append(&mut missing);
+    }
     colors
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -18,15 +18,19 @@ pub fn get_ascii_colors(
         dominant_language
     };
 
-    let mut colors: Vec<DynColors> = ascii_colors.iter().map(|s| num_to_color(s)).collect();
-
     let mut language_colors: Vec<DynColors> = language.get_colors(true_color);
 
-    if language_colors.len() > colors.len() {
-        let mut missing = language_colors.drain(colors.len()..).collect();
-        colors.append(&mut missing);
+    if ascii_colors.is_empty() {
+        language_colors
+    } else {
+        let mut colors: Vec<DynColors> = ascii_colors.iter().map(|s| num_to_color(s)).collect();
+
+        if language_colors.len() > colors.len() {
+            let mut missing = language_colors.drain(colors.len()..).collect();
+            colors.append(&mut missing);
+        }
+        colors
     }
-    colors
 }
 
 fn num_to_color(num: &str) -> DynColors {

--- a/src/ui/printer.rs
+++ b/src/ui/printer.rs
@@ -1,7 +1,6 @@
 use crate::info::Info;
 use crate::ui::ascii_art::AsciiArt;
 use anyhow::{Context, Result};
-use owo_colors::DynColors;
 use std::io::Write;
 use strum::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/ui/printer.rs
+++ b/src/ui/printer.rs
@@ -38,7 +38,6 @@ impl<W: Write> Printer<W> {
                 let center_pad = " ".repeat(CENTER_PAD_LENGTH);
                 let info_str = format!("{}", &self.info);
                 let mut info_lines = info_str.lines();
-                let colors: Vec<DynColors> = Vec::new();
                 let mut buf = String::new();
 
                 if self.info.config.art_off {
@@ -62,7 +61,7 @@ impl<W: Write> Printer<W> {
                     );
                 } else {
                     let mut logo_lines = if let Some(custom_ascii) = &self.info.config.ascii_input {
-                        AsciiArt::new(custom_ascii, &colors, !self.info.config.no_bold)
+                        AsciiArt::new(custom_ascii, &self.info.ascii_colors, !self.info.config.no_bold)
                     } else {
                         AsciiArt::new(
                             self.get_ascii(),

--- a/src/ui/printer.rs
+++ b/src/ui/printer.rs
@@ -61,7 +61,11 @@ impl<W: Write> Printer<W> {
                     );
                 } else {
                     let mut logo_lines = if let Some(custom_ascii) = &self.info.config.ascii_input {
-                        AsciiArt::new(custom_ascii, &self.info.ascii_colors, !self.info.config.no_bold)
+                        AsciiArt::new(
+                            custom_ascii,
+                            &self.info.ascii_colors,
+                            !self.info.config.no_bold,
+                        )
                     } else {
                         AsciiArt::new(
                             self.get_ascii(),


### PR DESCRIPTION
use `self.info.ascii_colors` instead of empty array.

#552 