### PR TITLE
WIP: Config file for theming/customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 *.snap
 /parts
 /prime
-.gitignore.swp
+*.swp
 .DS_Store
 result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "merge"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bbef93abb1da61525bbc45eeaff6473a41907d19f8f9aa5168d214e10693e9"
+dependencies = [
+ "merge_derive",
+ "num-traits",
+]
+
+[[package]]
+name = "merge_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209d075476da2e63b4b29e72a2ef627b840589588e71400a25e3565c4f849d07"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +1717,7 @@ dependencies = [
  "clap 3.2.22",
  "clap_complete",
  "color_quant",
+ "dirs 4.0.0",
  "enable-ansi-support",
  "git-features",
  "git-repository",
@@ -1702,6 +1725,7 @@ dependencies = [
  "image",
  "lazy_static",
  "libc",
+ "merge",
  "owo-colors",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ git-repository = { version = "0.23.1", default-features = false, features = [
 ] }
 git2 = { version = "0.15.0", default-features = false }
 image = "0.24.3"
+merge = "0.1.0"
 owo-colors = "3.5.0"
 regex = "1.6.0"
 serde = "1.0.144"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ bytecount = "0.6.3"
 clap = { version = "3.2.22", features = ["derive"] }
 clap_complete = "3.2.5"
 color_quant = "1.1.0"
+dirs = "4.0.0"
 git-features-for-configuration-only = { package = "git-features", version = "0.22.4", features = ["zlib-ng-compat"] }
 git-repository = { version = "0.23.1", default-features = false, features = [
   "max-performance-safe",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,6 +153,36 @@ pub struct Config {
     pub completion: Option<Shell>,
 }
 
+impl Default for Config {
+    fn default() -> Self { Config {
+        input: PathBuf::from("."),
+        ascii_input: Default::default(),
+        ascii_language: Default::default(),
+        ascii_colors: Default::default(),
+        disabled_fields: Default::default(),
+        image: Default::default(),
+        image_protocol: Default::default(),
+        color_resolution: 16,
+        no_bold: Default::default(),
+        no_merges: Default::default(),
+        no_color_palette: Default::default(),
+        number_of_authors: 3,
+        exclude: Default::default(),
+        no_bots: Default::default(),
+        languages: Default::default(),
+        package_managers: Default::default(),
+        output: Default::default(),
+        true_color: When::Auto,
+        show_logo: When::Always,
+        text_colors: Default::default(),
+        iso_time: Default::default(),
+        email: Default::default(),
+        include_hidden: Default::default(),
+        r#type: vec![LanguageType::Programming, LanguageType::Markup],
+        completion: Default::default(),
+    } }
+}
+
 pub fn print_supported_languages() -> Result<()> {
     for l in Language::iter() {
         println!("{}", l);
@@ -201,13 +231,13 @@ mod test {
 
     #[test]
     fn test_default_config() {
-        let config = get_default_config();
+        let config = Config::default();
         assert_eq!(config, Config::parse_from(&["onefetch"]))
     }
 
     #[test]
     fn test_custom_config() {
-        let mut config = get_default_config();
+        let mut config = Config::default();
         config.number_of_authors = 4;
         config.input = PathBuf::from("/tmp/folder");
         config.no_merges = true;
@@ -256,36 +286,6 @@ mod test {
     #[test]
     fn test_config_with_text_colors_but_out_of_bounds() {
         assert!(Config::try_parse_from(&["onefetch", "--text-colors", "17"]).is_err())
-    }
-
-    fn get_default_config() -> Config {
-        Config {
-            input: PathBuf::from("."),
-            ascii_input: Default::default(),
-            ascii_language: Default::default(),
-            ascii_colors: Default::default(),
-            disabled_fields: Default::default(),
-            image: Default::default(),
-            image_protocol: Default::default(),
-            color_resolution: 16,
-            no_bold: Default::default(),
-            no_merges: Default::default(),
-            no_color_palette: Default::default(),
-            number_of_authors: 3,
-            exclude: Default::default(),
-            no_bots: Default::default(),
-            languages: Default::default(),
-            package_managers: Default::default(),
-            output: Default::default(),
-            true_color: When::Auto,
-            show_logo: When::Always,
-            text_colors: Default::default(),
-            iso_time: Default::default(),
-            email: Default::default(),
-            include_hidden: Default::default(),
-            r#type: vec![LanguageType::Programming, LanguageType::Markup],
-            completion: Default::default(),
-        }
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use clap::AppSettings;
 use clap::{Command, Parser, ValueHint};
 use clap_complete::{generate, Generator, Shell};
+use merge::Merge;
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde::de::{self, Visitor};
@@ -17,12 +18,13 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use strum::IntoEnumIterator;
 
-#[derive(Clone, Debug, Parser, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Parser, PartialEq, Eq, Deserialize, Serialize, Merge)]
 #[clap(version, about, long_about = None, rename_all = "kebab-case")]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 pub struct Config {
     /// Run as if onefetch was started in <input> instead of the current working directory
     #[clap(default_value = ".", hide_default_value = true, value_hint = ValueHint::DirPath)]
+    #[merge(skip)]
     pub input: PathBuf,
     /// Takes a non-empty STRING as input to replace the ASCII logo
     ///
@@ -50,6 +52,7 @@ pub struct Config {
         short = 'c',
         value_parser = clap::value_parser!(u8).range(..16),
     )]
+    #[merge(strategy = overwrite_vector)]
     pub ascii_colors: Vec<u8>,
     /// Allows you to disable FIELD(s) from appearing in the output
     #[clap(
@@ -60,6 +63,7 @@ pub struct Config {
         arg_enum,
         value_name = "FIELD"
     )]
+    #[merge(strategy = overwrite_vector)]
     pub disabled_fields: Vec<InfoType>,
     /// Path to the IMAGE file
     #[clap(long, short, value_hint = ValueHint::FilePath)]
@@ -75,30 +79,40 @@ pub struct Config {
         default_value_t = 16usize,
         possible_values = ["16", "32", "64", "128", "256"],
     )]
+    #[merge(strategy = overwrite)]
     pub color_resolution: usize,
     /// Turns off bold formatting
     #[clap(long)]
+    #[merge(strategy = merge::bool::overwrite_false)]
     pub no_bold: bool,
     /// Ignores merge commits
     #[clap(long)]
+    #[merge(strategy = merge::bool::overwrite_false)]
     pub no_merges: bool,
     /// Hides the color palette
     #[clap(long)]
+    #[merge(strategy = merge::bool::overwrite_false)]
     pub no_color_palette: bool,
     /// NUM of authors to be shown
     #[clap(long, short, default_value_t = 3usize, value_name = "NUM")]
+    #[merge(strategy = overwrite)]
     pub number_of_authors: usize,
     /// gnore all files & directories matching EXCLUDE
     #[clap(long, multiple_values = true, short, value_hint = ValueHint::AnyPath)]
+    #[merge(strategy = overwrite_vector)]
     pub exclude: Vec<PathBuf>,
     /// Exclude [bot] commits. Use <REGEX> to override the default pattern
     #[clap(long, value_name = "REGEX")]
     pub no_bots: Option<Option<MyRegex>>,
     /// Prints out supported languages
     #[clap(long, short)]
+    #[serde(skip)]
+    #[merge(strategy = merge::bool::overwrite_false)]
     pub languages: bool,
     /// Prints out supported package managers
     #[clap(long, short)]
+    #[serde(skip)]
+    #[merge(strategy = merge::bool::overwrite_false)]
     pub package_managers: bool,
     /// Outputs Onefetch in a specific format
     #[clap(long, short, value_name = "FORMAT", arg_enum)]
@@ -107,11 +121,13 @@ pub struct Config {
     ///
     /// If set to auto: true color will be enabled if supported by the terminal
     #[clap(long, default_value = "auto", value_name = "WHEN", arg_enum)]
+    #[merge(strategy = overwrite)]
     pub true_color: When,
     /// Specify when to show the logo
     ///
     /// If set to auto: the logo will be hidden if the terminal's width < 95
     #[clap(long, default_value = "always", value_name = "WHEN", arg_enum)]
+    #[merge(strategy = overwrite)]
     pub show_logo: When,
     /// Changes the text colors (X X X...)
     ///
@@ -128,15 +144,19 @@ pub struct Config {
         value_parser = clap::value_parser!(u8).range(..16),
         max_values = 6
     )]
+    #[merge(strategy = overwrite_vector)]
     pub text_colors: Vec<u8>,
     /// Use ISO 8601 formatted timestamps
     #[clap(long, short = 'z')]
+    #[merge(strategy = merge::bool::overwrite_false)]
     pub iso_time: bool,
     /// Show the email address of each author
     #[clap(long, short = 'E')]
+    #[merge(strategy = merge::bool::overwrite_false)]
     pub email: bool,
     /// Count hidden files and directories
     #[clap(long)]
+    #[merge(strategy = merge::bool::overwrite_false)]
     pub include_hidden: bool,
     /// Filters output by language type
     #[clap(
@@ -146,7 +166,13 @@ pub struct Config {
         short = 'T',
         arg_enum,
     )]
+    #[merge(strategy = overwrite_vector)]
     pub r#type: Vec<LanguageType>,
+    /// Specify a custom path to a config file.
+    /// Default config is located at ${HOME}/.config/onefetch/config.conf.
+    #[clap(long, value_hint = ValueHint::AnyPath)]
+    #[merge(skip)]
+    pub config_path: Option<PathBuf>,
     /// If provided, outputs the completion file for given SHELL
     #[clap(long = "generate", value_name = "SHELL", arg_enum)]
     #[serde(skip)]
@@ -179,8 +205,18 @@ impl Default for Config {
         email: Default::default(),
         include_hidden: Default::default(),
         r#type: vec![LanguageType::Programming, LanguageType::Markup],
+        config_path: Default::default(),
         completion: Default::default(),
     } }
+}
+
+fn overwrite<T>(left: &mut T, right: T) {
+    *left = right;
+}
+
+fn overwrite_vector<T>(left: &mut Vec<T>, mut right: Vec<T>) {
+    left.clear();
+    left.append(&mut right);
 }
 
 pub fn print_supported_languages() -> Result<()> {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,0 +1,47 @@
+use anyhow::{anyhow, Result};
+use crate::cli::Config;
+use dirs::config_dir;
+use merge::Merge;
+use std::fs;
+use std::{fs::File, path::Path};
+use std::io::{BufReader, Read};
+
+fn read_config_file<P: AsRef<Path>>(path: &P) -> Result<Config> {
+    let f = File::open(&path)?;
+    let mut buf_reader = BufReader::new(f);
+    let mut contents = String::new();
+    buf_reader.read_to_string(&mut contents)?;
+    Ok(toml::from_str(contents.as_str()).unwrap())
+}
+
+fn load_config<P: AsRef<Path>>(path: Option<&P>) -> Result<Config> {
+    match path {
+        Some(config_path) => read_config_file(config_path),
+        None => {
+            let mut default_path = config_dir().unwrap();
+            default_path.push("onefetch.toml");
+            println!("Default config file path: {}", &default_path.display());
+            if default_path.exists() {
+                read_config_file(&default_path)
+            } else {
+                write_default_config(&default_path);
+                Err(anyhow!("Default config file did not exist: {:?}", default_path))
+            }
+        } 
+    }
+}
+
+fn write_default_config<P: AsRef<Path>>(default_path: &P) {
+    let toml = toml::to_string(&Config::default()).expect("Config should be serializable");
+    fs::write(default_path, toml).expect("Should be able to write to config dir");
+}
+
+pub fn populate_config(cli_config: Config) -> Config {
+    match load_config(cli_config.config_path.as_ref()) {
+        Ok(mut disk_config) => {
+            disk_config.merge(cli_config);
+            disk_config
+        },
+        Err(_) => cli_config
+    }
+}

--- a/src/info/info_field.rs
+++ b/src/info/info_field.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 pub trait InfoField {
     const TYPE: InfoType;
     fn value(&self) -> String;
@@ -11,7 +13,7 @@ pub trait InfoField {
     }
 }
 
-#[derive(Clone, clap::ValueEnum, Debug, Eq, PartialEq)]
+#[derive(Clone, clap::ValueEnum, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub enum InfoType {
     Title,
     Project,

--- a/src/info/langs/language.rs
+++ b/src/info/langs/language.rs
@@ -1,6 +1,5 @@
 use crate::info::info_field::{InfoField, InfoType};
 use owo_colors::OwoColorize;
-use serde::Serialize;
 
 include!(concat!(env!("OUT_DIR"), "/language.rs"));
 

--- a/src/info/langs/language.tera
+++ b/src/info/langs/language.tera
@@ -2,6 +2,7 @@ use owo_colors::{
     AnsiColors,
     DynColors::{self, Ansi, Rgb},
 };
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Write;
 use strum::EnumIter;
@@ -11,7 +12,7 @@ pub struct Colors {
     true_colors: Option<Vec<DynColors>>,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, clap::ValueEnum)]
+#[derive(Clone, PartialEq, Eq, Debug, clap::ValueEnum, Deserialize, Serialize)]
 pub enum LanguageType {
     Programming,
     Markup,
@@ -19,7 +20,7 @@ pub enum LanguageType {
     Data,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, EnumIter, clap::ValueEnum, Debug, Serialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, EnumIter, clap::ValueEnum, Debug, Deserialize, Serialize)]
 #[allow(clippy::upper_case_acronyms)]
 #[clap(rename_all = "lowercase")]
 pub enum Language {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> Result<()> {
     #[cfg(windows)]
     let _ = enable_ansi_support::enable_ansi_support();
 
-    let config = Config::parse();
+    let config = configuration::populate_config(Config::parse());
 
     if config.languages {
         return cli::print_supported_languages();
@@ -36,5 +36,6 @@ fn main() -> Result<()> {
 }
 
 mod cli;
+mod configuration;
 mod info;
 mod ui;

--- a/src/ui/image_backends/mod.rs
+++ b/src/ui/image_backends/mod.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use image::DynamicImage;
+use serde::{Deserialize, Serialize};
 
-#[derive(clap::ValueEnum, Clone, PartialEq, Eq, Debug)]
+#[derive(clap::ValueEnum, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub enum ImageProtocol {
     Kitty,
     Sixel,

--- a/src/ui/printer.rs
+++ b/src/ui/printer.rs
@@ -6,6 +6,7 @@ use crate::ui::image_backends::ImageBackend;
 use crate::ui::Language;
 use anyhow::{Context, Result};
 use image::DynamicImage;
+use serde::{Deserialize, Serialize};
 use std::fmt::Write as _;
 use std::io::Write;
 use terminal_size::{terminal_size, Width};
@@ -13,7 +14,7 @@ use terminal_size::{terminal_size, Width};
 const CENTER_PAD_LENGTH: usize = 3;
 const MAX_TERM_WIDTH: u16 = 95;
 
-#[derive(Clone, clap::ValueEnum, PartialEq, Eq, Debug)]
+#[derive(Clone, clap::ValueEnum, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub enum SerializationFormat {
     Json,
     Yaml,


### PR DESCRIPTION
Resolves #745.

### General
- [x] Add serialization/deserialization of Config into a config file
- [ ] Add tests for new code logic
- [ ] Add glyphs for palette and separators

### Bugs / Improvements
- Right now, the config file is written to config dir directly instead of creating a `onefetch` subdirectory. I'm still figuring out how to best ensure that a parent dictionary is created if necessary.
- I want to ensure that if the user-supplied config is malformed, `onefetch` prints a warning about that and uses the default config values. Or would it be better to fail completely instead of showing the info with default options?

### Other questions
- `cli.rs` got a lot longer. I'm thinking of moving config-specific code to a separate file, but that's most of `cli.rs`. What would be a good way to separate them?
- Which of the config value sources has more priority, the config file or the command line arguments? 
  - The way I see it, the user should be able to override any option via command line, regardless of what's in the config file. 
  -  But there are options where it's not practical. For example, it would make sense if `exclude` paths from both sources counted. Otherwise, the user would need to write out all the excluded paths in the config if they want to include an extra path.
  - As of right now, for consistency, all `bool` values are merged basically as an "or" (if it's `true` in the config file, then the command-line argument doesn't matter), and all other values are completely overwritten. This is obviously not ideal, and I plan to change it, but I'd like to hear your perspective on what I should change it to.
- I feel like there's an easy attribute solution for serializing `MyRegex` instead of the trait implementation I wrote, but I couldn't think of one.

I'm very new to Rust, so if something I wrote is not idiomatic, I'll be happy to change that if you point it out.