### PR TITLE
Install cargo-insta in dev containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     "args": { "VARIANT": "buster" }
   },
-  "postCreateCommand": "git config --global --add safe.directory $PWD",
+  "postCreateCommand": "git config --global --add safe.directory $PWD && cargo install cargo-insta",
   "extensions": ["EditorConfig.EditorConfig"],
   "remoteUser": "vscode"
 }

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,6 +5,8 @@ vscode:
     - 'rust-lang.rust-analyzer'
     - 'tamasfe.even-better-toml'
 tasks:
+  - name: Install cargo-insta
+    init: cargo install cargo-insta
   - name: Build Onefetch
     before: sudo apt install -y cmake
     init: cargo build


### PR DESCRIPTION
Since cargo-insta is a dependency to manage tests, the dev environment is incomplete if it is not installed.

~~Draft status because I haven't had a chance to actually test these out yet.~~