### PR TITLE
Automate publish to crates.io

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,3 +62,24 @@ jobs:
           installers-regex: '\.exe$'
           delete-previous-version: 'true'
           token: ${{ secrets.WINGET_TOKEN }}
+
+  cargo-publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: clippy
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish


### PR DESCRIPTION
This is pretty much just copied and pasted from [here](https://github.com/spenserblack/repofetch/blob/342ab94c3db7275048b8ed34581347e9e6621533/.github/workflows/release.yml).

I thought we were doing this already, but a quick search on cs.github.com didn't turn anything up.

As it doesn't use the existing file from `make build` (`cargo publish` always rebuilds AFAIK), I
made this a separate job.
