### PR TITLE
Add `--number-separator` CLI flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,15 +76,6 @@ checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
@@ -402,7 +393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb6f80f92629b81f5b17b616a99f72870556ca457bbbd99aeda7bb5d194316a2"
 dependencies = [
  "castaway",
- "itoa 1.0.3",
+ "itoa",
  "ryu",
 ]
 
@@ -413,7 +404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5138945395949e7dfba09646dc9e766b548ff48e23deb5246890e6b64ae9e1b9"
 dependencies = [
  "castaway",
- "itoa 1.0.3",
+ "itoa",
  "ryu",
 ]
 
@@ -839,7 +830,7 @@ dependencies = [
  "bstr 1.0.1",
  "btoi",
  "git-date 0.2.0",
- "itoa 1.0.3",
+ "itoa",
  "nom",
  "quick-error",
 ]
@@ -853,7 +844,7 @@ dependencies = [
  "bstr 1.0.1",
  "btoi",
  "git-date 0.3.0",
- "itoa 1.0.3",
+ "itoa",
  "nom",
  "quick-error",
 ]
@@ -983,7 +974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37881e9725df41e15d16216d3a0cee251fd8a39d425f75b389112df5c7f20f3d"
 dependencies = [
  "bstr 1.0.1",
- "itoa 1.0.3",
+ "itoa",
  "thiserror",
  "time",
 ]
@@ -995,7 +986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33db9f4462b565a33507aee113f3383bf16b988d2c573f07691e34302b7aa0a"
 dependencies = [
  "bstr 1.0.1",
- "itoa 1.0.3",
+ "itoa",
  "thiserror",
  "time",
 ]
@@ -1140,7 +1131,7 @@ dependencies = [
  "git-hash 0.9.11",
  "git-object 0.21.0",
  "git-traverse 0.17.0",
- "itoa 1.0.3",
+ "itoa",
  "memmap2 0.5.3",
  "smallvec",
  "thiserror",
@@ -1162,7 +1153,7 @@ dependencies = [
  "git-lock 3.0.0",
  "git-object 0.23.0",
  "git-traverse 0.19.0",
- "itoa 1.0.3",
+ "itoa",
  "memmap2 0.5.3",
  "smallvec",
  "thiserror",
@@ -1214,7 +1205,7 @@ dependencies = [
  "git-hash 0.9.11",
  "git-validate 0.6.0",
  "hex",
- "itoa 1.0.3",
+ "itoa",
  "nom",
  "smallvec",
  "thiserror",
@@ -1233,7 +1224,7 @@ dependencies = [
  "git-hash 0.10.0",
  "git-validate 0.7.0",
  "hex",
- "itoa 1.0.3",
+ "itoa",
  "nom",
  "smallvec",
  "thiserror",
@@ -1897,15 +1888,9 @@ checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "jobserver"
@@ -2104,12 +2089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,12 +2111,12 @@ dependencies = [
 
 [[package]]
 name = "num-format"
-version = "0.4.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.4.12",
- "itoa 0.4.8",
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -2223,6 +2202,7 @@ dependencies = [
  "image",
  "insta",
  "lazy_static",
+ "num-format",
  "onefetch-image",
  "onefetch-manifest",
  "owo-colors",
@@ -2776,7 +2756,7 @@ version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
- "itoa 1.0.3",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -2788,7 +2768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d232d893b10de3eb7258ff01974d6ee20663d8e833263c99409d4b13a0209da"
 dependencies = [
  "indexmap",
- "itoa 1.0.3",
+ "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
@@ -3060,7 +3040,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa 1.0.3",
+ "itoa",
  "libc",
  "num_threads",
  "serde",
@@ -3162,7 +3142,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ git-repository = { version = "0.29.0", default-features = false, features = [
 git2 = { version = "0.15.0", default-features = false }
 human-panic = "1.0.3"
 image = "0.24.4"
+num-format = "0.4.4"
 onefetch-image = { path = "image", version = "2.13.2" }
 onefetch-manifest = { path = "manifest", version = "2.13.2" }
 owo-colors = "3.5.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,6 +10,7 @@ use num_format::CustomFormat;
 use onefetch_image::ImageProtocol;
 use onefetch_manifest::ManifestType;
 use regex::Regex;
+use serde::Serialize;
 use std::env;
 use std::io;
 use std::path::PathBuf;
@@ -136,8 +137,8 @@ pub struct Config {
     #[arg(long, short = 'z')]
     pub iso_time: bool,
     /// Which thousands SEPARATOR to use
-    #[arg(long, value_name = "SEPARATOR", value_enum)]
-    pub number_separator: Option<NumberSeparator>,
+    #[arg(long, value_name = "SEPARATOR", default_value = "plain", value_enum)]
+    pub number_separator: NumberSeparator,
     /// Show the email address of each author
     #[arg(long, short = 'E')]
     pub email: bool,
@@ -183,7 +184,7 @@ impl Default for Config {
             show_logo: When::Always,
             text_colors: Default::default(),
             iso_time: Default::default(),
-            number_separator: Default::default(),
+            number_separator: NumberSeparator::Plain,
             email: Default::default(),
             include_hidden: Default::default(),
             r#type: vec![LanguageType::Programming, LanguageType::Markup],
@@ -234,8 +235,9 @@ pub enum When {
     Always,
 }
 
-#[derive(clap::ValueEnum, Clone, PartialEq, Eq, Debug)]
+#[derive(clap::ValueEnum, Clone, PartialEq, Eq, Debug, Serialize, Copy)]
 pub enum NumberSeparator {
+    Plain,
     Comma,
     Space,
     Underscore,
@@ -244,6 +246,7 @@ pub enum NumberSeparator {
 impl NumberSeparator {
     fn separator(&self) -> &'static str {
         match self {
+            Self::Plain => "",
             Self::Comma => ",",
             Self::Space => "\u{202f}",
             Self::Underscore => "_",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ use clap::builder::PossibleValuesParser;
 use clap::builder::TypedValueParser as _;
 use clap::{value_parser, Command, Parser, ValueHint};
 use clap_complete::{generate, Generator, Shell};
+use num_format::Locale;
 use onefetch_image::ImageProtocol;
 use onefetch_manifest::ManifestType;
 use regex::Regex;
@@ -125,7 +126,7 @@ pub struct Config {
     /// '--text-colors 9 10 11 12 13 14'
     #[arg(
         long,
-        short = 't',
+        short,
         value_name = "X",
         value_parser = value_parser!(u8).range(..16),
         num_args = 1..=6
@@ -134,6 +135,9 @@ pub struct Config {
     /// Use ISO 8601 formatted timestamps
     #[arg(long, short = 'z')]
     pub iso_time: bool,
+    /// Format numbers according to international standards
+    #[arg(long, short, value_name = "FORMAT", value_enum)]
+    pub format_numbers: Option<Format>,
     /// Show the email address of each author
     #[arg(long, short = 'E')]
     pub email: bool,
@@ -179,6 +183,7 @@ impl Default for Config {
             show_logo: When::Always,
             text_colors: Default::default(),
             iso_time: Default::default(),
+            format_numbers: Default::default(),
             email: Default::default(),
             include_hidden: Default::default(),
             r#type: vec![LanguageType::Programming, LanguageType::Markup],
@@ -227,6 +232,21 @@ pub enum When {
     Auto,
     Never,
     Always,
+}
+
+#[derive(clap::ValueEnum, Clone, PartialEq, Eq, Debug)]
+pub enum Format {
+    Fr,
+    En,
+}
+
+impl Format {
+    pub fn get_locale(&self) -> Locale {
+        match self {
+            Self::Fr => Locale::fr,
+            Self::En => Locale::en,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,8 +136,8 @@ pub struct Config {
     #[arg(long, short = 'z')]
     pub iso_time: bool,
     /// Which thousands SEPARATOR to use
-    #[arg(long, short, value_name = "SEPARATOR", value_enum)]
-    pub format_numbers: Option<ThousandsSeparator>,
+    #[arg(long, value_name = "SEPARATOR", value_enum)]
+    pub number_separator: Option<NumberSeparator>,
     /// Show the email address of each author
     #[arg(long, short = 'E')]
     pub email: bool,
@@ -183,7 +183,7 @@ impl Default for Config {
             show_logo: When::Always,
             text_colors: Default::default(),
             iso_time: Default::default(),
-            format_numbers: Default::default(),
+            number_separator: Default::default(),
             email: Default::default(),
             include_hidden: Default::default(),
             r#type: vec![LanguageType::Programming, LanguageType::Markup],
@@ -235,18 +235,18 @@ pub enum When {
 }
 
 #[derive(clap::ValueEnum, Clone, PartialEq, Eq, Debug)]
-pub enum ThousandsSeparator {
-    Commas,
-    Spaces,
-    Underscores,
+pub enum NumberSeparator {
+    Comma,
+    Space,
+    Underscore,
 }
 
-impl ThousandsSeparator {
+impl NumberSeparator {
     fn separator(&self) -> &'static str {
         match self {
-            Self::Commas => ",",
-            Self::Spaces => "\u{202f}",
-            Self::Underscores => "_",
+            Self::Comma => ",",
+            Self::Space => "\u{202f}",
+            Self::Underscore => "_",
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,9 +135,9 @@ pub struct Config {
     /// Use ISO 8601 formatted timestamps
     #[arg(long, short = 'z')]
     pub iso_time: bool,
-    /// Which FORMAT to use for the thousands separator.
-    #[arg(long, short, value_name = "FORMAT", value_enum)]
-    pub format_numbers: Option<NumberFormat>,
+    /// Which thousands SEPARATOR to use
+    #[arg(long, short, value_name = "SEPARATOR", value_enum)]
+    pub format_numbers: Option<ThousandsSeparator>,
     /// Show the email address of each author
     #[arg(long, short = 'E')]
     pub email: bool,
@@ -235,13 +235,13 @@ pub enum When {
 }
 
 #[derive(clap::ValueEnum, Clone, PartialEq, Eq, Debug)]
-pub enum NumberFormat {
+pub enum ThousandsSeparator {
     Commas,
     Spaces,
     Underscores,
 }
 
-impl NumberFormat {
+impl ThousandsSeparator {
     fn separator(&self) -> &'static str {
         match self {
             Self::Commas => ",",

--- a/src/info/git.rs
+++ b/src/info/git.rs
@@ -1,5 +1,5 @@
 use super::repo::author::Author;
-use crate::cli::{Format, MyRegex};
+use crate::cli::{MyRegex, NumberFormat};
 use anyhow::Result;
 use git::bstr::BString;
 use git_repository as git;
@@ -35,7 +35,7 @@ impl Commits {
         bot_regex_pattern: &Option<MyRegex>,
         number_of_authors_to_display: usize,
         show_email: bool,
-        format: Option<&Format>,
+        number_format: Option<&NumberFormat>,
     ) -> Result<Self> {
         // assure that objects we just traversed are coming from cache
         // when we read the commit right after.
@@ -94,7 +94,7 @@ impl Commits {
                     author_nbr_of_commits,
                     total_nbr_of_commits,
                     show_email,
-                    format,
+                    number_format,
                 )
             })
             .take(number_of_authors_to_display)

--- a/src/info/git.rs
+++ b/src/info/git.rs
@@ -35,7 +35,7 @@ impl Commits {
         bot_regex_pattern: &Option<MyRegex>,
         number_of_authors_to_display: usize,
         show_email: bool,
-        number_separator: Option<&NumberSeparator>,
+        number_separator: NumberSeparator,
     ) -> Result<Self> {
         // assure that objects we just traversed are coming from cache
         // when we read the commit right after.

--- a/src/info/git.rs
+++ b/src/info/git.rs
@@ -1,5 +1,5 @@
 use super::repo::author::Author;
-use crate::cli::MyRegex;
+use crate::cli::{Format, MyRegex};
 use anyhow::Result;
 use git::bstr::BString;
 use git_repository as git;
@@ -35,6 +35,7 @@ impl Commits {
         bot_regex_pattern: &Option<MyRegex>,
         number_of_authors_to_display: usize,
         show_email: bool,
+        format: Option<&Format>,
     ) -> Result<Self> {
         // assure that objects we just traversed are coming from cache
         // when we read the commit right after.
@@ -93,6 +94,7 @@ impl Commits {
                     author_nbr_of_commits,
                     total_nbr_of_commits,
                     show_email,
+                    format,
                 )
             })
             .take(number_of_authors_to_display)

--- a/src/info/git.rs
+++ b/src/info/git.rs
@@ -1,5 +1,5 @@
 use super::repo::author::Author;
-use crate::cli::{MyRegex, NumberFormat};
+use crate::cli::{MyRegex, ThousandsSeparator};
 use anyhow::Result;
 use git::bstr::BString;
 use git_repository as git;
@@ -35,7 +35,7 @@ impl Commits {
         bot_regex_pattern: &Option<MyRegex>,
         number_of_authors_to_display: usize,
         show_email: bool,
-        number_format: Option<&NumberFormat>,
+        thousands_separator: Option<&ThousandsSeparator>,
     ) -> Result<Self> {
         // assure that objects we just traversed are coming from cache
         // when we read the commit right after.
@@ -94,7 +94,7 @@ impl Commits {
                     author_nbr_of_commits,
                     total_nbr_of_commits,
                     show_email,
-                    number_format,
+                    thousands_separator,
                 )
             })
             .take(number_of_authors_to_display)

--- a/src/info/git.rs
+++ b/src/info/git.rs
@@ -1,5 +1,5 @@
 use super::repo::author::Author;
-use crate::cli::{MyRegex, ThousandsSeparator};
+use crate::cli::{MyRegex, NumberSeparator};
 use anyhow::Result;
 use git::bstr::BString;
 use git_repository as git;
@@ -35,7 +35,7 @@ impl Commits {
         bot_regex_pattern: &Option<MyRegex>,
         number_of_authors_to_display: usize,
         show_email: bool,
-        thousands_separator: Option<&ThousandsSeparator>,
+        number_separator: Option<&NumberSeparator>,
     ) -> Result<Self> {
         // assure that objects we just traversed are coming from cache
         // when we read the commit right after.
@@ -94,7 +94,7 @@ impl Commits {
                     author_nbr_of_commits,
                     total_nbr_of_commits,
                     show_email,
-                    thousands_separator,
+                    number_separator,
                 )
             })
             .take(number_of_authors_to_display)

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -18,7 +18,7 @@ use self::repo::size::SizeInfo;
 use self::repo::url::UrlInfo;
 use self::repo::version::VersionInfo;
 use self::title::Title;
-use crate::cli::{is_truecolor_terminal, Config, Format, MyRegex, When};
+use crate::cli::{is_truecolor_terminal, Config, MyRegex, NumberFormat, When};
 use crate::ui::get_ascii_colors;
 use crate::ui::text_colors::TextColors;
 use anyhow::{Context, Result};
@@ -356,10 +356,10 @@ impl Info {
 
 fn format_number<T: ToFormattedString + std::fmt::Display>(
     number: T,
-    format: Option<&Format>,
+    number_format: Option<&NumberFormat>,
 ) -> String {
-    match format {
-        Some(f) => number.to_formatted_string(&f.get_locale()),
+    match number_format {
+        Some(f) => number.to_formatted_string(&f.get_format()),
         None => number.to_string(),
     }
 }
@@ -424,10 +424,17 @@ mod tests {
 
     #[test]
     fn test_format_number() {
-        assert_eq!(&format_number(1_000_000, Some(&Format::En)), "1,000,000");
         assert_eq!(
-            &format_number(1_000_000, Some(&Format::Fr)),
+            &format_number(1_000_000, Some(&NumberFormat::Commas)),
+            "1,000,000"
+        );
+        assert_eq!(
+            &format_number(1_000_000, Some(&NumberFormat::Spaces)),
             "1\u{202f}000\u{202f}000"
+        );
+        assert_eq!(
+            &format_number(1_000_000, Some(&NumberFormat::Underscores)),
+            "1_000_000"
         );
         assert_eq!(&format_number(1_000_000, None), "1000000");
     }

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -18,7 +18,7 @@ use self::repo::size::SizeInfo;
 use self::repo::url::UrlInfo;
 use self::repo::version::VersionInfo;
 use self::title::Title;
-use crate::cli::{is_truecolor_terminal, Config, MyRegex, NumberFormat, When};
+use crate::cli::{is_truecolor_terminal, Config, MyRegex, ThousandsSeparator, When};
 use crate::ui::get_ascii_colors;
 use crate::ui::text_colors::TextColors;
 use anyhow::{Context, Result};
@@ -356,10 +356,10 @@ impl Info {
 
 fn format_number<T: ToFormattedString + std::fmt::Display>(
     number: T,
-    number_format: Option<&NumberFormat>,
+    thousands_separator: Option<&ThousandsSeparator>,
 ) -> String {
-    match number_format {
-        Some(f) => number.to_formatted_string(&f.get_format()),
+    match thousands_separator {
+        Some(v) => number.to_formatted_string(&v.get_format()),
         None => number.to_string(),
     }
 }
@@ -425,15 +425,15 @@ mod tests {
     #[test]
     fn test_format_number() {
         assert_eq!(
-            &format_number(1_000_000, Some(&NumberFormat::Commas)),
+            &format_number(1_000_000, Some(&ThousandsSeparator::Commas)),
             "1,000,000"
         );
         assert_eq!(
-            &format_number(1_000_000, Some(&NumberFormat::Spaces)),
+            &format_number(1_000_000, Some(&ThousandsSeparator::Spaces)),
             "1\u{202f}000\u{202f}000"
         );
         assert_eq!(
-            &format_number(1_000_000, Some(&NumberFormat::Underscores)),
+            &format_number(1_000_000, Some(&ThousandsSeparator::Underscores)),
             "1_000_000"
         );
         assert_eq!(&format_number(1_000_000, None), "1000000");

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -250,11 +250,11 @@ impl Info {
             &git_repo,
             &repo_url.repo_url,
             manifest.as_ref(),
-            config.number_separator.as_ref(),
+            config.number_separator,
         )?;
         let head = HeadInfo::new(&git_repo)?;
         let version = VersionInfo::new(&git_repo, manifest.as_ref())?;
-        let size = SizeInfo::new(&git_repo, config.number_separator.as_ref());
+        let size = SizeInfo::new(&git_repo, config.number_separator);
         let license = LicenseInfo::new(&repo_path, manifest.as_ref())?;
         let mut commits = Commits::new(
             git_repo,
@@ -262,7 +262,7 @@ impl Info {
             &no_bots,
             config.number_of_authors,
             config.email,
-            config.number_separator.as_ref(),
+            config.number_separator,
         )?;
         let created = CreatedInfo::new(config.iso_time, &commits);
         let languages = LanguagesInfo::new(
@@ -271,17 +271,13 @@ impl Info {
             config.number_of_languages,
             text_colors.info,
         );
-        let dependencies =
-            DependenciesInfo::new(manifest.as_ref(), config.number_separator.as_ref());
+        let dependencies = DependenciesInfo::new(manifest.as_ref(), config.number_separator);
         let authors = AuthorsInfo::new(text_colors.info, &mut commits);
         let last_change = LastChangeInfo::new(config.iso_time, &commits);
-        let contributors = ContributorsInfo::new(
-            &commits,
-            config.number_of_authors,
-            config.number_separator.as_ref(),
-        );
-        let commits = CommitsInfo::new(&commits, config.number_separator.as_ref());
-        let lines_of_code = LocInfo::new(lines_of_code, config.number_separator.as_ref());
+        let contributors =
+            ContributorsInfo::new(&commits, config.number_of_authors, config.number_separator);
+        let commits = CommitsInfo::new(&commits, config.number_separator);
+        let lines_of_code = LocInfo::new(lines_of_code, config.number_separator);
 
         Ok(Self {
             title,
@@ -357,12 +353,9 @@ impl Info {
 
 fn format_number<T: ToFormattedString + std::fmt::Display>(
     number: T,
-    number_separator: Option<&NumberSeparator>,
+    number_separator: NumberSeparator,
 ) -> String {
-    match number_separator {
-        Some(v) => number.to_formatted_string(&v.get_format()),
-        None => number.to_string(),
-    }
+    number.to_formatted_string(&number_separator.get_format())
 }
 
 fn get_style(is_bold: bool, color: DynColors) -> Style {
@@ -426,17 +419,17 @@ mod tests {
     #[test]
     fn test_format_number() {
         assert_eq!(
-            &format_number(1_000_000, Some(&NumberSeparator::Comma)),
+            &format_number(1_000_000, NumberSeparator::Comma),
             "1,000,000"
         );
         assert_eq!(
-            &format_number(1_000_000, Some(&NumberSeparator::Space)),
+            &format_number(1_000_000, NumberSeparator::Space),
             "1\u{202f}000\u{202f}000"
         );
         assert_eq!(
-            &format_number(1_000_000, Some(&NumberSeparator::Underscore)),
+            &format_number(1_000_000, NumberSeparator::Underscore),
             "1_000_000"
         );
-        assert_eq!(&format_number(1_000_000, None), "1000000");
+        assert_eq!(&format_number(1_000_000, NumberSeparator::Plain), "1000000");
     }
 }

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -18,7 +18,7 @@ use self::repo::size::SizeInfo;
 use self::repo::url::UrlInfo;
 use self::repo::version::VersionInfo;
 use self::title::Title;
-use crate::cli::{is_truecolor_terminal, Config, MyRegex, ThousandsSeparator, When};
+use crate::cli::{is_truecolor_terminal, Config, MyRegex, NumberSeparator, When};
 use crate::ui::get_ascii_colors;
 use crate::ui::text_colors::TextColors;
 use anyhow::{Context, Result};
@@ -250,11 +250,11 @@ impl Info {
             &git_repo,
             &repo_url.repo_url,
             manifest.as_ref(),
-            config.format_numbers.as_ref(),
+            config.number_separator.as_ref(),
         )?;
         let head = HeadInfo::new(&git_repo)?;
         let version = VersionInfo::new(&git_repo, manifest.as_ref())?;
-        let size = SizeInfo::new(&git_repo, config.format_numbers.as_ref());
+        let size = SizeInfo::new(&git_repo, config.number_separator.as_ref());
         let license = LicenseInfo::new(&repo_path, manifest.as_ref())?;
         let mut commits = Commits::new(
             git_repo,
@@ -262,7 +262,7 @@ impl Info {
             &no_bots,
             config.number_of_authors,
             config.email,
-            config.format_numbers.as_ref(),
+            config.number_separator.as_ref(),
         )?;
         let created = CreatedInfo::new(config.iso_time, &commits);
         let languages = LanguagesInfo::new(
@@ -271,16 +271,17 @@ impl Info {
             config.number_of_languages,
             text_colors.info,
         );
-        let dependencies = DependenciesInfo::new(manifest.as_ref(), config.format_numbers.as_ref());
+        let dependencies =
+            DependenciesInfo::new(manifest.as_ref(), config.number_separator.as_ref());
         let authors = AuthorsInfo::new(text_colors.info, &mut commits);
         let last_change = LastChangeInfo::new(config.iso_time, &commits);
         let contributors = ContributorsInfo::new(
             &commits,
             config.number_of_authors,
-            config.format_numbers.as_ref(),
+            config.number_separator.as_ref(),
         );
-        let commits = CommitsInfo::new(&commits, config.format_numbers.as_ref());
-        let lines_of_code = LocInfo::new(lines_of_code, config.format_numbers.as_ref());
+        let commits = CommitsInfo::new(&commits, config.number_separator.as_ref());
+        let lines_of_code = LocInfo::new(lines_of_code, config.number_separator.as_ref());
 
         Ok(Self {
             title,
@@ -356,9 +357,9 @@ impl Info {
 
 fn format_number<T: ToFormattedString + std::fmt::Display>(
     number: T,
-    thousands_separator: Option<&ThousandsSeparator>,
+    number_separator: Option<&NumberSeparator>,
 ) -> String {
-    match thousands_separator {
+    match number_separator {
         Some(v) => number.to_formatted_string(&v.get_format()),
         None => number.to_string(),
     }
@@ -425,15 +426,15 @@ mod tests {
     #[test]
     fn test_format_number() {
         assert_eq!(
-            &format_number(1_000_000, Some(&ThousandsSeparator::Commas)),
+            &format_number(1_000_000, Some(&NumberSeparator::Comma)),
             "1,000,000"
         );
         assert_eq!(
-            &format_number(1_000_000, Some(&ThousandsSeparator::Spaces)),
+            &format_number(1_000_000, Some(&NumberSeparator::Space)),
             "1\u{202f}000\u{202f}000"
         );
         assert_eq!(
-            &format_number(1_000_000, Some(&ThousandsSeparator::Underscores)),
+            &format_number(1_000_000, Some(&NumberSeparator::Underscore)),
             "1_000_000"
         );
         assert_eq!(&format_number(1_000_000, None), "1000000");

--- a/src/info/repo/author.rs
+++ b/src/info/repo/author.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::NumberFormat,
+    cli::ThousandsSeparator,
     info::{
         format_number,
         git::Commits,
@@ -28,14 +28,14 @@ impl Author {
         nbr_of_commits: usize,
         total_nbr_of_commits: usize,
         show_email: bool,
-        number_format: Option<&NumberFormat>,
+        thousands_separator: Option<&ThousandsSeparator>,
     ) -> Self {
         let contribution =
             (nbr_of_commits as f32 * 100. / total_nbr_of_commits as f32).round() as usize;
         Self {
             name: name.to_string(),
             email: email.to_string(),
-            nbr_of_commits: format_number(nbr_of_commits, number_format),
+            nbr_of_commits: format_number(nbr_of_commits, thousands_separator),
             contribution,
             show_email,
         }

--- a/src/info/repo/author.rs
+++ b/src/info/repo/author.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::ThousandsSeparator,
+    cli::NumberSeparator,
     info::{
         format_number,
         git::Commits,
@@ -28,14 +28,14 @@ impl Author {
         nbr_of_commits: usize,
         total_nbr_of_commits: usize,
         show_email: bool,
-        thousands_separator: Option<&ThousandsSeparator>,
+        number_separator: Option<&NumberSeparator>,
     ) -> Self {
         let contribution =
             (nbr_of_commits as f32 * 100. / total_nbr_of_commits as f32).round() as usize;
         Self {
             name: name.to_string(),
             email: email.to_string(),
-            nbr_of_commits: format_number(nbr_of_commits, thousands_separator),
+            nbr_of_commits: format_number(nbr_of_commits, number_separator),
             contribution,
             show_email,
         }

--- a/src/info/repo/author.rs
+++ b/src/info/repo/author.rs
@@ -15,10 +15,12 @@ use std::fmt::Write;
 pub struct Author {
     name: String,
     email: String,
-    nbr_of_commits: String,
+    nbr_of_commits: usize,
     contribution: usize,
     #[serde(skip_serializing)]
     show_email: bool,
+    #[serde(skip_serializing)]
+    number_separator: NumberSeparator,
 }
 
 impl Author {
@@ -28,16 +30,17 @@ impl Author {
         nbr_of_commits: usize,
         total_nbr_of_commits: usize,
         show_email: bool,
-        number_separator: Option<&NumberSeparator>,
+        number_separator: NumberSeparator,
     ) -> Self {
         let contribution =
             (nbr_of_commits as f32 * 100. / total_nbr_of_commits as f32).round() as usize;
         Self {
             name: name.to_string(),
             email: email.to_string(),
-            nbr_of_commits: format_number(nbr_of_commits, number_separator),
+            nbr_of_commits,
             contribution,
             show_email,
+            number_separator,
         }
     }
 }
@@ -48,13 +51,18 @@ impl std::fmt::Display for Author {
             write!(
                 f,
                 "{}% {} <{}> {}",
-                self.contribution, self.name, self.email, self.nbr_of_commits
+                self.contribution,
+                self.name,
+                self.email,
+                format_number(self.nbr_of_commits, self.number_separator)
             )
         } else {
             write!(
                 f,
                 "{}% {} {}",
-                self.contribution, self.name, self.nbr_of_commits
+                self.contribution,
+                self.name,
+                format_number(self.nbr_of_commits, self.number_separator)
             )
         }
     }
@@ -123,7 +131,7 @@ mod test {
             1500,
             2000,
             true,
-            None,
+            NumberSeparator::Plain,
         );
 
         assert_eq!(author.to_string(), "75% John Doe <john.doe@email.com> 1500");
@@ -137,7 +145,7 @@ mod test {
             1500,
             2000,
             false,
-            None,
+            NumberSeparator::Plain,
         );
 
         assert_eq!(author.to_string(), "75% John Doe 1500");
@@ -151,7 +159,7 @@ mod test {
             1500,
             2000,
             true,
-            None,
+            NumberSeparator::Plain,
         );
 
         let authors_info = AuthorsInfo {
@@ -170,7 +178,7 @@ mod test {
             1500,
             2000,
             true,
-            None,
+            NumberSeparator::Plain,
         );
 
         let author_2 = Author::new(
@@ -179,7 +187,7 @@ mod test {
             240,
             300,
             false,
-            None,
+            NumberSeparator::Plain,
         );
 
         let authors_info = AuthorsInfo {
@@ -198,7 +206,7 @@ mod test {
             1500,
             2000,
             true,
-            None,
+            NumberSeparator::Plain,
         );
 
         let authors_info = AuthorsInfo {
@@ -222,7 +230,7 @@ mod test {
             1500,
             2000,
             true,
-            None,
+            NumberSeparator::Plain,
         );
 
         let author_2 = Author::new(
@@ -231,7 +239,7 @@ mod test {
             240,
             300,
             false,
-            None,
+            NumberSeparator::Plain,
         );
 
         let authors_info = AuthorsInfo {

--- a/src/info/repo/author.rs
+++ b/src/info/repo/author.rs
@@ -1,6 +1,10 @@
-use crate::info::{
-    git::Commits,
-    info_field::{InfoField, InfoType},
+use crate::{
+    cli::Format,
+    info::{
+        format_number,
+        git::Commits,
+        info_field::{InfoField, InfoType},
+    },
 };
 use git_repository as git;
 use owo_colors::{DynColors, OwoColorize};
@@ -11,7 +15,7 @@ use std::fmt::Write;
 pub struct Author {
     name: String,
     email: String,
-    nbr_of_commits: usize,
+    nbr_of_commits: String,
     contribution: usize,
     #[serde(skip_serializing)]
     show_email: bool,
@@ -24,13 +28,14 @@ impl Author {
         nbr_of_commits: usize,
         total_nbr_of_commits: usize,
         show_email: bool,
+        format: Option<&Format>,
     ) -> Self {
         let contribution =
             (nbr_of_commits as f32 * 100. / total_nbr_of_commits as f32).round() as usize;
         Self {
             name: name.to_string(),
             email: email.to_string(),
-            nbr_of_commits,
+            nbr_of_commits: format_number(nbr_of_commits, format),
             contribution,
             show_email,
         }
@@ -118,6 +123,7 @@ mod test {
             1500,
             2000,
             true,
+            None,
         );
 
         assert_eq!(author.to_string(), "75% John Doe <john.doe@email.com> 1500");
@@ -131,6 +137,7 @@ mod test {
             1500,
             2000,
             false,
+            None,
         );
 
         assert_eq!(author.to_string(), "75% John Doe 1500");
@@ -144,6 +151,7 @@ mod test {
             1500,
             2000,
             true,
+            None,
         );
 
         let authors_info = AuthorsInfo {
@@ -162,6 +170,7 @@ mod test {
             1500,
             2000,
             true,
+            None,
         );
 
         let author_2 = Author::new(
@@ -170,6 +179,7 @@ mod test {
             240,
             300,
             false,
+            None,
         );
 
         let authors_info = AuthorsInfo {
@@ -188,6 +198,7 @@ mod test {
             1500,
             2000,
             true,
+            None,
         );
 
         let authors_info = AuthorsInfo {
@@ -211,6 +222,7 @@ mod test {
             1500,
             2000,
             true,
+            None,
         );
 
         let author_2 = Author::new(
@@ -219,6 +231,7 @@ mod test {
             240,
             300,
             false,
+            None,
         );
 
         let authors_info = AuthorsInfo {

--- a/src/info/repo/author.rs
+++ b/src/info/repo/author.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::Format,
+    cli::NumberFormat,
     info::{
         format_number,
         git::Commits,
@@ -28,14 +28,14 @@ impl Author {
         nbr_of_commits: usize,
         total_nbr_of_commits: usize,
         show_email: bool,
-        format: Option<&Format>,
+        number_format: Option<&NumberFormat>,
     ) -> Self {
         let contribution =
             (nbr_of_commits as f32 * 100. / total_nbr_of_commits as f32).round() as usize;
         Self {
             name: name.to_string(),
             email: email.to_string(),
-            nbr_of_commits: format_number(nbr_of_commits, format),
+            nbr_of_commits: format_number(nbr_of_commits, number_format),
             contribution,
             show_email,
         }

--- a/src/info/repo/commits.rs
+++ b/src/info/repo/commits.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::NumberFormat,
+    cli::ThousandsSeparator,
     info::{
         format_number,
         git::Commits,
@@ -12,16 +12,19 @@ pub struct CommitsInfo {
 }
 
 impl CommitsInfo {
-    pub fn new(commits: &Commits, number_format: Option<&NumberFormat>) -> Self {
-        let number_of_commits = number_of_commits(commits, number_format);
+    pub fn new(commits: &Commits, thousands_separator: Option<&ThousandsSeparator>) -> Self {
+        let number_of_commits = number_of_commits(commits, thousands_separator);
         Self { number_of_commits }
     }
 }
 
-fn number_of_commits(commits: &Commits, number_format: Option<&NumberFormat>) -> String {
+fn number_of_commits(
+    commits: &Commits,
+    thousands_separator: Option<&ThousandsSeparator>,
+) -> String {
     format!(
         "{}{}",
-        format_number(commits.num_commits, number_format),
+        format_number(commits.num_commits, thousands_separator),
         commits.is_shallow.then(|| " (shallow)").unwrap_or_default()
     )
 }

--- a/src/info/repo/commits.rs
+++ b/src/info/repo/commits.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::Format,
+    cli::NumberFormat,
     info::{
         format_number,
         git::Commits,
@@ -12,16 +12,16 @@ pub struct CommitsInfo {
 }
 
 impl CommitsInfo {
-    pub fn new(commits: &Commits, format: Option<&Format>) -> Self {
-        let number_of_commits = number_of_commits(commits, format);
+    pub fn new(commits: &Commits, number_format: Option<&NumberFormat>) -> Self {
+        let number_of_commits = number_of_commits(commits, number_format);
         Self { number_of_commits }
     }
 }
 
-fn number_of_commits(commits: &Commits, format: Option<&Format>) -> String {
+fn number_of_commits(commits: &Commits, number_format: Option<&NumberFormat>) -> String {
     format!(
         "{}{}",
-        format_number(commits.num_commits, format),
+        format_number(commits.num_commits, number_format),
         commits.is_shallow.then(|| " (shallow)").unwrap_or_default()
     )
 }

--- a/src/info/repo/commits.rs
+++ b/src/info/repo/commits.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::ThousandsSeparator,
+    cli::NumberSeparator,
     info::{
         format_number,
         git::Commits,
@@ -12,19 +12,16 @@ pub struct CommitsInfo {
 }
 
 impl CommitsInfo {
-    pub fn new(commits: &Commits, thousands_separator: Option<&ThousandsSeparator>) -> Self {
-        let number_of_commits = number_of_commits(commits, thousands_separator);
+    pub fn new(commits: &Commits, number_separator: Option<&NumberSeparator>) -> Self {
+        let number_of_commits = number_of_commits(commits, number_separator);
         Self { number_of_commits }
     }
 }
 
-fn number_of_commits(
-    commits: &Commits,
-    thousands_separator: Option<&ThousandsSeparator>,
-) -> String {
+fn number_of_commits(commits: &Commits, number_separator: Option<&NumberSeparator>) -> String {
     format!(
         "{}{}",
-        format_number(commits.num_commits, thousands_separator),
+        format_number(commits.num_commits, number_separator),
         commits.is_shallow.then(|| " (shallow)").unwrap_or_default()
     )
 }

--- a/src/info/repo/commits.rs
+++ b/src/info/repo/commits.rs
@@ -8,28 +8,30 @@ use crate::{
 };
 
 pub struct CommitsInfo {
-    pub number_of_commits: String,
+    pub number_of_commits: usize,
+    is_shallow: bool,
+    number_separator: NumberSeparator,
 }
 
 impl CommitsInfo {
-    pub fn new(commits: &Commits, number_separator: Option<&NumberSeparator>) -> Self {
-        let number_of_commits = number_of_commits(commits, number_separator);
-        Self { number_of_commits }
+    pub fn new(commits: &Commits, number_separator: NumberSeparator) -> Self {
+        Self {
+            number_of_commits: commits.num_commits,
+            is_shallow: commits.is_shallow,
+            number_separator,
+        }
     }
 }
 
-fn number_of_commits(commits: &Commits, number_separator: Option<&NumberSeparator>) -> String {
-    format!(
-        "{}{}",
-        format_number(commits.num_commits, number_separator),
-        commits.is_shallow.then(|| " (shallow)").unwrap_or_default()
-    )
-}
 impl InfoField for CommitsInfo {
     const TYPE: InfoType = InfoType::Commits;
 
     fn value(&self) -> String {
-        self.number_of_commits.to_string()
+        format!(
+            "{}{}",
+            format_number(self.number_of_commits, self.number_separator),
+            self.is_shallow.then(|| " (shallow)").unwrap_or_default()
+        )
     }
 
     fn title(&self) -> String {
@@ -44,7 +46,9 @@ mod test {
     #[test]
     fn test_display_commits_info() {
         let commits_info = CommitsInfo {
-            number_of_commits: "3".to_string(),
+            number_of_commits: 3,
+            is_shallow: false,
+            number_separator: NumberSeparator::Plain,
         };
 
         assert_eq!(commits_info.value(), "3".to_string());
@@ -52,20 +56,12 @@ mod test {
 
     #[test]
     fn test_display_commits_info_shallow() {
-        use crate::info::git::Commits;
-        use git_repository::actor::Time;
-
-        let timestamp = Time::now_utc();
-        let commits = Commits {
-            authors: vec![],
-            total_num_authors: 0,
-            num_commits: 2,
+        let commits_info = CommitsInfo {
+            number_of_commits: 2,
             is_shallow: true,
-            time_of_most_recent_commit: timestamp,
-            time_of_first_commit: timestamp,
+            number_separator: NumberSeparator::Plain,
         };
 
-        let info = CommitsInfo::new(&commits, None);
-        assert_eq!(info.value(), "2 (shallow)".to_string());
+        assert_eq!(commits_info.value(), "2 (shallow)".to_string());
     }
 }

--- a/src/info/repo/commits.rs
+++ b/src/info/repo/commits.rs
@@ -1,6 +1,10 @@
-use crate::info::{
-    git::Commits,
-    info_field::{InfoField, InfoType},
+use crate::{
+    cli::Format,
+    info::{
+        format_number,
+        git::Commits,
+        info_field::{InfoField, InfoType},
+    },
 };
 
 pub struct CommitsInfo {
@@ -8,16 +12,16 @@ pub struct CommitsInfo {
 }
 
 impl CommitsInfo {
-    pub fn new(commits: &Commits) -> Self {
-        let number_of_commits = number_of_commits(commits);
+    pub fn new(commits: &Commits, format: Option<&Format>) -> Self {
+        let number_of_commits = number_of_commits(commits, format);
         Self { number_of_commits }
     }
 }
 
-fn number_of_commits(commits: &Commits) -> String {
+fn number_of_commits(commits: &Commits, format: Option<&Format>) -> String {
     format!(
         "{}{}",
-        commits.num_commits,
+        format_number(commits.num_commits, format),
         commits.is_shallow.then(|| " (shallow)").unwrap_or_default()
     )
 }
@@ -61,7 +65,7 @@ mod test {
             time_of_first_commit: timestamp,
         };
 
-        let info = CommitsInfo::new(&commits);
+        let info = CommitsInfo::new(&commits, None);
         assert_eq!(info.value(), "2 (shallow)".to_string());
     }
 }

--- a/src/info/repo/contributors.rs
+++ b/src/info/repo/contributors.rs
@@ -1,35 +1,49 @@
-use crate::info::{
-    git::Commits,
-    info_field::{InfoField, InfoType},
+use crate::{
+    cli::Format,
+    info::{
+        format_number,
+        git::Commits,
+        info_field::{InfoField, InfoType},
+    },
 };
 pub struct ContributorsInfo {
-    pub number_of_contributors: usize,
-    pub number_of_authors_to_display: usize,
+    pub number_of_contributors: String,
 }
 
 impl ContributorsInfo {
-    pub fn new(commits: &Commits, number_of_authors_to_display: usize) -> Self {
-        let contributors = number_of_contributors(commits);
-        Self {
-            number_of_contributors: contributors,
+    pub fn new(
+        commits: &Commits,
+        number_of_authors_to_display: usize,
+        format: Option<&Format>,
+    ) -> Self {
+        let number_of_contributors = number_of_contributors(
+            commits.total_num_authors,
             number_of_authors_to_display,
+            format,
+        );
+        Self {
+            number_of_contributors,
         }
     }
 }
 
-fn number_of_contributors(commits: &Commits) -> usize {
-    commits.total_num_authors
+fn number_of_contributors(
+    total_num_authors: usize,
+    number_of_authors_to_display: usize,
+    format: Option<&Format>,
+) -> String {
+    if total_num_authors > number_of_authors_to_display {
+        format_number(total_num_authors, format)
+    } else {
+        "".to_string()
+    }
 }
 
 impl InfoField for ContributorsInfo {
     const TYPE: InfoType = InfoType::Contributors;
 
     fn value(&self) -> String {
-        if self.number_of_contributors > self.number_of_authors_to_display {
-            self.number_of_contributors.to_string()
-        } else {
-            "".to_string()
-        }
+        self.number_of_contributors.clone()
     }
 
     fn title(&self) -> String {
@@ -40,12 +54,11 @@ impl InfoField for ContributorsInfo {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::info::git::Commits;
+    use git_repository::actor::Time;
 
     #[test]
     fn test_display_contributors_info() {
-        use crate::info::git::Commits;
-        use git_repository::actor::Time;
-
         let timestamp = Time::now_utc();
         let commits = Commits {
             authors: vec![],
@@ -56,17 +69,24 @@ mod test {
             time_of_first_commit: timestamp,
         };
 
-        let contributors_info = ContributorsInfo::new(&commits, 2);
+        let contributors_info = ContributorsInfo::new(&commits, 2, None);
         assert_eq!(contributors_info.value(), "12".to_string());
         assert_eq!(contributors_info.title(), "Contributors".to_string());
     }
 
     #[test]
     fn test_display_contributors_less_than_authors_to_display() {
-        let contributors_info = ContributorsInfo {
-            number_of_contributors: 1,
-            number_of_authors_to_display: 3,
+        let timestamp = Time::now_utc();
+        let commits = Commits {
+            authors: vec![],
+            total_num_authors: 1,
+            num_commits: 2,
+            is_shallow: true,
+            time_of_most_recent_commit: timestamp,
+            time_of_first_commit: timestamp,
         };
+
+        let contributors_info = ContributorsInfo::new(&commits, 2, None);
 
         assert!(contributors_info.value().is_empty());
     }

--- a/src/info/repo/contributors.rs
+++ b/src/info/repo/contributors.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::Format,
+    cli::NumberFormat,
     info::{
         format_number,
         git::Commits,
@@ -14,12 +14,12 @@ impl ContributorsInfo {
     pub fn new(
         commits: &Commits,
         number_of_authors_to_display: usize,
-        format: Option<&Format>,
+        number_format: Option<&NumberFormat>,
     ) -> Self {
         let number_of_contributors = number_of_contributors(
             commits.total_num_authors,
             number_of_authors_to_display,
-            format,
+            number_format,
         );
         Self {
             number_of_contributors,
@@ -30,10 +30,10 @@ impl ContributorsInfo {
 fn number_of_contributors(
     total_num_authors: usize,
     number_of_authors_to_display: usize,
-    format: Option<&Format>,
+    number_format: Option<&NumberFormat>,
 ) -> String {
     if total_num_authors > number_of_authors_to_display {
-        format_number(total_num_authors, format)
+        format_number(total_num_authors, number_format)
     } else {
         "".to_string()
     }

--- a/src/info/repo/contributors.rs
+++ b/src/info/repo/contributors.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::NumberFormat,
+    cli::ThousandsSeparator,
     info::{
         format_number,
         git::Commits,
@@ -14,12 +14,12 @@ impl ContributorsInfo {
     pub fn new(
         commits: &Commits,
         number_of_authors_to_display: usize,
-        number_format: Option<&NumberFormat>,
+        thousands_separator: Option<&ThousandsSeparator>,
     ) -> Self {
         let number_of_contributors = number_of_contributors(
             commits.total_num_authors,
             number_of_authors_to_display,
-            number_format,
+            thousands_separator,
         );
         Self {
             number_of_contributors,
@@ -30,10 +30,10 @@ impl ContributorsInfo {
 fn number_of_contributors(
     total_num_authors: usize,
     number_of_authors_to_display: usize,
-    number_format: Option<&NumberFormat>,
+    thousands_separator: Option<&ThousandsSeparator>,
 ) -> String {
     if total_num_authors > number_of_authors_to_display {
-        format_number(total_num_authors, number_format)
+        format_number(total_num_authors, thousands_separator)
     } else {
         "".to_string()
     }

--- a/src/info/repo/contributors.rs
+++ b/src/info/repo/contributors.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::ThousandsSeparator,
+    cli::NumberSeparator,
     info::{
         format_number,
         git::Commits,
@@ -14,12 +14,12 @@ impl ContributorsInfo {
     pub fn new(
         commits: &Commits,
         number_of_authors_to_display: usize,
-        thousands_separator: Option<&ThousandsSeparator>,
+        number_separator: Option<&NumberSeparator>,
     ) -> Self {
         let number_of_contributors = number_of_contributors(
             commits.total_num_authors,
             number_of_authors_to_display,
-            thousands_separator,
+            number_separator,
         );
         Self {
             number_of_contributors,
@@ -30,10 +30,10 @@ impl ContributorsInfo {
 fn number_of_contributors(
     total_num_authors: usize,
     number_of_authors_to_display: usize,
-    thousands_separator: Option<&ThousandsSeparator>,
+    number_separator: Option<&NumberSeparator>,
 ) -> String {
     if total_num_authors > number_of_authors_to_display {
-        format_number(total_num_authors, thousands_separator)
+        format_number(total_num_authors, number_separator)
     } else {
         "".to_string()
     }

--- a/src/info/repo/dependencies.rs
+++ b/src/info/repo/dependencies.rs
@@ -1,4 +1,10 @@
-use crate::info::info_field::{InfoField, InfoType};
+use crate::{
+    cli::Format,
+    info::{
+        format_number,
+        info_field::{InfoField, InfoType},
+    },
+};
 use onefetch_manifest::Manifest;
 
 pub struct DependenciesInfo {
@@ -6,11 +12,16 @@ pub struct DependenciesInfo {
 }
 
 impl DependenciesInfo {
-    pub fn new(manifest: Option<&Manifest>) -> Self {
+    pub fn new(manifest: Option<&Manifest>, format: Option<&Format>) -> Self {
         let dependencies = manifest
             .and_then(|m| {
-                (m.number_of_dependencies != 0)
-                    .then(|| format!("{} ({})", m.number_of_dependencies, m.manifest_type))
+                (m.number_of_dependencies != 0).then(|| {
+                    format!(
+                        "{} ({})",
+                        format_number(m.number_of_dependencies, format),
+                        m.manifest_type
+                    )
+                })
             })
             .unwrap_or_default();
 
@@ -37,14 +48,17 @@ mod test {
 
     #[test]
     fn should_display_license() {
-        let dependencies_info = DependenciesInfo::new(Some(&Manifest {
-            manifest_type: ManifestType::Cargo,
-            name: String::new(),
-            description: None,
-            number_of_dependencies: 21,
-            version: String::new(),
-            license: None,
-        }));
+        let dependencies_info = DependenciesInfo::new(
+            Some(&Manifest {
+                manifest_type: ManifestType::Cargo,
+                name: String::new(),
+                description: None,
+                number_of_dependencies: 21,
+                version: String::new(),
+                license: None,
+            }),
+            None,
+        );
 
         assert_eq!(dependencies_info.value(), "21 (Cargo)".to_string());
     }

--- a/src/info/repo/dependencies.rs
+++ b/src/info/repo/dependencies.rs
@@ -12,7 +12,7 @@ pub struct DependenciesInfo {
 }
 
 impl DependenciesInfo {
-    pub fn new(manifest: Option<&Manifest>, number_separator: Option<&NumberSeparator>) -> Self {
+    pub fn new(manifest: Option<&Manifest>, number_separator: NumberSeparator) -> Self {
         let dependencies = manifest
             .and_then(|m| {
                 (m.number_of_dependencies != 0).then(|| {
@@ -57,7 +57,7 @@ mod test {
                 version: String::new(),
                 license: None,
             }),
-            None,
+            NumberSeparator::Plain,
         );
 
         assert_eq!(dependencies_info.value(), "21 (Cargo)".to_string());

--- a/src/info/repo/dependencies.rs
+++ b/src/info/repo/dependencies.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::ThousandsSeparator,
+    cli::NumberSeparator,
     info::{
         format_number,
         info_field::{InfoField, InfoType},
@@ -12,16 +12,13 @@ pub struct DependenciesInfo {
 }
 
 impl DependenciesInfo {
-    pub fn new(
-        manifest: Option<&Manifest>,
-        thousands_separator: Option<&ThousandsSeparator>,
-    ) -> Self {
+    pub fn new(manifest: Option<&Manifest>, number_separator: Option<&NumberSeparator>) -> Self {
         let dependencies = manifest
             .and_then(|m| {
                 (m.number_of_dependencies != 0).then(|| {
                     format!(
                         "{} ({})",
-                        format_number(m.number_of_dependencies, thousands_separator),
+                        format_number(m.number_of_dependencies, number_separator),
                         m.manifest_type
                     )
                 })

--- a/src/info/repo/dependencies.rs
+++ b/src/info/repo/dependencies.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::Format,
+    cli::NumberFormat,
     info::{
         format_number,
         info_field::{InfoField, InfoType},
@@ -12,13 +12,13 @@ pub struct DependenciesInfo {
 }
 
 impl DependenciesInfo {
-    pub fn new(manifest: Option<&Manifest>, format: Option<&Format>) -> Self {
+    pub fn new(manifest: Option<&Manifest>, number_format: Option<&NumberFormat>) -> Self {
         let dependencies = manifest
             .and_then(|m| {
                 (m.number_of_dependencies != 0).then(|| {
                     format!(
                         "{} ({})",
-                        format_number(m.number_of_dependencies, format),
+                        format_number(m.number_of_dependencies, number_format),
                         m.manifest_type
                     )
                 })

--- a/src/info/repo/dependencies.rs
+++ b/src/info/repo/dependencies.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::NumberFormat,
+    cli::ThousandsSeparator,
     info::{
         format_number,
         info_field::{InfoField, InfoType},
@@ -12,13 +12,16 @@ pub struct DependenciesInfo {
 }
 
 impl DependenciesInfo {
-    pub fn new(manifest: Option<&Manifest>, number_format: Option<&NumberFormat>) -> Self {
+    pub fn new(
+        manifest: Option<&Manifest>,
+        thousands_separator: Option<&ThousandsSeparator>,
+    ) -> Self {
         let dependencies = manifest
             .and_then(|m| {
                 (m.number_of_dependencies != 0).then(|| {
                     format!(
                         "{} ({})",
-                        format_number(m.number_of_dependencies, number_format),
+                        format_number(m.number_of_dependencies, thousands_separator),
                         m.manifest_type
                     )
                 })

--- a/src/info/repo/loc.rs
+++ b/src/info/repo/loc.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::Format,
+    cli::NumberFormat,
     info::{
         format_number,
         info_field::{InfoField, InfoType},
@@ -11,9 +11,9 @@ pub struct LocInfo {
 }
 
 impl LocInfo {
-    pub fn new(lines_of_code: usize, format: Option<&Format>) -> Self {
+    pub fn new(lines_of_code: usize, number_format: Option<&NumberFormat>) -> Self {
         Self {
-            lines_of_code: format_number(lines_of_code, format),
+            lines_of_code: format_number(lines_of_code, number_format),
         }
     }
 }

--- a/src/info/repo/loc.rs
+++ b/src/info/repo/loc.rs
@@ -7,13 +7,15 @@ use crate::{
 };
 
 pub struct LocInfo {
-    pub lines_of_code: String,
+    pub lines_of_code: usize,
+    number_separator: NumberSeparator,
 }
 
 impl LocInfo {
-    pub fn new(lines_of_code: usize, number_separator: Option<&NumberSeparator>) -> Self {
+    pub fn new(lines_of_code: usize, number_separator: NumberSeparator) -> Self {
         Self {
-            lines_of_code: format_number(lines_of_code, number_separator),
+            lines_of_code,
+            number_separator,
         }
     }
 }
@@ -22,7 +24,7 @@ impl InfoField for LocInfo {
     const TYPE: InfoType = InfoType::LinesOfCode;
 
     fn value(&self) -> String {
-        self.lines_of_code.clone()
+        format_number(self.lines_of_code, self.number_separator)
     }
 
     fn title(&self) -> String {
@@ -36,7 +38,11 @@ mod test {
 
     #[test]
     fn test_display_loc_info() {
-        let loc_info = LocInfo::new(1235, None);
+        let loc_info = LocInfo {
+            lines_of_code: 1235,
+            number_separator: NumberSeparator::Plain,
+        };
+
         assert_eq!(loc_info.value(), "1235".to_string());
     }
 }

--- a/src/info/repo/loc.rs
+++ b/src/info/repo/loc.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::ThousandsSeparator,
+    cli::NumberSeparator,
     info::{
         format_number,
         info_field::{InfoField, InfoType},
@@ -11,9 +11,9 @@ pub struct LocInfo {
 }
 
 impl LocInfo {
-    pub fn new(lines_of_code: usize, thousands_separator: Option<&ThousandsSeparator>) -> Self {
+    pub fn new(lines_of_code: usize, number_separator: Option<&NumberSeparator>) -> Self {
         Self {
-            lines_of_code: format_number(lines_of_code, thousands_separator),
+            lines_of_code: format_number(lines_of_code, number_separator),
         }
     }
 }

--- a/src/info/repo/loc.rs
+++ b/src/info/repo/loc.rs
@@ -1,14 +1,28 @@
-use crate::info::info_field::{InfoField, InfoType};
+use crate::{
+    cli::Format,
+    info::{
+        format_number,
+        info_field::{InfoField, InfoType},
+    },
+};
 
 pub struct LocInfo {
-    pub lines_of_code: usize,
+    pub lines_of_code: String,
+}
+
+impl LocInfo {
+    pub fn new(lines_of_code: usize, format: Option<&Format>) -> Self {
+        Self {
+            lines_of_code: format_number(lines_of_code, format),
+        }
+    }
 }
 
 impl InfoField for LocInfo {
     const TYPE: InfoType = InfoType::LinesOfCode;
 
     fn value(&self) -> String {
-        self.lines_of_code.to_string()
+        self.lines_of_code.clone()
     }
 
     fn title(&self) -> String {
@@ -22,10 +36,7 @@ mod test {
 
     #[test]
     fn test_display_loc_info() {
-        let loc_info = LocInfo {
-            lines_of_code: 1235,
-        };
-
+        let loc_info = LocInfo::new(1235, None);
         assert_eq!(loc_info.value(), "1235".to_string());
     }
 }

--- a/src/info/repo/loc.rs
+++ b/src/info/repo/loc.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::NumberFormat,
+    cli::ThousandsSeparator,
     info::{
         format_number,
         info_field::{InfoField, InfoType},
@@ -11,9 +11,9 @@ pub struct LocInfo {
 }
 
 impl LocInfo {
-    pub fn new(lines_of_code: usize, number_format: Option<&NumberFormat>) -> Self {
+    pub fn new(lines_of_code: usize, thousands_separator: Option<&ThousandsSeparator>) -> Self {
         Self {
-            lines_of_code: format_number(lines_of_code, number_format),
+            lines_of_code: format_number(lines_of_code, thousands_separator),
         }
     }
 }

--- a/src/info/repo/project.rs
+++ b/src/info/repo/project.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::NumberFormat,
+    cli::ThousandsSeparator,
     info::{
         format_number,
         info_field::{InfoField, InfoType},
@@ -23,11 +23,11 @@ impl ProjectInfo {
         repo: &Repository,
         repo_url: &str,
         manifest: Option<&Manifest>,
-        number_format: Option<&NumberFormat>,
+        thousands_separator: Option<&ThousandsSeparator>,
     ) -> Result<Self> {
         let repo_name = get_repo_name(repo_url, manifest)?;
-        let number_of_branches = format_number(get_number_of_branches(repo)?, number_format);
-        let number_of_tags = format_number(get_number_of_tags(repo)?, number_format);
+        let number_of_branches = format_number(get_number_of_branches(repo)?, thousands_separator);
+        let number_of_tags = format_number(get_number_of_tags(repo)?, thousands_separator);
         Ok(Self {
             repo_name,
             number_of_branches,

--- a/src/info/repo/project.rs
+++ b/src/info/repo/project.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::Format,
+    cli::NumberFormat,
     info::{
         format_number,
         info_field::{InfoField, InfoType},
@@ -23,11 +23,11 @@ impl ProjectInfo {
         repo: &Repository,
         repo_url: &str,
         manifest: Option<&Manifest>,
-        format: Option<&Format>,
+        number_format: Option<&NumberFormat>,
     ) -> Result<Self> {
         let repo_name = get_repo_name(repo_url, manifest)?;
-        let number_of_branches = format_number(get_number_of_branches(repo)?, format);
-        let number_of_tags = format_number(get_number_of_tags(repo)?, format);
+        let number_of_branches = format_number(get_number_of_branches(repo)?, number_format);
+        let number_of_tags = format_number(get_number_of_tags(repo)?, number_format);
         Ok(Self {
             repo_name,
             number_of_branches,

--- a/src/info/repo/project.rs
+++ b/src/info/repo/project.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::ThousandsSeparator,
+    cli::NumberSeparator,
     info::{
         format_number,
         info_field::{InfoField, InfoType},
@@ -23,11 +23,11 @@ impl ProjectInfo {
         repo: &Repository,
         repo_url: &str,
         manifest: Option<&Manifest>,
-        thousands_separator: Option<&ThousandsSeparator>,
+        number_separator: Option<&NumberSeparator>,
     ) -> Result<Self> {
         let repo_name = get_repo_name(repo_url, manifest)?;
-        let number_of_branches = format_number(get_number_of_branches(repo)?, thousands_separator);
-        let number_of_tags = format_number(get_number_of_tags(repo)?, thousands_separator);
+        let number_of_branches = format_number(get_number_of_branches(repo)?, number_separator);
+        let number_of_tags = format_number(get_number_of_tags(repo)?, number_separator);
         Ok(Self {
             repo_name,
             number_of_branches,

--- a/src/info/repo/project.rs
+++ b/src/info/repo/project.rs
@@ -16,6 +16,7 @@ pub struct ProjectInfo {
     pub repo_name: String,
     pub number_of_branches: usize,
     pub number_of_tags: usize,
+    #[serde(skip_serializing)]
     number_separator: NumberSeparator,
 }
 

--- a/src/info/repo/size.rs
+++ b/src/info/repo/size.rs
@@ -1,18 +1,24 @@
-use crate::info::info_field::{InfoField, InfoType};
+use crate::{
+    cli::Format,
+    info::{
+        format_number,
+        info_field::{InfoField, InfoType},
+    },
+};
 use byte_unit::Byte;
 use git_repository::Repository;
 
 pub struct SizeInfo {
     pub repo_size: String,
-    pub file_count: u64,
+    pub file_count: String,
 }
 
 impl SizeInfo {
-    pub fn new(repo: &Repository) -> Self {
+    pub fn new(repo: &Repository, format: Option<&Format>) -> Self {
         let (repo_size, file_count) = get_repo_size(repo);
         Self {
             repo_size,
-            file_count,
+            file_count: format_number(file_count, format),
         }
     }
 }
@@ -36,9 +42,9 @@ fn bytes_to_human_readable(bytes: u128) -> String {
 
 impl std::fmt::Display for SizeInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self.file_count {
-            0 => write!(f, "{}", &self.repo_size),
-            1 => write!(f, "{} (1 file)", self.repo_size),
+        match self.file_count.as_str() {
+            "0" => write!(f, "{}", &self.repo_size),
+            "1" => write!(f, "{} (1 file)", self.repo_size),
             _ => {
                 write!(f, "{} ({} files)", self.repo_size, self.file_count)
             }
@@ -65,7 +71,7 @@ mod test {
     fn test_display_size_info() {
         let size_info = SizeInfo {
             repo_size: "2.40 MiB".to_string(),
-            file_count: 123,
+            file_count: "123".to_string(),
         };
 
         assert_eq!(size_info.value(), "2.40 MiB (123 files)".to_string());
@@ -75,7 +81,7 @@ mod test {
     fn test_display_size_info_no_files() {
         let size_info = SizeInfo {
             repo_size: "2.40 MiB".to_string(),
-            file_count: 0,
+            file_count: "0".to_string(),
         };
 
         assert_eq!(size_info.value(), "2.40 MiB".to_string());
@@ -85,7 +91,7 @@ mod test {
     fn test_display_size_info_one_files() {
         let size_info = SizeInfo {
             repo_size: "2.40 MiB".to_string(),
-            file_count: 1,
+            file_count: "1".to_string(),
         };
 
         assert_eq!(size_info.value(), "2.40 MiB (1 file)".to_string());

--- a/src/info/repo/size.rs
+++ b/src/info/repo/size.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::NumberFormat,
+    cli::ThousandsSeparator,
     info::{
         format_number,
         info_field::{InfoField, InfoType},
@@ -14,11 +14,11 @@ pub struct SizeInfo {
 }
 
 impl SizeInfo {
-    pub fn new(repo: &Repository, number_format: Option<&NumberFormat>) -> Self {
+    pub fn new(repo: &Repository, thousands_separator: Option<&ThousandsSeparator>) -> Self {
         let (repo_size, file_count) = get_repo_size(repo);
         Self {
             repo_size,
-            file_count: format_number(file_count, number_format),
+            file_count: format_number(file_count, thousands_separator),
         }
     }
 }

--- a/src/info/repo/size.rs
+++ b/src/info/repo/size.rs
@@ -10,15 +10,17 @@ use git_repository::Repository;
 
 pub struct SizeInfo {
     pub repo_size: String,
-    pub file_count: String,
+    pub file_count: u64,
+    number_separator: NumberSeparator,
 }
 
 impl SizeInfo {
-    pub fn new(repo: &Repository, number_separator: Option<&NumberSeparator>) -> Self {
+    pub fn new(repo: &Repository, number_separator: NumberSeparator) -> Self {
         let (repo_size, file_count) = get_repo_size(repo);
         Self {
             repo_size,
-            file_count: format_number(file_count, number_separator),
+            file_count,
+            number_separator,
         }
     }
 }
@@ -42,11 +44,16 @@ fn bytes_to_human_readable(bytes: u128) -> String {
 
 impl std::fmt::Display for SizeInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self.file_count.as_str() {
-            "0" => write!(f, "{}", &self.repo_size),
-            "1" => write!(f, "{} (1 file)", self.repo_size),
+        match self.file_count {
+            0 => write!(f, "{}", &self.repo_size),
+            1 => write!(f, "{} (1 file)", self.repo_size),
             _ => {
-                write!(f, "{} ({} files)", self.repo_size, self.file_count)
+                write!(
+                    f,
+                    "{} ({} files)",
+                    self.repo_size,
+                    format_number(self.file_count, self.number_separator)
+                )
             }
         }
     }
@@ -71,7 +78,8 @@ mod test {
     fn test_display_size_info() {
         let size_info = SizeInfo {
             repo_size: "2.40 MiB".to_string(),
-            file_count: "123".to_string(),
+            file_count: 123,
+            number_separator: NumberSeparator::Plain,
         };
 
         assert_eq!(size_info.value(), "2.40 MiB (123 files)".to_string());
@@ -81,7 +89,8 @@ mod test {
     fn test_display_size_info_no_files() {
         let size_info = SizeInfo {
             repo_size: "2.40 MiB".to_string(),
-            file_count: "0".to_string(),
+            file_count: 0,
+            number_separator: NumberSeparator::Plain,
         };
 
         assert_eq!(size_info.value(), "2.40 MiB".to_string());
@@ -91,7 +100,8 @@ mod test {
     fn test_display_size_info_one_files() {
         let size_info = SizeInfo {
             repo_size: "2.40 MiB".to_string(),
-            file_count: "1".to_string(),
+            file_count: 1,
+            number_separator: NumberSeparator::Plain,
         };
 
         assert_eq!(size_info.value(), "2.40 MiB (1 file)".to_string());

--- a/src/info/repo/size.rs
+++ b/src/info/repo/size.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::ThousandsSeparator,
+    cli::NumberSeparator,
     info::{
         format_number,
         info_field::{InfoField, InfoType},
@@ -14,11 +14,11 @@ pub struct SizeInfo {
 }
 
 impl SizeInfo {
-    pub fn new(repo: &Repository, thousands_separator: Option<&ThousandsSeparator>) -> Self {
+    pub fn new(repo: &Repository, number_separator: Option<&NumberSeparator>) -> Self {
         let (repo_size, file_count) = get_repo_size(repo);
         Self {
             repo_size,
-            file_count: format_number(file_count, thousands_separator),
+            file_count: format_number(file_count, number_separator),
         }
     }
 }

--- a/src/info/repo/size.rs
+++ b/src/info/repo/size.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::Format,
+    cli::NumberFormat,
     info::{
         format_number,
         info_field::{InfoField, InfoType},
@@ -14,11 +14,11 @@ pub struct SizeInfo {
 }
 
 impl SizeInfo {
-    pub fn new(repo: &Repository, format: Option<&Format>) -> Self {
+    pub fn new(repo: &Repository, number_format: Option<&NumberFormat>) -> Self {
         let (repo_size, file_count) = get_repo_size(repo);
         Self {
             repo_size,
-            file_count: format_number(file_count, format),
+            file_count: format_number(file_count, number_format),
         }
     }
 }

--- a/tests/snapshots/repo__repo.snap
+++ b/tests/snapshots/repo__repo.snap
@@ -7,8 +7,8 @@ expression: info
   "gitVersion": "git version",
   "project": {
     "repo_name": "repo",
-    "number_of_branches": 0,
-    "number_of_tags": 1
+    "number_of_branches": "0",
+    "number_of_tags": "1"
   },
   "description": "Amazing tool",
   "head": {
@@ -30,27 +30,27 @@ expression: info
     {
       "name": "Author Four",
       "email": "author4@example.org",
-      "nbr_of_commits": 1,
+      "nbr_of_commits": "1",
       "contribution": 25
     },
     {
       "name": "Author One",
       "email": "author1@example.org",
-      "nbr_of_commits": 1,
+      "nbr_of_commits": "1",
       "contribution": 25
     },
     {
       "name": "Author Three",
       "email": "author3@example.org",
-      "nbr_of_commits": 1,
+      "nbr_of_commits": "1",
       "contribution": 25
     }
   ],
   "lastChange": "22 years ago",
-  "contributors": 4,
+  "contributors": "4",
   "repoUrl": "https://github.com/user/repo.git",
   "numberOfCommits": "4",
-  "linesOfCode": 4,
+  "linesOfCode": "4",
   "repoSize": "22 B",
   "license": "MIT"
 }

--- a/tests/snapshots/repo__repo.snap
+++ b/tests/snapshots/repo__repo.snap
@@ -7,8 +7,9 @@ expression: info
   "gitVersion": "git version",
   "project": {
     "repo_name": "repo",
-    "number_of_branches": "0",
-    "number_of_tags": "1"
+    "number_of_branches": 0,
+    "number_of_tags": 1,
+    "number_separator": "Plain"
   },
   "description": "Amazing tool",
   "head": {
@@ -30,27 +31,27 @@ expression: info
     {
       "name": "Author Four",
       "email": "author4@example.org",
-      "nbr_of_commits": "1",
+      "nbr_of_commits": 1,
       "contribution": 25
     },
     {
       "name": "Author One",
       "email": "author1@example.org",
-      "nbr_of_commits": "1",
+      "nbr_of_commits": 1,
       "contribution": 25
     },
     {
       "name": "Author Three",
       "email": "author3@example.org",
-      "nbr_of_commits": "1",
+      "nbr_of_commits": 1,
       "contribution": 25
     }
   ],
   "lastChange": "22 years ago",
-  "contributors": "4",
+  "contributors": 4,
   "repoUrl": "https://github.com/user/repo.git",
-  "numberOfCommits": "4",
-  "linesOfCode": "4",
+  "numberOfCommits": 4,
+  "linesOfCode": 4,
   "repoSize": "22 B",
   "license": "MIT"
 }

--- a/tests/snapshots/repo__repo.snap
+++ b/tests/snapshots/repo__repo.snap
@@ -8,8 +8,7 @@ expression: info
   "project": {
     "repo_name": "repo",
     "number_of_branches": 0,
-    "number_of_tags": 1,
-    "number_separator": "Plain"
+    "number_of_tags": 1
   },
   "description": "Amazing tool",
   "head": {


### PR DESCRIPTION
refers to #706 

![image](https://user-images.githubusercontent.com/13710835/206937125-a25786f0-eeeb-4eb4-adc8-b7a83ff19a1f.png)
![image](https://user-images.githubusercontent.com/13710835/207143835-b4308d38-c414-4b98-a2a0-ca7d5912ca8a.png)

Impacted by the CLI flag:

* Number of branches and number of tags
* Number of dependencies
* Number of commits per author
* Number of commits
* LOC
* Number of files