### PR TITLE
Use ISO time for snapshot tests

### DIFF
--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -27,6 +27,7 @@ fn test_repo() -> Result<()> {
     let repo = repo("repo.sh")?;
     let config: Config = Config {
         input: repo.path().to_path_buf(),
+        iso_time: true,
         ..Default::default()
     };
     let info = Info::new(&config)?;

--- a/tests/snapshots/repo__repo.snap
+++ b/tests/snapshots/repo__repo.snap
@@ -18,7 +18,7 @@ expression: info
     ]
   },
   "version": "tag1",
-  "created": "22 years ago",
+  "created": "2000-01-02T00:00:00Z",
   "languages": [
     {
       "language": "Rust",
@@ -46,7 +46,7 @@ expression: info
       "contribution": 25
     }
   ],
-  "lastChange": "22 years ago",
+  "lastChange": "2000-01-02T00:00:00Z",
   "contributors": 4,
   "repoUrl": "https://github.com/user/repo.git",
   "numberOfCommits": 4,


### PR DESCRIPTION
Fixes tests failing after enough time has passed.

ref: https://github.com/o2sh/onefetch/pull/904#issuecomment-1365788241