### PR TITLE
update gitoxide to v0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,16 +140,7 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
-dependencies = [
- "generic-array 0.14.6",
+ "generic-array",
 ]
 
 [[package]]
@@ -388,15 +379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,16 +457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array 0.14.6",
- "typenum",
-]
-
-[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,17 +499,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
-dependencies = [
- "block-buffer 0.10.2",
- "crypto-common",
+ "generic-array",
 ]
 
 [[package]]
@@ -734,16 +696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "git-actor"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb53b8b0a098e3db89958c0aa36e1cbaa5e80fdfc98a7535e7078552120cc03"
+checksum = "ec7820628a520837a6969cff126b236444be347a682bf435c9372cb59462e8ed"
 dependencies = [
  "bstr",
  "btoi",
@@ -783,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "git-attributes"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51845b670130052b90b0938d97d9507c81f3e81f355b232d024729a771293b82"
+checksum = "9fd272a7ccd728534d36965123516057c2d605a9b73454c13e481f0b7c5e3b31"
 dependencies = [
  "bstr",
  "compact_str",
@@ -800,27 +752,27 @@ dependencies = [
 
 [[package]]
 name = "git-bitmap"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5442ba44b4385121a333f56837f3e6ce5a1b843d080b93d764578960a510507b"
+checksum = "327098a7ad27ae298d7e71602dbd4375cc828d755d10a720e4be0be1b4ec38f0"
 dependencies = [
  "quick-error",
 ]
 
 [[package]]
 name = "git-chunk"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c915097c009d7870a27ee62dcadbf1410f07cdc6c510efcfb8c1011917bd4f22"
+checksum = "0023a89f84bcc8600556630109edfad1bdeb1820ea8a77306a7ca9c01188ef97"
 dependencies = [
  "quick-error",
 ]
 
 [[package]]
 name = "git-config"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168f2e6bec559afb1e029510ee1746f0971fd35bbd5c20bf43c9df74e32be8f8"
+checksum = "3f873c1aa1d8340ad156181ac425c8bbd696534d94821d5bcd8c576bbfc13856"
 dependencies = [
  "bitflags",
  "bstr",
@@ -839,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "git-credentials"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b8d4f207f3a4abb83743960e1edb52682d9d2f6630f4da2582d4a1b8420df5"
+checksum = "e623570bb5075bc4f3c0270f5a763f89d51ec6f14a27803ce4d0d9fd8b765496"
 dependencies = [
  "bstr",
  "git-sec",
@@ -850,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "git-date"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2c5b328bf9081b27042a274c895758df97309275e618e4fcfede919ce3d282"
+checksum = "ca9d7b206556d9a34f87e7e70e89463940fc015ae2bb25c3d66efcae0c5521db"
 dependencies = [
  "bstr",
  "itoa 1.0.3",
@@ -862,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "git-diff"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a3d2379658de2bf9b25e730ca8e486d66f1f9515e7f82b1d165f5e0afec742"
+checksum = "3eb6ff7cebb31c3c5285cc887f513509797fd73598ec9b346ace58bdf6597689"
 dependencies = [
  "git-hash",
  "git-object",
@@ -873,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "git-discover"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf1909f287bd3365dabdbb657f78f02c2ef496001db782f6137588c9668623a"
+checksum = "74e956f5d946471c9edba2781e081340a2147a3046b1f183727aadca3b3df547"
 dependencies = [
  "bstr",
  "git-hash",
@@ -887,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "git-features"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48289da362ef7ee1412a9a80bb459406d3045ad604484526210d594d10aa5268"
+checksum = "4ed4ee460edb68580e3685a6d20d9c1bd0dabed564667f5273fa8b0871380b64"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",
@@ -903,16 +855,15 @@ dependencies = [
  "parking_lot 0.12.0",
  "prodash",
  "quick-error",
- "sha-1 0.10.0",
  "sha1_smol",
  "walkdir",
 ]
 
 [[package]]
 name = "git-glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a226a7037e481a312ddba5cc55f6d7aa3eb5043d61e95c289af3632be942f0e"
+checksum = "3d1879e27b5cb57bee828ea57a1ce9a004e9ae51fa71a2d4fb031175386df246"
 dependencies = [
  "bitflags",
  "bstr",
@@ -921,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "git-hash"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898628aaedf437563872461736f861acc1503e23ee4a59857513b0261c014460"
+checksum = "42611c78e4545531ae2078b7599f23dbec4e0f03d42adbe0cfd1189866ea09a5"
 dependencies = [
  "hex",
  "quick-error",
@@ -932,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "git-index"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80691537dd8702a4dc317a1aebc969fae51b0dc995e44e07203cfcb60d49efef"
+checksum = "2032b59abc5b4029498f41373f4567568f835629fe7963bf11c4cf8881a6eab2"
 dependencies = [
  "atoi",
  "bitflags",
@@ -964,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "git-mailmap"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f4cb7573041054d62372386e887c46025c6ab1af164db55c8a657d4f02d1ec"
+checksum = "bb5e445a76b3c2ddf8d920b45674a5b0781243879c41750eaf87ac18627015b9"
 dependencies = [
  "bstr",
  "git-actor",
@@ -976,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "git-object"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873d25c73b490aad3897d12f5d1bb9e91404590f37dcf9b72d229972192c07c"
+checksum = "5045f17a3fba3e1668571ec725fd45f948c901bb2562c72ee8e6be7aaa8f7a6f"
 dependencies = [
  "bstr",
  "btoi",
@@ -996,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "git-odb"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69359d85f7dbbe05984024e63e581092ef38bdf0f12c461077d190fe47b061d"
+checksum = "44578bb80d492d4569eb07426c069f2cc6985af8a3ed9b895f8d8ac6112ab390"
 dependencies = [
  "arc-swap",
  "git-features",
@@ -1015,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "git-pack"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89910dcf8ea9befe504e6373832b38c9da49e8dd830206c7f9deae29f1e1d58c"
+checksum = "84efc688a585c627f782c6b1ba06bc8a7450131e4dda240386bff1ee705e009f"
 dependencies = [
  "bytesize",
  "clru",
@@ -1041,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "git-packetline"
-version = "0.12.6"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafc2cdf2499cac5ac5ca87bc0b167d79fb98235c0454b404bf954b01a4fddd3"
+checksum = "f80cbb5c48737d89cfb2ba74b8b62df2c36a4ce98ad8225e4125be37453c7fde"
 dependencies = [
  "bstr",
  "hex",
@@ -1062,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "git-protocol"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36b18dc7dfca4b70a478604afd86fabf999013649be3c7501997befc6e02afc"
+checksum = "724cd5b3aa601b83937f116bb27dd5f6cb5de521aa103bc803230f9d0fb5edd4"
 dependencies = [
  "bstr",
  "btoi",
@@ -1074,15 +1025,15 @@ dependencies = [
  "git-transport",
  "maybe-async",
  "nom",
- "quick-error",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "git-quote"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec1960fa4f68a1637ce03d8c151ae2f8565d1de119a3eee8b5b9a364a08aacb"
+checksum = "38e200d7357e12e0676cd3348176665f90f9a6139caa87ca49a19a6dd6e996cf"
 dependencies = [
  "bstr",
  "btoi",
@@ -1091,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "git-ref"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c37be789a743f28b1430c9d6096fa637eb696746ae88b76c4b96112e802c8f"
+checksum = "97982aefe48e8ff0c9e0c3bb2c9f9388c9653072fa8706aaa87ac8c90e2dfa4a"
 dependencies = [
  "git-actor",
  "git-features",
@@ -1110,10 +1061,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-repository"
-version = "0.21.1"
+name = "git-refspec"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09bc3239f9e983ee0bf87a952644bde5b6344219fab54acba959365852b319ea"
+checksum = "32886438939729151852fb2379007a3f17695232cdc65a81c7e757ae4b587b71"
+dependencies = [
+ "bstr",
+ "git-hash",
+ "git-revision",
+ "git-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "git-repository"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329493b8366835aa7bb4fc44ef13e624ecb62f3244d55e87715683823a81c814"
 dependencies = [
  "byte-unit",
  "clru",
@@ -1122,7 +1087,6 @@ dependencies = [
  "git-config",
  "git-credentials",
  "git-date",
- "git-diff",
  "git-discover",
  "git-features",
  "git-glob",
@@ -1136,6 +1100,7 @@ dependencies = [
  "git-path",
  "git-protocol",
  "git-ref",
+ "git-refspec",
  "git-revision",
  "git-sec",
  "git-tempfile",
@@ -1154,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "git-revision"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fc0b04b5160de248d4ef2248d41d38dac53388dade1a547dd954dead01c62b"
+checksum = "3df272beb7bbab23b9ff467e167ab6cda85fc77e6944bd0e2b08daccce5cfed2"
 dependencies = [
  "bstr",
  "git-date",
@@ -1169,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "git-sec"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffcecb38973b7c8fb3be5ae855a366a1e615fe1b7cf38d217f3e1adeb3608170"
+checksum = "0073a138d171b64d5251726620c2232f695f7fbcfa7e5678dc62c1c19846f0e5"
 dependencies = [
  "bitflags",
  "dirs 4.0.0",
@@ -1197,25 +1162,24 @@ dependencies = [
 
 [[package]]
 name = "git-transport"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e0e75b18177b33ce67eae76d9ab210bd1a0543ed160656bf741edefee2f3d"
+checksum = "2f482f64944993d0a461be8a7d3fcf3a29cf2e8e91f94fa2359820e67813d6a8"
 dependencies = [
  "bstr",
  "git-features",
  "git-packetline",
  "git-sec",
  "git-url",
- "quick-error",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "git-traverse"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b9468cd57d145b8bc06f1a8e867b8ed5044c3f856cc7b98a9aac97f9163aa"
+checksum = "5edc8f220eb957d4ddba19bf42dca323a3e584d067634946a3bf30cca4383052"
 dependencies = [
  "git-hash",
  "git-object",
@@ -1225,23 +1189,23 @@ dependencies = [
 
 [[package]]
 name = "git-url"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7efc31fd6bb3a52a18006dfaf686e3ba4d0d7ad0ca325bfc7d719affd28dc624"
+checksum = "e7805eb7dddaf2d4097495e7bee7611385a7d9ac7b5991e11500e616f559e4af"
 dependencies = [
  "bstr",
  "git-features",
  "git-path",
  "home",
- "quick-error",
+ "thiserror",
  "url",
 ]
 
 [[package]]
 name = "git-validate"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2c1eaaa942eb3c49ab20f27c0715e79e26e6b156a0f77d7ed7bbb26126a8fa"
+checksum = "7af1453adfe6011f0ef71824591b7cdd85850c27bbf3dc8fa855574bed2fe107"
 dependencies = [
  "bstr",
  "quick-error",
@@ -1249,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "git-worktree"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779a6a2a0d51b690fdf1e0024138a2f320be89db7fc2e7f5becd20e65aa42344"
+checksum = "5f4f5175b6a78a8689d86d9e53ac767f69a8472a6c4b20f8d16fd9a0bf84ba3a"
 dependencies = [
  "bstr",
  "git-attributes",
@@ -1941,7 +1905,7 @@ checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
  "pest",
- "sha-1 0.8.2",
+ "sha-1",
 ]
 
 [[package]]
@@ -2310,31 +2274,10 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
+ "block-buffer",
+ "digest",
  "fake-simd",
  "opaque-debug",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.3",
- "sha1-asm",
-]
-
-[[package]]
-name = "sha1-asm"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563d4f7100bc3fce234e5f37bbf63dc2752558964505ba6ac3f7204bdc59eaac"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "git-path"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f054752f9f73d557f4ef0a4e48f2f7e01454abd7accdef9f85f0ef4fa2c6e8f"
+checksum = "eb95b96097d742975f700c6a125ab447b051787eec322e3f6e59e83c867dea40"
 dependencies = [
  "bstr",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -367,7 +376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb6f80f92629b81f5b17b616a99f72870556ca457bbbd99aeda7bb5d194316a2"
 dependencies = [
  "castaway",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
 ]
@@ -377,6 +386,15 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -457,6 +475,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array 0.14.6",
+ "typenum",
+]
+
+[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,7 +527,17 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -696,6 +734,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,14 +768,14 @@ dependencies = [
 
 [[package]]
 name = "git-actor"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5d2a77331398a96dc6464f1602358f80831f8c1d482d9b36b8589b89727b46"
+checksum = "9fb53b8b0a098e3db89958c0aa36e1cbaa5e80fdfc98a7535e7078552120cc03"
 dependencies = [
  "bstr",
  "btoi",
  "git-date",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "nom",
  "quick-error",
  "serde",
@@ -735,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "git-attributes"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d0551e2d2931a8af08fe587d1d109a621a521fb3f250bd8745653f70fda27f"
+checksum = "51845b670130052b90b0938d97d9507c81f3e81f355b232d024729a771293b82"
 dependencies = [
  "bstr",
  "compact_str",
@@ -745,16 +793,16 @@ dependencies = [
  "git-glob",
  "git-path",
  "git-quote",
- "quick-error",
  "serde",
+ "thiserror",
  "unicode-bom",
 ]
 
 [[package]]
 name = "git-bitmap"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7715cc94cd761fe92bb5626a332e4886292c7af88984abfdafad82dd56002475"
+checksum = "5442ba44b4385121a333f56837f3e6ce5a1b843d080b93d764578960a510507b"
 dependencies = [
  "quick-error",
 ]
@@ -770,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "git-config"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2517e4a1f8c82266debd70d43aac472ebc6cc403d4b4213e222d2c4d2c67aa97"
+checksum = "168f2e6bec559afb1e029510ee1746f0971fd35bbd5c20bf43c9df74e32be8f8"
 dependencies = [
  "bitflags",
  "bstr",
@@ -802,21 +850,21 @@ dependencies = [
 
 [[package]]
 name = "git-date"
-version = "0.0.2"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de28bca8c01f1ed4e776bed75802c7f7e671da112496445dfcf885bc1a357250"
+checksum = "9a2c5b328bf9081b27042a274c895758df97309275e618e4fcfede919ce3d282"
 dependencies = [
  "bstr",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "serde",
  "time",
 ]
 
 [[package]]
 name = "git-diff"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9907f146e0ea61fabca745e45296a4da11cf4d6fd4d7aaa544ccc00f211419"
+checksum = "c7a3d2379658de2bf9b25e730ca8e486d66f1f9515e7f82b1d165f5e0afec742"
 dependencies = [
  "git-hash",
  "git-object",
@@ -825,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "git-discover"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db794b6e98c7fb9667c371d64a35534a4bfe088868a80efe4cfe38a71379bab"
+checksum = "5cf1909f287bd3365dabdbb657f78f02c2ef496001db782f6137588c9668623a"
 dependencies = [
  "bstr",
  "git-hash",
@@ -839,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "git-features"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bfebf2c0a0d28414aa7c3baa058d5c1c2969e553806904343a2c11483f425a"
+checksum = "48289da362ef7ee1412a9a80bb459406d3045ad604484526210d594d10aa5268"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",
@@ -855,6 +903,7 @@ dependencies = [
  "parking_lot 0.12.0",
  "prodash",
  "quick-error",
+ "sha-1 0.10.0",
  "sha1_smol",
  "walkdir",
 ]
@@ -872,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "git-hash"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82a0c09fdddeb738ed8338d214652c6d60ebf814a30d9ae1ecae7c91e0bbe81"
+checksum = "898628aaedf437563872461736f861acc1503e23ee4a59857513b0261c014460"
 dependencies = [
  "hex",
  "quick-error",
@@ -883,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "git-index"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6795e3808f9ddc823c9864bec0ddb5c1e44479ac5aea0d6ff25ae0f0d657c1"
+checksum = "80691537dd8702a4dc317a1aebc969fae51b0dc995e44e07203cfcb60d49efef"
 dependencies = [
  "atoi",
  "bitflags",
@@ -895,10 +944,11 @@ dependencies = [
  "git-features",
  "git-hash",
  "git-object",
+ "itoa 1.0.3",
  "memmap2 0.5.3",
- "quick-error",
  "serde",
  "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -914,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "git-mailmap"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df9c0eee51e09351bcaddb6783fdb979fb3ba9c61da259968ff923dd5635b44"
+checksum = "61f4cb7573041054d62372386e887c46025c6ab1af164db55c8a657d4f02d1ec"
 dependencies = [
  "bstr",
  "git-actor",
@@ -926,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "git-object"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bbda5da28d4bb564100373816dd21ba94709c39df12c114764967356430a8e"
+checksum = "2873d25c73b490aad3897d12f5d1bb9e91404590f37dcf9b72d229972192c07c"
 dependencies = [
  "bstr",
  "btoi",
@@ -937,7 +987,7 @@ dependencies = [
  "git-hash",
  "git-validate",
  "hex",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "nom",
  "quick-error",
  "serde",
@@ -946,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "git-odb"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff0f045f8ef21a99fcd9ca540b5a3a7d9f50805316fc183da1e580978c9c561"
+checksum = "e69359d85f7dbbe05984024e63e581092ef38bdf0f12c461077d190fe47b061d"
 dependencies = [
  "arc-swap",
  "git-features",
@@ -965,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "git-pack"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02268bfe5fe46a6b8dfa5d14357cc1086eba134e254ca7703261ed00f142eb62"
+checksum = "89910dcf8ea9befe504e6373832b38c9da49e8dd830206c7f9deae29f1e1d58c"
 dependencies = [
  "bytesize",
  "clru",
@@ -991,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "git-packetline"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42acbfb60871e96ed09f8c0730020aa4ccfa6ab6bcbb2b64a5150bfc7053773"
+checksum = "fafc2cdf2499cac5ac5ca87bc0b167d79fb98235c0454b404bf954b01a4fddd3"
 dependencies = [
  "bstr",
  "hex",
@@ -1012,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "git-protocol"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a592b906754f6b30e7c5ee36ead6d815e18ebbfc0db8f6491b005c9608db6d"
+checksum = "f36b18dc7dfca4b70a478604afd86fabf999013649be3c7501997befc6e02afc"
 dependencies = [
  "bstr",
  "btoi",
@@ -1041,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "git-ref"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e365e9a3ee19ca10c9cd8f6f7ea4d464b6dfc73b5ef0f0cbc5747e29dfc14e93"
+checksum = "95c37be789a743f28b1430c9d6096fa637eb696746ae88b76c4b96112e802c8f"
 dependencies = [
  "git-actor",
  "git-features",
@@ -1061,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "git-repository"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9636655207e546b2885248ead6252b54c319cca182914fd7a6cb1d499ab84dc3"
+checksum = "09bc3239f9e983ee0bf87a952644bde5b6344219fab54acba959365852b319ea"
 dependencies = [
  "byte-unit",
  "clru",
@@ -1095,22 +1145,25 @@ dependencies = [
  "git-validate",
  "git-worktree",
  "log",
+ "serde",
  "signal-hook",
+ "smallvec",
  "thiserror",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "git-revision"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681181c8e87d96d6a47bafe1e4d8c9c7b0091c69573e69bd01422fc1a828f43d"
+checksum = "66fc0b04b5160de248d4ef2248d41d38dac53388dade1a547dd954dead01c62b"
 dependencies = [
  "bstr",
  "git-date",
  "git-hash",
  "git-object",
  "hash_hasher",
+ "serde",
  "thiserror",
 ]
 
@@ -1144,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "git-transport"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9ed1ce98841c5335b5eddc58a8338e385f68fbefc80f18bfe563b10ce081c4"
+checksum = "023e0e75b18177b33ce67eae76d9ab210bd1a0543ed160656bf741edefee2f3d"
 dependencies = [
  "bstr",
  "git-features",
@@ -1160,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "git-traverse"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff51d777e90a9a46b6d556ff4715eace4a42d7fde546ef21a315a80d4121827"
+checksum = "c89b9468cd57d145b8bc06f1a8e867b8ed5044c3f856cc7b98a9aac97f9163aa"
 dependencies = [
  "git-hash",
  "git-object",
@@ -1172,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "git-url"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650aa16382e135904f7303cd4156778df3979fc4f3589ea07d870444272486a3"
+checksum = "7efc31fd6bb3a52a18006dfaf686e3ba4d0d7ad0ca325bfc7d719affd28dc624"
 dependencies = [
  "bstr",
  "git-features",
@@ -1196,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "git-worktree"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7e0c10fb0543096aa759e4f082866399e375ffb5e95a4f9e3dcdb3cd6ec488"
+checksum = "779a6a2a0d51b690fdf1e0024138a2f320be89db7fc2e7f5becd20e65aa42344"
 dependencies = [
  "bstr",
  "git-attributes",
@@ -1452,9 +1505,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
@@ -1888,7 +1941,7 @@ checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
  "pest",
- "sha-1",
+ "sha-1 0.8.2",
 ]
 
 [[package]]
@@ -2233,7 +2286,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
 ]
@@ -2245,7 +2298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b7c9017c64a49806c6e8df8ef99b92446d09c92457f85f91835b01a8064ae0"
 dependencies = [
  "indexmap",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
  "unsafe-libyaml",
@@ -2257,10 +2310,31 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+ "sha1-asm",
+]
+
+[[package]]
+name = "sha1-asm"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563d4f7100bc3fce234e5f37bbf63dc2752558964505ba6ac3f7204bdc59eaac"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2448,18 +2522,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2501,9 +2575,10 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "libc",
  "num_threads",
+ "time-macros",
 ]
 
 [[package]]
@@ -2514,6 +2589,12 @@ checksum = "3e32d019b4f7c100bcd5494e40a27119d45b71fba2b07a4684153129279a4647"
 dependencies = [
  "time",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bytecount = "0.6.3"
 clap = {version = "3.2.17", features = ["derive"]}
 clap_complete = "3.2.4"
 color_quant = "1.1.0"
-git-repository = {version = "0.20.0", features = ["max-performance", "unstable", "serde1"]}
+git-repository = {version = "0.21.1", features = ["max-performance", "unstable", "serde1"]}
 git2 = {version = "0.15.0", default-features = false}
 image = "0.24.3"
 owo-colors = "3.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bytecount = "0.6.3"
 clap = {version = "3.2.17", features = ["derive"]}
 clap_complete = "3.2.4"
 color_quant = "1.1.0"
-git-repository = {version = "0.21.1", features = ["max-performance", "unstable", "serde1"]}
+git-repository = {version = "0.22.0", default-features = false, features = ["max-performance-safe", "unstable", "serde1"]}
 git2 = {version = "0.15.0", default-features = false}
 image = "0.24.3"
 owo-colors = "3.4.0"

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -168,7 +168,7 @@ impl Info {
         let repo = git::discover(&config.input)?;
         let workdir = repo
             .work_dir()
-            .context("a non-bare repository is needed")?
+            .context("please run onefetch inside of a non-bare git repository")?
             .to_owned();
 
         let pending_changes = std::thread::spawn({

--- a/src/info/repo.rs
+++ b/src/info/repo.rs
@@ -57,7 +57,7 @@ impl Commits {
         let mut commit_iter = repo.head_commit()?.ancestors().all()?;
         let mut commit_iter_peekable = commit_iter.by_ref().peekable();
 
-        let mailmap = repo.load_mailmap();
+        let mailmap = repo.open_mailmap();
         let mut author_to_number_of_commits: HashMap<Sig, usize> = HashMap::new();
         let mut total_nbr_of_commits = 0;
 
@@ -165,8 +165,8 @@ impl Repo {
 
     // This collects the repo size excluding .git
     pub fn get_repo_size(&self) -> (String, u64) {
-        let (repo_size, file_count) = match self.repo.load_index() {
-            Some(Ok(index)) => {
+        let (repo_size, file_count) = match self.repo.index() {
+            Ok(index) => {
                 let repo_size = index.entries().iter().map(|e| e.stat.size as u128).sum();
                 (repo_size, index.entries().len() as u64)
             }

--- a/src/info/repo.rs
+++ b/src/info/repo.rs
@@ -4,12 +4,10 @@ use crate::info::head_refs::HeadRefs;
 use anyhow::{Context, Result};
 use byte_unit::Byte;
 use git::bstr::BString;
-use git2::{Repository, RepositoryOpenFlags, Status, StatusOptions, StatusShow};
+use git2::{Status, StatusOptions, StatusShow};
 use git_repository as git;
 use git_repository::bstr::ByteSlice;
 use std::collections::HashMap;
-use std::path::Path;
-use std::path::PathBuf;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
@@ -297,11 +295,6 @@ where
     T: Into<OffsetDateTime>,
 {
     dt.into().format(&Rfc3339).unwrap()
-}
-
-pub fn is_valid(repo_path: &PathBuf) -> Result<bool> {
-    let repo = Repository::open_ext(repo_path, RepositoryOpenFlags::empty(), Vec::<&Path>::new());
-    Ok(!repo?.is_bare())
 }
 
 #[cfg(test)]

--- a/src/info/repo.rs
+++ b/src/info/repo.rs
@@ -240,7 +240,7 @@ impl Repo {
             None => return Ok(Default::default()),
         };
 
-        let url = git::url::parse(remote_url.as_bytes())?;
+        let url = git::url::parse(remote_url.as_str().into())?;
         let path = git::path::from_bstr(url.path.as_bstr());
         let repo_name = path
             .with_extension("")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(feature = "fail-on-deprecated", deny(deprecated))]
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use cli::Config;
-use info::{repo, Info};
+use info::Info;
 use std::io;
 use ui::printer::Printer;
 
@@ -27,12 +27,7 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    if !repo::is_valid(&config.input)? {
-        bail!("please run onefetch inside of a non-bare git repository");
-    }
-
     let info = Info::new(&config)?;
-
     let mut printer = Printer::new(io::BufWriter::new(io::stdout()), info, config)?;
 
     printer.print()?;


### PR DESCRIPTION
The most notable improvement is its ability to open submodule
repositories, thus increasing the amount of repositories onefetch
can handle.
