### PR TITLE
Fix secondary devcontainer setup

### DIFF
--- a/.devcontainer/website/devcontainer.json
+++ b/.devcontainer/website/devcontainer.json
@@ -2,7 +2,6 @@
   "name": "Node.js & TypeScript",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:16-bullseye",
   "workspaceFolder": "/workspaces/onefetch/docs/vercel",
-  "workspaceMount": "/",
   "extensions": ["esbenp.prettier-vscode", "svelte.svelte-vscode"],
   "postCreateCommand": "npm ci",
   "settings": {

--- a/.devcontainer/website/devcontainer.json
+++ b/.devcontainer/website/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "name": "Node.js & TypeScript",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:16-bullseye",
+  "workspaceFolder": "/workspaces/onefetch/docs/vercel",
+  "workspaceMount": "/",
   "extensions": ["esbenp.prettier-vscode", "svelte.svelte-vscode"],
   "postCreateCommand": "npm ci",
   "settings": {

--- a/.devcontainer/website/devcontainer.json
+++ b/.devcontainer/website/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "name": "Node.js & TypeScript",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:16-bullseye",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/onefetch,type=bind,consistency=cached",
   "workspaceFolder": "/workspaces/onefetch/docs/vercel",
   "extensions": ["esbenp.prettier-vscode", "svelte.svelte-vscode"],
   "postCreateCommand": "npm ci",


### PR DESCRIPTION
At least from the docs I've read, alternate dev container configs must be in `/.devcontainer/SUBFOLDER/`.

To use, when creating a codespace, instead of clicking `+`, they can click `...` and then "New with options".

There's still a bit more that can be done (I think it would be reasonable for `npm run dev` to be a postAttachCommand), but I wasn't sure if that should be a different PR or part of this one 🙂 