### PR TITLE
Ignore docs for CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,16 @@ name: CI
 on:
   push:
     branches: ["*"]
+    paths:
+      - 'src/**'
+      - 'resources/**'
+      - 'Cargo.*'
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'resources/**'
+      - 'Cargo.*'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,14 @@ name: CI
 on:
   push:
     branches: ["*"]
-    paths:
-      - 'src/**'
-      - 'resources/**'
-      - 'Cargo.*'
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
   pull_request:
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'resources/**'
-      - 'Cargo.*'
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
 
 jobs:
   build:


### PR DESCRIPTION
This will only run the CI if a contributor has edited
- the `src/` directory
- the `resources/` directory
- the manifest files

This prevents unnecessary workflow runs. For example, on documentation
changes.

For example, #693 didn't need to be in a "workflow run pending" status since none of the changes are tested by the workflow.