### PR TITLE
changes to improve bash logo #777

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -77,31 +77,36 @@ AutoHotKey:
 Bash:
   type: programming
   ascii: |
-    {0}                ;sh:'
-    {0}             :ba:sh:,ba;
-    {0}          ;sh,         ':ba;
-    {0}      ':ba                ':sh;
-    {0}   ,sh'                      ,ash,
-    {0} ,s:'                           ':h;
-    {0}'ba                              ,aoOk,
-    {0}:b,                           ;hkABASH:
-    {0}:b,                        ;oOBASHBASH:
-    {0}:b,                    ':bBASHBASHBASH:
-    {0}:b,                 ':AKBBBASHBASHBASH:
-    {0}:b,               ;okNBBB$BASHBASHBASH:
-    {0}:b,               oABASH$ $BBBBASHBASH:
-    {0}:b,               oBASH$   $BBBASHBASH:
-    {0}:b,               oBAS$  $BASHBAS  ASH:
-    {0};b;               oBASHB$  $BBB  HBASH;
-    {0} :ba'             oBAS$   $HH  SHBASHa
-    {0}  ':sh;           oBASH$ $BASHBASHBA'
-    {0}     ':ba:        oBASHB$BASHBAS:'
-    {0}         ;shh:,   oBASHBASHBA;
-    {0}            ,:ba;o0ABN0Aa,
-    {0}                ;sh:'
+    {0}                  ===          ==
+    {0}              ====             ==
+    {0}==        ====                 ==
+    {0} ==   ====                     ==
+    {0}   ===                         ==
+    {0}    ==                         ==
+    {0}    ==       ::                ==
+    {0}    ==    ::::::::             ==
+    {0}    ==   :::::::::             ==
+    {0}    ==   :::                   ==
+    {0}    ==  ::::                   ==
+    {0}    ==   :::::::::             ==
+    {0}    ==   ::::::::::            ==
+    {0}    ==         ::::            ==
+    {0}    ==          ::::      {1}[[]] {0}==
+    {0}    ==    :::  ::::     {1}[[]]   {0}==
+    {0}    ==   ::::::::::  {1}[[]]   {0}===
+    {0}    ==    ::::::::       ===
+    {0}==  ==       ::       ===
+    {0} == ==            ====
+    {0}   ===        ====
+    {0}    ==    ====
+    {0}      ====
   colors:
     ansi:
       - white
+      - green
+    hex:
+      - '#555555'
+      - '#008000'
     chip: '#89E051'
 C:
   type: programming


### PR DESCRIPTION
Changes to improve bash logo:

Before -> After
<img width="283" alt="image" src="https://user-images.githubusercontent.com/2379260/193477641-30edc2a7-8b0d-4824-a1a5-f75569e86c25.png">  <img width="255" alt="image" src="https://user-images.githubusercontent.com/2379260/193477651-c83d344a-b95e-4472-91fa-6a8906259210.png">

Truecolor :-)
<img width="279" alt="image" src="https://user-images.githubusercontent.com/2379260/193477664-eab6b3f4-ccc2-4794-830b-6cfa7b1f5e19.png">

