### PR TITLE
upgrade gitoxide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "ahash"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464b3811b747f8f7ebc8849c9c728c39f6ac98a055edad93baf9eb330e3f8f9d"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,9 +158,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
- "lazy_static",
  "memchr",
- "regex-automata",
 ]
 
 [[package]]
@@ -363,6 +373,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5138945395949e7dfba09646dc9e766b548ff48e23deb5246890e6b64ae9e1b9"
+dependencies = [
+ "castaway",
+ "itoa 1.0.3",
+ "ryu",
+]
+
+[[package]]
 name = "console"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,20 +436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,16 +468,6 @@ dependencies = [
  "lazy_static",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -772,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -795,13 +792,13 @@ dependencies = [
 
 [[package]]
 name = "git-actor"
-version = "0.11.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f71e800c934ad4cb177a1a396a6ea57e4cb493bd5278d350752205570863478"
+checksum = "cf7264c42a5cc700f39d78a47a0eedbba7c26d8982519aeaa0eed05e4516a86a"
 dependencies = [
- "bstr 0.2.17",
+ "bstr 1.0.1",
  "btoi",
- "git-date 0.1.0",
+ "git-date",
  "itoa 1.0.3",
  "nom",
  "quick-error",
@@ -809,32 +806,16 @@ dependencies = [
 
 [[package]]
 name = "git-actor"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7264c42a5cc700f39d78a47a0eedbba7c26d8982519aeaa0eed05e4516a86a"
+checksum = "18d4ce09c0a6c71c044700e5932877667f427f007b77e6c39ab49aebc4719e25"
 dependencies = [
  "bstr 1.0.1",
  "btoi",
- "git-date 0.2.0",
+ "git-date",
  "itoa 1.0.3",
  "nom",
  "quick-error",
-]
-
-[[package]]
-name = "git-attributes"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af13ab50e0e1acc574908fbe70b8d604cd0baec86531cacfa062fd6886d40a9"
-dependencies = [
- "bstr 0.2.17",
- "compact_str",
- "git-features",
- "git-glob 0.3.2",
- "git-path 0.4.1",
- "git-quote 0.2.1",
- "thiserror",
- "unicode-bom",
 ]
 
 [[package]]
@@ -844,11 +825,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1b888e06e6913604328738052794efbe54234c425b3d49c033856f1804996d"
 dependencies = [
  "bstr 1.0.1",
- "compact_str",
- "git-features",
- "git-glob 0.4.0",
- "git-path 0.5.0",
- "git-quote 0.3.0",
+ "compact_str 0.4.0",
+ "git-features 0.22.6",
+ "git-glob",
+ "git-path",
+ "git-quote",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "git-attributes"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c62e66a042c6b39c6dbfa3be37d134900d99ff9c54bbe489ed560a573895d5d"
+dependencies = [
+ "bstr 1.0.1",
+ "compact_str 0.6.1",
+ "git-features 0.23.1",
+ "git-glob",
+ "git-path",
+ "git-quote",
  "thiserror",
  "unicode-bom",
 ]
@@ -864,54 +861,70 @@ dependencies = [
 
 [[package]]
 name = "git-chunk"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0023a89f84bcc8600556630109edfad1bdeb1820ea8a77306a7ca9c01188ef97"
+checksum = "07b2bc1635b660ad6e30379a84a4946590a3c124b747107c2cca1d9dbb98f588"
 dependencies = [
- "quick-error",
+ "thiserror",
+]
+
+[[package]]
+name = "git-command"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e4b01997b6551554fdac6f02277d0d04c3e869daa649bedd06d38c86f11dc42"
+dependencies = [
+ "bstr 1.0.1",
 ]
 
 [[package]]
 name = "git-config"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d533a785dd345fb133acde7a88ac264de96a1982cecad7f0e8a644ff4c39dcc5"
+checksum = "bd8603e953bd4c9bf310e74e43697400f5542f1cc75fad46fbd7427135a9534f"
 dependencies = [
- "bitflags",
- "bstr 0.2.17",
- "git-features",
- "git-glob 0.3.2",
- "git-path 0.4.1",
- "git-ref 0.15.4",
- "git-sec 0.3.1",
- "libc",
+ "bstr 1.0.1",
+ "git-config-value",
+ "git-features 0.23.1",
+ "git-glob",
+ "git-path",
+ "git-ref 0.18.0",
+ "git-sec",
  "memchr",
  "nom",
+ "once_cell",
  "smallvec",
  "thiserror",
  "unicode-bom",
 ]
 
 [[package]]
-name = "git-credentials"
-version = "0.4.0"
+name = "git-config-value"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e623570bb5075bc4f3c0270f5a763f89d51ec6f14a27803ce4d0d9fd8b765496"
+checksum = "805f2a8e0f576586bed3de3f1cb26700dfd73cf2197bd95306eb6a77ffb5034d"
 dependencies = [
- "bstr 0.2.17",
- "git-sec 0.3.1",
- "quick-error",
+ "bitflags",
+ "bstr 1.0.1",
+ "git-path",
+ "libc",
+ "thiserror",
 ]
 
 [[package]]
-name = "git-date"
-version = "0.1.0"
+name = "git-credentials"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d58ccaaf783384a6ad68a6abf84942a3f88e34970ced3b34dc68183be50996d"
+checksum = "3f540186ea56fd075ba2b923180ebf4318e66ceaeac0a2a518e75dab8517d339"
 dependencies = [
- "bstr 0.2.17",
- "itoa 1.0.3",
- "time",
+ "bstr 1.0.1",
+ "git-command",
+ "git-config-value",
+ "git-path",
+ "git-prompt",
+ "git-sec",
+ "git-url",
+ "thiserror",
 ]
 
 [[package]]
@@ -928,26 +941,13 @@ dependencies = [
 
 [[package]]
 name = "git-diff"
-version = "0.18.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ebd9b84031acd1a71ec260cf6f917554d010a386db3284fbe6f66682795ea"
+checksum = "2c4c61358be0a961adf3ebc9a9e126678d98a906a293959847f0b7f3b580c21c"
 dependencies = [
  "git-hash",
- "git-object 0.20.3",
- "thiserror",
-]
-
-[[package]]
-name = "git-discover"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5807c4243d232e55d743bc3105526fdbcc721d5f2fec99f83722d126ff1f40"
-dependencies = [
- "bstr 0.2.17",
- "git-hash",
- "git-path 0.4.1",
- "git-ref 0.15.4",
- "git-sec 0.3.1",
+ "git-object 0.22.1",
+ "imara-diff",
  "thiserror",
 ]
 
@@ -959,9 +959,23 @@ checksum = "36d9a4470396ded9b3eb1a645bc26742f365c7acf8f8505dfb4bcc68c48e5d56"
 dependencies = [
  "bstr 1.0.1",
  "git-hash",
- "git-path 0.5.0",
+ "git-path",
  "git-ref 0.16.0",
- "git-sec 0.4.0",
+ "git-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "git-discover"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881e4136d5599cfdb79d8ef60d650823d1a563589fa493d8e4961e64d78a79f2"
+dependencies = [
+ "bstr 1.0.1",
+ "git-hash",
+ "git-path",
+ "git-ref 0.18.0",
+ "git-sec",
  "thiserror",
 ]
 
@@ -971,17 +985,29 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5c20d8d0e488f547dfe796f245dcd70e37f24a4f51ba159be26074bf465c71"
 dependencies = [
+ "git-hash",
+ "libc",
+ "prodash 20.2.0",
+ "sha1_smol",
+ "walkdir",
+]
+
+[[package]]
+name = "git-features"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be88ae837674c71b30c6517c6f5f1335f8135bb8a9ffef20000d211933bed08"
+dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "crossbeam-utils",
  "flate2",
  "git-hash",
- "jwalk",
  "libc",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
- "prodash",
+ "parking_lot 0.12.1",
+ "prodash 21.0.0",
  "quick-error",
  "sha1_smol",
  "walkdir",
@@ -989,19 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "git-glob"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1879e27b5cb57bee828ea57a1ce9a004e9ae51fa71a2d4fb031175386df246"
-dependencies = [
- "bitflags",
- "bstr 0.2.17",
-]
-
-[[package]]
-name = "git-glob"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8243c0d7ceefd49353ee54a836b09c402ca7ab95342a7ab312b4a726d7d94b15"
+checksum = "14d17fc8ae791cd6ee271b283835a3ce6f0e970a9a23f67e332b179055bd260f"
 dependencies = [
  "bitflags",
  "bstr 1.0.1",
@@ -1009,31 +1025,11 @@ dependencies = [
 
 [[package]]
 name = "git-hash"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54f21dd924b7b34e90967091890139afd743a271ed1ebf60bfbe3b65030c4a3"
+checksum = "16d46e6c2d1e8da4438a87bf516a6761b300964a353541fea61e96b3c7b34554"
 dependencies = [
  "hex",
- "thiserror",
-]
-
-[[package]]
-name = "git-index"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c351681b3d8b7daafe19567eae36b57d8ec254d515e0c684470055ea19cd9478"
-dependencies = [
- "atoi",
- "bitflags",
- "bstr 0.2.17",
- "filetime",
- "git-bitmap",
- "git-features",
- "git-hash",
- "git-object 0.20.3",
- "itoa 1.0.3",
- "memmap2 0.5.3",
- "smallvec",
  "thiserror",
 ]
 
@@ -1048,7 +1044,7 @@ dependencies = [
  "bstr 1.0.1",
  "filetime",
  "git-bitmap",
- "git-features",
+ "git-features 0.22.6",
  "git-hash",
  "git-object 0.21.0",
  "git-traverse 0.17.0",
@@ -1059,10 +1055,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-lock"
-version = "2.1.0"
+name = "git-index"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44915b070cde930ecc0e251d53f40d2ad66354546edcfd04720b12e1936e91"
+checksum = "821583c2d12b1e864694eb0bf1cca10ff6a3f45966f5f834e0f921b496dbe7cb"
+dependencies = [
+ "atoi",
+ "bitflags",
+ "bstr 1.0.1",
+ "filetime",
+ "git-bitmap",
+ "git-features 0.23.1",
+ "git-hash",
+ "git-lock",
+ "git-object 0.22.1",
+ "git-traverse 0.18.0",
+ "itoa 1.0.3",
+ "memmap2 0.5.3",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "git-lock"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff6ad736a93573e219cb9b81c2edb6df0ced812f886e8003df375d96e650e73"
 dependencies = [
  "fastrand",
  "git-tempfile",
@@ -1071,32 +1089,13 @@ dependencies = [
 
 [[package]]
 name = "git-mailmap"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb5e445a76b3c2ddf8d920b45674a5b0781243879c41750eaf87ac18627015b9"
+checksum = "bb3f85ce84b2328aeb3124a809f7b3a63e59c4d63c227dba7a9cdf6fca6c0987"
 dependencies = [
- "bstr 0.2.17",
- "git-actor 0.11.4",
+ "bstr 1.0.1",
+ "git-actor 0.13.0",
  "quick-error",
-]
-
-[[package]]
-name = "git-object"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd987a3518738c902bd654f9b6ae7aa24934bf5a80b1614f8afb3a02c9bb16d3"
-dependencies = [
- "bstr 0.2.17",
- "btoi",
- "git-actor 0.11.4",
- "git-features",
- "git-hash",
- "git-validate 0.5.5",
- "hex",
- "itoa 1.0.3",
- "nom",
- "quick-error",
- "smallvec",
 ]
 
 [[package]]
@@ -1108,9 +1107,28 @@ dependencies = [
  "bstr 1.0.1",
  "btoi",
  "git-actor 0.12.0",
- "git-features",
+ "git-features 0.22.6",
  "git-hash",
- "git-validate 0.6.0",
+ "git-validate",
+ "hex",
+ "itoa 1.0.3",
+ "nom",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "git-object"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9469a8c00d8bb500ee76a12e455bb174b4ddf71674713335dd1a84313723f7b3"
+dependencies = [
+ "bstr 1.0.1",
+ "btoi",
+ "git-actor 0.13.0",
+ "git-features 0.23.1",
+ "git-hash",
+ "git-validate",
  "hex",
  "itoa 1.0.3",
  "nom",
@@ -1120,55 +1138,45 @@ dependencies = [
 
 [[package]]
 name = "git-odb"
-version = "0.32.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3353cd4fc18d186c4b4e5588deb0a2822bfe4459ff50e12087881bb526f12ff6"
+checksum = "76eb64cf37326fccda46fee6dc6c8c39d2e8b03f13031cb094a928d61c97b95c"
 dependencies = [
  "arc-swap",
- "git-features",
+ "git-features 0.23.1",
  "git-hash",
- "git-object 0.20.3",
+ "git-object 0.22.1",
  "git-pack",
- "git-path 0.4.1",
- "git-quote 0.2.1",
- "parking_lot 0.12.0",
+ "git-path",
+ "git-quote",
+ "parking_lot 0.12.1",
  "tempfile",
  "thiserror",
 ]
 
 [[package]]
 name = "git-pack"
-version = "0.22.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61a510ef71bd87ad35206553af23863351fac761bf9fc624c3a8e7c40ab39f"
+checksum = "51f385ab95e01ecface60658b0d0f1181f51e114213e584bb7a16c5af47d653f"
 dependencies = [
  "bytesize",
  "clru",
  "dashmap 5.3.3",
  "git-chunk",
  "git-diff",
- "git-features",
+ "git-features 0.23.1",
  "git-hash",
- "git-object 0.20.3",
- "git-path 0.4.1",
+ "git-object 0.22.1",
+ "git-path",
  "git-tempfile",
- "git-traverse 0.16.4",
+ "git-traverse 0.18.0",
  "hash_hasher",
  "memmap2 0.5.3",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "smallvec",
  "thiserror",
  "uluru",
-]
-
-[[package]]
-name = "git-path"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb95b96097d742975f700c6a125ab447b051787eec322e3f6e59e83c867dea40"
-dependencies = [
- "bstr 0.2.17",
- "thiserror",
 ]
 
 [[package]]
@@ -1182,14 +1190,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-quote"
-version = "0.2.1"
+name = "git-prompt"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e200d7357e12e0676cd3348176665f90f9a6139caa87ca49a19a6dd6e996cf"
+checksum = "fa6947935c0671342277bc883ff0687978477b570c1ffe2200b9ba5ac8afdd9f"
 dependencies = [
- "bstr 0.2.17",
- "btoi",
- "quick-error",
+ "git-command",
+ "git-config-value",
+ "nix",
+ "parking_lot 0.12.1",
+ "thiserror",
 ]
 
 [[package]]
@@ -1205,37 +1215,37 @@ dependencies = [
 
 [[package]]
 name = "git-ref"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5926938f4732a200a5897f512234bf6d23e4bc5f23a6d371aae4a66c51020"
-dependencies = [
- "git-actor 0.11.4",
- "git-features",
- "git-hash",
- "git-lock",
- "git-object 0.20.3",
- "git-path 0.4.1",
- "git-tempfile",
- "git-validate 0.5.5",
- "memmap2 0.5.3",
- "nom",
- "quick-error",
-]
-
-[[package]]
-name = "git-ref"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2c421bef14d0b1e9ad38ccf23313bc931f2df43cfb9407515d925808bc6909b"
 dependencies = [
  "git-actor 0.12.0",
- "git-features",
+ "git-features 0.22.6",
  "git-hash",
  "git-lock",
  "git-object 0.21.0",
- "git-path 0.5.0",
+ "git-path",
  "git-tempfile",
- "git-validate 0.6.0",
+ "git-validate",
+ "memmap2 0.5.3",
+ "nom",
+ "thiserror",
+]
+
+[[package]]
+name = "git-ref"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "638c9e454bacb2965a43f05b4a383c8f66dc64f3a770bd0324b221c2a20e121d"
+dependencies = [
+ "git-actor 0.13.0",
+ "git-features 0.23.1",
+ "git-hash",
+ "git-lock",
+ "git-object 0.22.1",
+ "git-path",
+ "git-tempfile",
+ "git-validate",
  "memmap2 0.5.3",
  "nom",
  "thiserror",
@@ -1243,53 +1253,55 @@ dependencies = [
 
 [[package]]
 name = "git-refspec"
-version = "0.1.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4aaf5caf9900e2a2e9a171543fa89795ac24435835a42279b9020ad7956db3d"
+checksum = "9497af773538ae8cfda053ff7dd0a9e6c28d333ba653040f54b8b4ee32f14187"
 dependencies = [
- "bstr 0.2.17",
+ "bstr 1.0.1",
  "git-hash",
  "git-revision",
- "git-validate 0.5.5",
+ "git-validate",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "git-repository"
-version = "0.23.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7064371f20e047fd14c2650cc2943e83ee42a82e910b1f4114beecd511a048c7"
+checksum = "e3e2c5e4611c366b025c4501677e2077d1fba1d365f9e211398d4426f482e204"
 dependencies = [
  "byte-unit",
  "clru",
- "git-actor 0.11.4",
- "git-attributes 0.3.3",
+ "git-actor 0.13.0",
+ "git-attributes 0.5.0",
  "git-config",
  "git-credentials",
- "git-date 0.1.0",
+ "git-date",
  "git-diff",
- "git-discover 0.4.2",
- "git-features",
- "git-glob 0.3.2",
+ "git-discover 0.7.0",
+ "git-features 0.23.1",
+ "git-glob",
  "git-hash",
- "git-index 0.4.3",
+ "git-index 0.7.1",
  "git-lock",
  "git-mailmap",
- "git-object 0.20.3",
+ "git-object 0.22.1",
  "git-odb",
  "git-pack",
- "git-path 0.4.1",
- "git-ref 0.15.4",
+ "git-path",
+ "git-prompt",
+ "git-ref 0.18.0",
  "git-refspec",
  "git-revision",
- "git-sec 0.3.1",
+ "git-sec",
  "git-tempfile",
- "git-traverse 0.16.4",
+ "git-traverse 0.18.0",
  "git-url",
- "git-validate 0.5.5",
- "git-worktree 0.4.3",
+ "git-validate",
+ "git-worktree 0.7.0",
  "log",
+ "once_cell",
  "signal-hook",
  "smallvec",
  "thiserror",
@@ -1298,41 +1310,27 @@ dependencies = [
 
 [[package]]
 name = "git-revision"
-version = "0.4.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1877eb33a9caf9cbb5438d9358ebaf16b858f0e4f502b1c07bf0b1c512b90922"
+checksum = "1efd31c63c3745b5dba5ec7109eec41a9c717f4e1e797fe0ef93098f33f31b25"
 dependencies = [
- "bstr 0.2.17",
- "git-date 0.1.0",
+ "bstr 1.0.1",
+ "git-date",
  "git-hash",
- "git-object 0.20.3",
+ "git-object 0.22.1",
  "hash_hasher",
  "thiserror",
 ]
 
 [[package]]
 name = "git-sec"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0073a138d171b64d5251726620c2232f695f7fbcfa7e5678dc62c1c19846f0e5"
+checksum = "8c79769f6546814d0774db7295c768441016b7e40bdd414fa8dfae2c616a1892"
 dependencies = [
  "bitflags",
  "dirs 4.0.0",
- "git-path 0.4.1",
- "libc",
- "thiserror",
- "windows",
-]
-
-[[package]]
-name = "git-sec"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa3f4fc5e0d205b22ebd9965a627fa68bb8487d4a0db11230f3cedf96d72abe"
-dependencies = [
- "bitflags",
- "dirs 4.0.0",
- "git-path 0.5.0",
+ "git-path",
  "libc",
  "windows",
 ]
@@ -1369,22 +1367,10 @@ dependencies = [
  "is_ci",
  "nom",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "tar",
  "tempfile",
  "xz2",
-]
-
-[[package]]
-name = "git-traverse"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460071dc01c13b4fbf29500b30341212fa6ff5015f2902c6d111c7da534ffc10"
-dependencies = [
- "git-hash",
- "git-object 0.20.3",
- "hash_hasher",
- "thiserror",
 ]
 
 [[package]]
@@ -1400,27 +1386,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-url"
-version = "0.7.3"
+name = "git-traverse"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86916e1476cc349ec60435b8cc18e607e2d480219a47165aa0272d45e8315527"
+checksum = "0d0c4dd773c69f294f43ace8373d48eb770129791f104c6857fa8cac0505af89"
 dependencies = [
- "bstr 0.2.17",
- "git-features",
- "git-path 0.4.1",
- "home",
+ "git-hash",
+ "git-object 0.22.1",
+ "hash_hasher",
  "thiserror",
- "url",
 ]
 
 [[package]]
-name = "git-validate"
-version = "0.5.5"
+name = "git-url"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af1453adfe6011f0ef71824591b7cdd85850c27bbf3dc8fa855574bed2fe107"
+checksum = "21b7f8323196840e7932f5b60e1d9c1d6c140fd806bc512f8beedc3f990a1f81"
 dependencies = [
- "bstr 0.2.17",
- "quick-error",
+ "bstr 1.0.1",
+ "git-features 0.23.1",
+ "git-path",
+ "home",
+ "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -1435,36 +1423,36 @@ dependencies = [
 
 [[package]]
 name = "git-worktree"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda70d3dd8d593afa8c7e97ecb51f9f22cdc750d48a56c18745e1c69ae2d7ad7"
-dependencies = [
- "bstr 0.2.17",
- "git-attributes 0.3.3",
- "git-features",
- "git-glob 0.3.2",
- "git-hash",
- "git-index 0.4.3",
- "git-object 0.20.3",
- "git-path 0.4.1",
- "io-close",
- "thiserror",
-]
-
-[[package]]
-name = "git-worktree"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "837329f3b5e7befb5e9538dada08f225d69a3f9faf484c6e599732ed1fc845b1"
 dependencies = [
  "bstr 1.0.1",
  "git-attributes 0.4.0",
- "git-features",
- "git-glob 0.4.0",
+ "git-features 0.22.6",
+ "git-glob",
  "git-hash",
  "git-index 0.5.0",
  "git-object 0.21.0",
- "git-path 0.5.0",
+ "git-path",
+ "io-close",
+ "thiserror",
+]
+
+[[package]]
+name = "git-worktree"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bcc69c36a29cfa283710b7901877ab251d658935f5a41ed824416af500e0ed"
+dependencies = [
+ "bstr 1.0.1",
+ "git-attributes 0.5.0",
+ "git-features 0.23.1",
+ "git-glob",
+ "git-hash",
+ "git-index 0.7.1",
+ "git-object 0.22.1",
+ "git-path",
  "io-close",
  "thiserror",
 ]
@@ -1547,9 +1535,9 @@ checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -1661,6 +1649,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "imara-diff"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8"
+dependencies = [
+ "ahash",
+ "hashbrown",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,16 +1752,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jwalk"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172752e853a067cbce46427de8470ddf308af7fd8ceaf9b682ef31a5021b6bb9"
-dependencies = [
- "crossbeam",
- "rayon",
 ]
 
 [[package]]
@@ -1924,6 +1912,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,7 +2017,7 @@ dependencies = [
  "clap_complete",
  "color_quant",
  "enable-ansi-support",
- "git-features",
+ "git-features 0.23.1",
  "git-repository",
  "git-testtools",
  "git2",
@@ -2075,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
  "parking_lot_core 0.9.3",
@@ -2308,6 +2308,16 @@ name = "prodash"
 version = "20.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd4e8b029f29b4eb8f95315957fb7ac8a8fd1924405fadf885b0e208fe34ba39"
+dependencies = [
+ "bytesize",
+ "human_format",
+]
+
+[[package]]
+name = "prodash"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27f6a3ef883aaea624a6ad91c88452e5df05430a79fd880c12673a7bc1648d6"
 dependencies = [
  "bytesize",
  "human_format",
@@ -3054,9 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3151,15 +3161,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.37.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
+checksum = "e30acc718a52fb130fec72b1cb5f55ffeeec9253e1b785e94db222178a6acaa1"
 dependencies = [
- "windows_aarch64_msvc 0.37.0",
- "windows_i686_gnu 0.37.0",
- "windows_i686_msvc 0.37.0",
- "windows_x86_64_gnu 0.37.0",
- "windows_x86_64_msvc 0.37.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.40.0",
+ "windows_i686_gnu 0.40.0",
+ "windows_i686_msvc 0.40.0",
+ "windows_x86_64_gnu 0.40.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.40.0",
 ]
 
 [[package]]
@@ -3176,6 +3188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3caa4a1a16561b714323ca6b0817403738583033a6a92e04c5d10d4ba37ca10"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,9 +3201,9 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.37.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
+checksum = "328973c62dfcc50fb1aaa8e7100676e0b642fe56bac6bafff3327902db843ab4"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3195,9 +3213,9 @@ checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.37.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
+checksum = "aa5b09fad70f0df85dea2ac2a525537e415e2bf63ee31cf9b8e263645ee9f3c1"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3207,9 +3225,9 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.37.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
+checksum = "2a1ad4031c1a98491fa195d8d43d7489cb749f135f2e5c4eed58da094bd0d876"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3219,9 +3237,15 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.37.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
+checksum = "520ff37edd72da8064b49d2281182898e17f0688ae9f4070bca27e4b5c162ac7"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046e5b82215102c44fd75f488f1b9158973d02aa34d06ed85c23d6f5520a2853"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3231,9 +3255,9 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.37.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
+checksum = "2a0c9c6df55dd1bfa76e131cef44bdd8ec9c819ef3611f04dfe453fd5bfeda28"
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,11 @@ bytecount = "0.6.3"
 clap = { version = "4.0.22", features = ["derive"] }
 clap_complete = "4.0.3"
 color_quant = "1.1.0"
-git-features-for-configuration-only = { package = "git-features", version = "0.22.4", features = [
+git-features-for-configuration-only = { package = "git-features", version = "0.23.1", features = [
     "zlib-ng-compat",
 ] }
-git-repository = { version = "0.23.1", default-features = false, features = [
+git-repository = { version = "0.27.0", default-features = false, features = [
     "max-performance-safe",
-    "unstable",
 ] }
 git2 = { version = "0.15.0", default-features = false }
 image = "0.24.4"

--- a/src/ui/image_backends/kitty.rs
+++ b/src/ui/image_backends/kitty.rs
@@ -118,7 +118,7 @@ impl super::ImageBackend for KittyBackend {
             raw_image.len()
         );
 
-        let encoded_image = base64::encode(&raw_image); // image data is base64 encoded
+        let encoded_image = base64::encode(raw_image); // image data is base64 encoded
         let mut image_data = Vec::<u8>::new();
         for chunk in encoded_image.as_bytes().chunks(4096) {
             // send a 4096 byte chunk of base64 encoded rgba image data


### PR DESCRIPTION
Standard maintenance, which adjust for a breaking change in cargo features of `git-repository`.
