### PR TITLE
Info struct to holds a Vec<InfoField>

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,8 @@
 /.github/ @spenserblack @o2sh
 /src/ui/image_backends/ @CephalonRho @yoichi
 /src/info/git.rs @Byron
-/src/info/repo @o2sh @Byron
+/src/info/repo @o2sh
 /languages.yaml @spenserblack @o2sh
 /templates/language.rs @spenserblack
-/src/info/deps/ @HallerPatrick @o2sh
 /src/cli.rs @spenserblack @o2sh
 /vercel/ @spenserblack

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "erased-serde"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ca605381c017ec7a5fef5e548f1cfaa419ed0f6df6367339300db74c92aa7d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +826,17 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghost"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41973d4c45f7a35af8753ba3457cc99d406d863941fd7f52663cff54a5ab99b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1641,6 +1661,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16fe3b35d64bd1f72917f06425e7573a2f63f74f42c8f56e53ea6826dde3a2b5"
+dependencies = [
+ "ctor",
+ "ghost",
+]
+
+[[package]]
 name = "io-close"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,6 +2037,7 @@ dependencies = [
  "time",
  "time-humanize",
  "tokei",
+ "typetag",
  "winres",
  "yaml-rust",
 ]
@@ -2917,6 +2948,30 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "typetag"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63205b6a08578f24e4288dd01692d5d215b0c2e90613089187d2e9879788ed94"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5fd220a6403b4959b40a7f276a8d8d52a987b010dd8efd5c923f8f2d8933132"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ owo-colors = "3.5.0"
 regex = "1.6.0"
 serde = "1.0.147"
 serde_json = "1.0.89"
+typetag = "0.2"
 serde_yaml = "0.9.14"
 # TODO With the new value parsers, we're really close to being able to eliminate
 # the strum dependency

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ owo-colors = "3.5.0"
 regex = "1.6.0"
 serde = "1.0.147"
 serde_json = "1.0.89"
-typetag = "0.2"
 serde_yaml = "0.9.14"
 # TODO With the new value parsers, we're really close to being able to eliminate
 # the strum dependency
@@ -48,6 +47,7 @@ terminal_size = "0.2"
 time = { version = "0.3.17", features = ["formatting"] }
 time-humanize = { version = "0.1.3", features = ["time"] }
 tokei = "12.1.2"
+typetag = "0.2"
 yaml-rust = "0.4.5"
 
 [dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -279,7 +279,7 @@ mod test {
             input: PathBuf::from("/tmp/folder"),
             no_merges: true,
             ascii_colors: vec![5, 0],
-            disabled_fields: vec![InfoType::Version, InfoType::Repo],
+            disabled_fields: vec![InfoType::Version, InfoType::URL],
             show_logo: When::Never,
             ascii_language: Some(Language::Lisp),
             ..Default::default()
@@ -298,7 +298,7 @@ mod test {
                 "0",
                 "--disabled-fields",
                 "version",
-                "repo",
+                "url",
                 "--show-logo",
                 "never",
                 "--ascii-language",

--- a/src/info/info_field.rs
+++ b/src/info/info_field.rs
@@ -57,20 +57,22 @@ mod test {
     }
 
     #[test]
-    fn test_info_field_get() {
+    fn test_info_field_with_value() {
         let info = InfoFieldImpl("test");
         assert_eq!(info.has_value(&[]), true);
+        assert_eq!(info.title(), "title".to_string());
+        assert_eq!(info.r#type(), InfoType::Project);
         assert_eq!(info.value(), "test".to_string());
     }
 
     #[test]
-    fn test_info_field_get_none_when_type_disabled() {
+    fn test_info_field_when_type_is_disabled() {
         let info = InfoFieldImpl("test");
         assert_eq!(info.has_value(&[InfoType::Project]), false);
     }
 
     #[test]
-    fn test_info_field_get_none_when_value_is_empty() {
+    fn test_info_field_without_value() {
         let info = InfoFieldImpl("");
         assert_eq!(info.has_value(&[]), false);
     }

--- a/src/info/info_field.rs
+++ b/src/info/info_field.rs
@@ -6,12 +6,8 @@ pub trait InfoField {
     fn should_color(&self) -> bool {
         true
     }
-    fn get(&self, disabled_infos: &[InfoType]) -> Option<String> {
-        let info_field_value = self.value();
-        if disabled_infos.contains(&self.r#type()) || info_field_value.is_empty() {
-            return None;
-        }
-        Some(info_field_value)
+    fn has_value(&self, disabled_infos: &[InfoType]) -> bool {
+        !(disabled_infos.contains(&self.r#type()) || self.value().is_empty())
     }
 }
 
@@ -63,18 +59,19 @@ mod test {
     #[test]
     fn test_info_field_get() {
         let info = InfoFieldImpl("test");
-        assert_eq!(info.get(&[]), Some("test".into()));
+        assert_eq!(info.has_value(&[]), true);
+        assert_eq!(info.value(), "test".to_string());
     }
 
     #[test]
     fn test_info_field_get_none_when_type_disabled() {
         let info = InfoFieldImpl("test");
-        assert_eq!(info.get(&[InfoType::Project]), None);
+        assert_eq!(info.has_value(&[InfoType::Project]), false);
     }
 
     #[test]
     fn test_info_field_get_none_when_value_is_empty() {
         let info = InfoFieldImpl("");
-        assert_eq!(info.get(&[]), None);
+        assert_eq!(info.has_value(&[]), false);
     }
 }

--- a/src/info/info_field.rs
+++ b/src/info/info_field.rs
@@ -1,10 +1,14 @@
+#[typetag::serialize]
 pub trait InfoField {
-    const TYPE: InfoType;
     fn value(&self) -> String;
     fn title(&self) -> String;
+    fn r#type(&self) -> InfoType;
+    fn should_color(&self) -> bool {
+        true
+    }
     fn get(&self, disabled_infos: &[InfoType]) -> Option<String> {
         let info_field_value = self.value();
-        if disabled_infos.contains(&Self::TYPE) || info_field_value.is_empty() {
+        if disabled_infos.contains(&self.r#type()) || info_field_value.is_empty() {
             return None;
         }
         Some(info_field_value)
@@ -25,7 +29,7 @@ pub enum InfoType {
     Authors,
     LastChange,
     Contributors,
-    Repo,
+    URL,
     Commits,
     LinesOfCode,
     Size,
@@ -34,19 +38,25 @@ pub enum InfoType {
 
 #[cfg(test)]
 mod test {
+    use serde::Serialize;
+
     use super::*;
 
+    #[derive(Serialize)]
     struct InfoFieldImpl(&'static str);
 
+    #[typetag::serialize]
     impl InfoField for InfoFieldImpl {
-        const TYPE: InfoType = InfoType::Project;
-
         fn value(&self) -> String {
             self.0.into()
         }
 
         fn title(&self) -> String {
             "title".into()
+        }
+
+        fn r#type(&self) -> InfoType {
+            InfoType::Project
         }
     }
 

--- a/src/info/langs/language.rs
+++ b/src/info/langs/language.rs
@@ -12,10 +12,15 @@ pub struct LanguageWithPercentage {
     pub percentage: f64,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LanguagesInfo {
     pub languages_with_percentage: Vec<LanguageWithPercentage>,
+    #[serde(skip_serializing)]
     true_color: bool,
+    #[serde(skip_serializing)]
     number_of_languages: usize,
+    #[serde(skip_serializing)]
     info_color: DynColors,
 }
 
@@ -126,9 +131,8 @@ impl std::fmt::Display for LanguagesInfo {
     }
 }
 
+#[typetag::serialize]
 impl InfoField for LanguagesInfo {
-    const TYPE: InfoType = InfoType::Languages;
-
     fn value(&self) -> String {
         self.to_string()
     }
@@ -139,6 +143,13 @@ impl InfoField for LanguagesInfo {
             title.push('s')
         }
         title
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::Languages
+    }
+    fn should_color(&self) -> bool {
+        false
     }
 }
 

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -65,15 +65,17 @@ impl std::fmt::Display for Info {
         }
 
         //Info lines
-        for info_field in self.info_fields.iter() {
-            if let Some(info_field_value) = info_field.get(&self.disabled_fields) {
-                self.write_styled_info_line(
-                    f,
-                    &info_field.title(),
-                    &info_field_value,
-                    info_field.should_color(),
-                )?;
-            }
+        for info_field in self
+            .info_fields
+            .iter()
+            .filter(|x| x.has_value(&self.disabled_fields))
+        {
+            self.write_styled_info_line(
+                f,
+                &info_field.title(),
+                &info_field.value(),
+                info_field.should_color(),
+            )?
         }
 
         //Palette

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -26,7 +26,6 @@ use num_format::ToFormattedString;
 use onefetch_manifest::Manifest;
 use owo_colors::{DynColors, OwoColorize, Style};
 use regex::Regex;
-use serde::ser::SerializeStruct;
 use serde::Serialize;
 use std::path::Path;
 use std::str::FromStr;
@@ -39,29 +38,22 @@ mod repo;
 pub mod test;
 pub mod title;
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Info {
     title: Title,
-    project: ProjectInfo,
-    description: DescriptionInfo,
-    head: HeadInfo,
-    pending: PendingInfo,
-    version: VersionInfo,
-    created: CreatedInfo,
-    languages: LanguagesInfo,
-    dependencies: DependenciesInfo,
-    authors: AuthorsInfo,
-    last_change: LastChangeInfo,
-    contributors: ContributorsInfo,
-    repo: UrlInfo,
-    commits: CommitsInfo,
-    lines_of_code: LocInfo,
-    size: SizeInfo,
-    license: LicenseInfo,
+    info_fields: Vec<Box<dyn InfoField>>,
+    #[serde(skip_serializing)]
     disabled_fields: Vec<InfoType>,
+    #[serde(skip_serializing)]
     text_colors: TextColors,
+    #[serde(skip_serializing)]
     no_color_palette: bool,
+    #[serde(skip_serializing)]
     no_bold: bool,
+    #[serde(skip_serializing)]
     pub dominant_language: Language,
+    #[serde(skip_serializing)]
     pub ascii_colors: Vec<DynColors>,
 }
 
@@ -73,93 +65,15 @@ impl std::fmt::Display for Info {
         }
 
         //Info lines
-        if let Some(project_info_value) = self.project.get(&self.disabled_fields) {
-            self.write_styled_info_line(f, &self.project.title(), &project_info_value, true)?;
-        }
-
-        if let Some(description_info_value) = self.description.get(&self.disabled_fields) {
-            self.write_styled_info_line(
-                f,
-                &self.description.title(),
-                &description_info_value,
-                true,
-            )?;
-        }
-
-        if let Some(head_info_value) = self.head.get(&self.disabled_fields) {
-            self.write_styled_info_line(f, &self.head.title(), &head_info_value, true)?;
-        }
-
-        if let Some(pending_info_value) = self.pending.get(&self.disabled_fields) {
-            self.write_styled_info_line(f, &self.pending.title(), &pending_info_value, true)?;
-        }
-
-        if let Some(version_info_value) = self.version.get(&self.disabled_fields) {
-            self.write_styled_info_line(f, &self.version.title(), &version_info_value, true)?;
-        }
-
-        if let Some(created_info_value) = self.created.get(&self.disabled_fields) {
-            self.write_styled_info_line(f, &self.created.title(), &created_info_value, true)?;
-        }
-
-        if let Some(languages_info_value) = self.languages.get(&self.disabled_fields) {
-            self.write_styled_info_line(f, &self.languages.title(), &languages_info_value, false)?;
-        }
-
-        if let Some(dependencies_info_value) = self.dependencies.get(&self.disabled_fields) {
-            self.write_styled_info_line(
-                f,
-                &self.dependencies.title(),
-                &dependencies_info_value,
-                true,
-            )?;
-        }
-
-        if let Some(authors_info_value) = self.authors.get(&self.disabled_fields) {
-            self.write_styled_info_line(f, &self.authors.title(), &authors_info_value, false)?;
-        }
-
-        if let Some(last_change_info_value) = self.last_change.get(&self.disabled_fields) {
-            self.write_styled_info_line(
-                f,
-                &self.last_change.title(),
-                &last_change_info_value,
-                true,
-            )?;
-        }
-
-        if let Some(contributors_info_value) = self.contributors.get(&self.disabled_fields) {
-            self.write_styled_info_line(
-                f,
-                &self.contributors.title(),
-                &contributors_info_value,
-                true,
-            )?;
-        }
-
-        if let Some(repo_info_value) = self.repo.get(&self.disabled_fields) {
-            self.write_styled_info_line(f, &self.repo.title(), &repo_info_value, true)?;
-        }
-
-        if let Some(commits_info_value) = self.commits.get(&self.disabled_fields) {
-            self.write_styled_info_line(f, &self.commits.title(), &commits_info_value, true)?;
-        }
-
-        if let Some(lines_of_code_info_value) = self.lines_of_code.get(&self.disabled_fields) {
-            self.write_styled_info_line(
-                f,
-                &self.lines_of_code.title(),
-                &lines_of_code_info_value,
-                true,
-            )?;
-        }
-
-        if let Some(size_info_value) = self.size.get(&self.disabled_fields) {
-            self.write_styled_info_line(f, &self.size.title(), &size_info_value, true)?;
-        }
-
-        if let Some(license_info_value) = self.license.get(&self.disabled_fields) {
-            self.write_styled_info_line(f, &self.license.title(), &license_info_value, true)?;
+        for info_field in self.info_fields.iter() {
+            if let Some(info_field_value) = info_field.get(&self.disabled_fields) {
+                self.write_styled_info_line(
+                    f,
+                    &info_field.title(),
+                    &info_field_value,
+                    info_field.should_color(),
+                )?;
+            }
         }
 
         //Palette
@@ -279,24 +193,27 @@ impl Info {
         let commits = CommitsInfo::new(&commits, config.number_separator);
         let lines_of_code = LocInfo::new(lines_of_code, config.number_separator);
 
+        let info_fields: Vec<Box<dyn InfoField>> = vec![
+            Box::new(project),
+            Box::new(description),
+            Box::new(head),
+            Box::new(pending),
+            Box::new(version),
+            Box::new(created),
+            Box::new(languages),
+            Box::new(dependencies),
+            Box::new(authors),
+            Box::new(last_change),
+            Box::new(contributors),
+            Box::new(repo_url),
+            Box::new(commits),
+            Box::new(lines_of_code),
+            Box::new(size),
+            Box::new(license),
+        ];
         Ok(Self {
             title,
-            project,
-            description,
-            head,
-            pending,
-            version,
-            created,
-            languages,
-            dependencies,
-            authors,
-            last_change,
-            contributors,
-            repo: repo_url,
-            commits,
-            lines_of_code,
-            size,
-            license,
+            info_fields,
             disabled_fields: config.disabled_fields.clone(),
             text_colors,
             dominant_language,
@@ -364,34 +281,6 @@ fn get_style(is_bold: bool, color: DynColors) -> Style {
         style = style.bold();
     }
     style
-}
-
-impl Serialize for Info {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_struct("Info", 17)?;
-        state.serialize_field("gitUsername", &self.title.git_username)?;
-        state.serialize_field("gitVersion", &self.title.git_version)?;
-        state.serialize_field("project", &self.project)?;
-        state.serialize_field("description", &self.description.description)?;
-        state.serialize_field("head", &self.head.head_refs)?;
-        state.serialize_field("version", &self.version.version)?;
-        state.serialize_field("created", &self.created.creation_date)?;
-        state.serialize_field("languages", &self.languages.languages_with_percentage)?;
-        state.serialize_field("dependencies", &self.dependencies.dependencies)?;
-        state.serialize_field("authors", &self.authors.authors)?;
-        state.serialize_field("lastChange", &self.last_change.last_change)?;
-        state.serialize_field("contributors", &self.contributors.number_of_contributors)?;
-        state.serialize_field("repoUrl", &self.repo.repo_url)?;
-        state.serialize_field("numberOfCommits", &self.commits.number_of_commits)?;
-        state.serialize_field("linesOfCode", &self.lines_of_code.lines_of_code)?;
-        state.serialize_field("repoSize", &self.size.repo_size)?;
-        state.serialize_field("license", &self.license.license)?;
-
-        state.end()
-    }
 }
 
 #[cfg(test)]

--- a/src/info/repo/author.rs
+++ b/src/info/repo/author.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use std::fmt::Write;
 
 #[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Author {
     name: String,
     email: String,
@@ -68,8 +69,10 @@ impl std::fmt::Display for Author {
     }
 }
 
+#[derive(Serialize)]
 pub struct AuthorsInfo {
     pub authors: Vec<Author>,
+    #[serde(skip_serializing)]
     pub info_color: DynColors,
 }
 
@@ -103,9 +106,8 @@ impl std::fmt::Display for AuthorsInfo {
     }
 }
 
+#[typetag::serialize]
 impl InfoField for AuthorsInfo {
-    const TYPE: InfoType = InfoType::Authors;
-
     fn value(&self) -> String {
         self.to_string()
     }
@@ -116,6 +118,14 @@ impl InfoField for AuthorsInfo {
             title.push('s')
         }
         title
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::Authors
+    }
+
+    fn should_color(&self) -> bool {
+        false
     }
 }
 

--- a/src/info/repo/commits.rs
+++ b/src/info/repo/commits.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 use crate::{
     cli::NumberSeparator,
     info::{
@@ -7,9 +9,12 @@ use crate::{
     },
 };
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CommitsInfo {
     pub number_of_commits: usize,
     is_shallow: bool,
+    #[serde(skip_serializing)]
     number_separator: NumberSeparator,
 }
 
@@ -23,9 +28,8 @@ impl CommitsInfo {
     }
 }
 
+#[typetag::serialize]
 impl InfoField for CommitsInfo {
-    const TYPE: InfoType = InfoType::Commits;
-
     fn value(&self) -> String {
         format!(
             "{}{}",
@@ -36,6 +40,10 @@ impl InfoField for CommitsInfo {
 
     fn title(&self) -> String {
         "Commits".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::Commits
     }
 }
 

--- a/src/info/repo/contributors.rs
+++ b/src/info/repo/contributors.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 use crate::{
     cli::NumberSeparator,
     info::{
@@ -6,9 +8,14 @@ use crate::{
         info_field::{InfoField, InfoType},
     },
 };
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ContributorsInfo {
     pub number_of_contributors: usize,
+    #[serde(skip_serializing)]
     pub number_of_authors_to_display: usize,
+    #[serde(skip_serializing)]
     number_separator: NumberSeparator,
 }
 
@@ -26,9 +33,8 @@ impl ContributorsInfo {
     }
 }
 
+#[typetag::serialize]
 impl InfoField for ContributorsInfo {
-    const TYPE: InfoType = InfoType::Contributors;
-
     fn value(&self) -> String {
         if self.number_of_contributors > self.number_of_authors_to_display {
             format_number(self.number_of_contributors, self.number_separator)
@@ -39,6 +45,10 @@ impl InfoField for ContributorsInfo {
 
     fn title(&self) -> String {
         "Contributors".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::Contributors
     }
 }
 

--- a/src/info/repo/created.rs
+++ b/src/info/repo/created.rs
@@ -1,9 +1,13 @@
+use serde::Serialize;
+
 use super::gitoxide_time_to_formatted_time;
 use crate::info::{
     git::Commits,
     info_field::{InfoField, InfoType},
 };
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreatedInfo {
     pub creation_date: String,
 }
@@ -19,15 +23,18 @@ fn get_creation_date(commits: &Commits, iso_time: bool) -> String {
     gitoxide_time_to_formatted_time(commits.time_of_first_commit, iso_time)
 }
 
+#[typetag::serialize]
 impl InfoField for CreatedInfo {
-    const TYPE: InfoType = InfoType::Created;
-
     fn value(&self) -> String {
         self.creation_date.to_string()
     }
 
     fn title(&self) -> String {
         "Created".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::Created
     }
 }
 

--- a/src/info/repo/dependencies.rs
+++ b/src/info/repo/dependencies.rs
@@ -6,7 +6,9 @@ use crate::{
     },
 };
 use onefetch_manifest::Manifest;
+use serde::Serialize;
 
+#[derive(Serialize)]
 pub struct DependenciesInfo {
     pub dependencies: String,
 }
@@ -29,15 +31,18 @@ impl DependenciesInfo {
     }
 }
 
+#[typetag::serialize]
 impl InfoField for DependenciesInfo {
-    const TYPE: InfoType = InfoType::Dependencies;
-
     fn value(&self) -> String {
         self.dependencies.clone()
     }
 
     fn title(&self) -> String {
         "Dependencies".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::Dependencies
     }
 }
 

--- a/src/info/repo/description.rs
+++ b/src/info/repo/description.rs
@@ -1,9 +1,11 @@
 use crate::info::info_field::{InfoField, InfoType};
 use onefetch_manifest::Manifest;
+use serde::Serialize;
 use std::fmt::Write;
 
 const NUMBER_OF_WORDS_PER_LINE: usize = 5;
 
+#[derive(Serialize)]
 pub struct DescriptionInfo {
     pub description: Option<String>,
 }
@@ -19,9 +21,8 @@ impl DescriptionInfo {
     }
 }
 
+#[typetag::serialize]
 impl InfoField for DescriptionInfo {
-    const TYPE: InfoType = InfoType::Description;
-
     fn value(&self) -> String {
         match &self.description {
             Some(value) => {
@@ -48,6 +49,10 @@ impl InfoField for DescriptionInfo {
 
     fn title(&self) -> String {
         "Description".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::Description
     }
 }
 

--- a/src/info/repo/head.rs
+++ b/src/info/repo/head.rs
@@ -4,6 +4,7 @@ use git_repository::{reference::Category, Reference, Repository};
 use serde::Serialize;
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HeadRefs {
     short_commit_id: String,
     refs: Vec<String>,
@@ -34,6 +35,8 @@ impl std::fmt::Display for HeadRefs {
     }
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HeadInfo {
     pub head_refs: HeadRefs,
 }
@@ -60,15 +63,18 @@ fn get_head_refs(repo: &Repository) -> Result<HeadRefs> {
     Ok(HeadRefs::new(head_oid.shorten()?.to_string(), refs_info))
 }
 
+#[typetag::serialize]
 impl InfoField for HeadInfo {
-    const TYPE: InfoType = InfoType::Head;
-
     fn value(&self) -> String {
         self.head_refs.to_string()
     }
 
     fn title(&self) -> String {
         "HEAD".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::Head
     }
 }
 

--- a/src/info/repo/last_change.rs
+++ b/src/info/repo/last_change.rs
@@ -1,9 +1,13 @@
+use serde::Serialize;
+
 use super::gitoxide_time_to_formatted_time;
 use crate::info::{
     git::Commits,
     info_field::{InfoField, InfoType},
 };
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LastChangeInfo {
     pub last_change: String,
 }
@@ -20,15 +24,18 @@ fn get_date_of_last_commit(commits: &Commits, iso_time: bool) -> String {
     gitoxide_time_to_formatted_time(commits.time_of_most_recent_commit, iso_time)
 }
 
+#[typetag::serialize]
 impl InfoField for LastChangeInfo {
-    const TYPE: InfoType = InfoType::LastChange;
-
     fn value(&self) -> String {
         self.last_change.to_string()
     }
 
     fn title(&self) -> String {
         "Last change".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::LastChange
     }
 }
 

--- a/src/info/repo/license.rs
+++ b/src/info/repo/license.rs
@@ -2,6 +2,7 @@ use crate::info::info_field::{InfoField, InfoType};
 use anyhow::{bail, Result};
 use askalono::{Store, TextData};
 use onefetch_manifest::Manifest;
+use serde::Serialize;
 use std::path::Path;
 use std::{ffi::OsStr, fs};
 
@@ -73,6 +74,7 @@ fn is_license_file<S: AsRef<str>>(file_name: S) -> bool {
         .any(|&name| file_name.as_ref().starts_with(name))
 }
 
+#[derive(Serialize)]
 pub struct LicenseInfo {
     pub license: String,
 }
@@ -84,15 +86,18 @@ impl LicenseInfo {
     }
 }
 
+#[typetag::serialize]
 impl InfoField for LicenseInfo {
-    const TYPE: InfoType = InfoType::License;
-
     fn value(&self) -> String {
         self.license.to_string()
     }
 
     fn title(&self) -> String {
         "License".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::License
     }
 }
 

--- a/src/info/repo/loc.rs
+++ b/src/info/repo/loc.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 use crate::{
     cli::NumberSeparator,
     info::{
@@ -6,8 +8,11 @@ use crate::{
     },
 };
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LocInfo {
     pub lines_of_code: usize,
+    #[serde(skip_serializing)]
     number_separator: NumberSeparator,
 }
 
@@ -20,15 +25,18 @@ impl LocInfo {
     }
 }
 
+#[typetag::serialize]
 impl InfoField for LocInfo {
-    const TYPE: InfoType = InfoType::LinesOfCode;
-
     fn value(&self) -> String {
         format_number(self.lines_of_code, self.number_separator)
     }
 
     fn title(&self) -> String {
         "Lines of code".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::LinesOfCode
     }
 }
 

--- a/src/info/repo/pending.rs
+++ b/src/info/repo/pending.rs
@@ -2,7 +2,10 @@ use crate::info::info_field::{InfoField, InfoType};
 use anyhow::Result;
 use git2::{Status, StatusOptions, StatusShow};
 use git_repository::Repository;
+use serde::Serialize;
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PendingInfo {
     pub pending_changes: String,
 }
@@ -56,15 +59,18 @@ fn get_pending_changes(repo: &git2::Repository) -> Result<String> {
     Ok(result.trim().into())
 }
 
+#[typetag::serialize]
 impl InfoField for PendingInfo {
-    const TYPE: InfoType = InfoType::Pending;
-
     fn value(&self) -> String {
         self.pending_changes.to_string()
     }
 
     fn title(&self) -> String {
         "Pending".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::Pending
     }
 }
 

--- a/src/info/repo/project.rs
+++ b/src/info/repo/project.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use std::ffi::OsStr;
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProjectInfo {
     pub repo_name: String,
     pub number_of_branches: usize,
@@ -108,15 +109,18 @@ impl std::fmt::Display for ProjectInfo {
     }
 }
 
+#[typetag::serialize]
 impl InfoField for ProjectInfo {
-    const TYPE: InfoType = InfoType::Project;
-
     fn value(&self) -> String {
         self.to_string()
     }
 
     fn title(&self) -> String {
         "Project".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::Project
     }
 }
 

--- a/src/info/repo/size.rs
+++ b/src/info/repo/size.rs
@@ -7,10 +7,14 @@ use crate::{
 };
 use byte_unit::Byte;
 use git_repository::Repository;
+use serde::Serialize;
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SizeInfo {
     pub repo_size: String,
     pub file_count: u64,
+    #[serde(skip_serializing)]
     number_separator: NumberSeparator,
 }
 
@@ -59,14 +63,17 @@ impl std::fmt::Display for SizeInfo {
     }
 }
 
+#[typetag::serialize]
 impl InfoField for SizeInfo {
-    const TYPE: InfoType = InfoType::Size;
-
     fn value(&self) -> String {
         self.to_string()
     }
     fn title(&self) -> String {
         "Size".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::Size
     }
 }
 

--- a/src/info/repo/url.rs
+++ b/src/info/repo/url.rs
@@ -1,7 +1,10 @@
 use crate::info::info_field::{InfoField, InfoType};
 use anyhow::Result;
 use git_repository::Repository;
+use serde::Serialize;
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UrlInfo {
     pub repo_url: String,
 }
@@ -39,15 +42,18 @@ fn get_url(repo: &Repository) -> Result<String> {
     Ok(remote_url)
 }
 
+#[typetag::serialize]
 impl InfoField for UrlInfo {
-    const TYPE: InfoType = InfoType::Repo;
-
     fn value(&self) -> String {
         self.repo_url.to_string()
     }
 
     fn title(&self) -> String {
-        "Repo".into()
+        "URL".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::URL
     }
 }
 

--- a/src/info/repo/version.rs
+++ b/src/info/repo/version.rs
@@ -2,7 +2,9 @@ use crate::info::info_field::{InfoField, InfoType};
 use anyhow::Result;
 use git_repository::Repository;
 use onefetch_manifest::Manifest;
+use serde::Serialize;
 
+#[derive(Serialize)]
 pub struct VersionInfo {
     pub version: String,
 }
@@ -38,15 +40,19 @@ fn get_version(repo: &Repository, manifest: Option<&Manifest>) -> Result<String>
         Ok(version)
     }
 }
-impl InfoField for VersionInfo {
-    const TYPE: InfoType = InfoType::Version;
 
+#[typetag::serialize]
+impl InfoField for VersionInfo {
     fn value(&self) -> String {
         self.version.to_string()
     }
 
     fn title(&self) -> String {
         "Version".into()
+    }
+
+    fn r#type(&self) -> InfoType {
+        InfoType::Version
     }
 }
 

--- a/src/info/title.rs
+++ b/src/info/title.rs
@@ -5,6 +5,7 @@ use owo_colors::{DynColors, OwoColorize};
 use serde::Serialize;
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Title {
     pub git_username: String,
     pub git_version: String,

--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -34,8 +34,8 @@ fn test_repo() -> Result<()> {
     insta::assert_json_snapshot!(
         info,
         {
-            ".gitVersion" => "git version",
-            ".head.short_commit_id" => "short commit"
+            ".title.gitVersion" => "git version",
+            ".infoFields[].HeadInfo.headRefs.shortCommitId" => "short commit"
         }
     );
 

--- a/tests/snapshots/repo__repo.snap
+++ b/tests/snapshots/repo__repo.snap
@@ -3,54 +3,123 @@ source: tests/repo.rs
 expression: info
 ---
 {
-  "gitUsername": "onefetch-committer-name",
-  "gitVersion": "git version",
-  "project": {
-    "repo_name": "repo",
-    "number_of_branches": 0,
-    "number_of_tags": 1
+  "title": {
+    "gitUsername": "onefetch-committer-name",
+    "gitVersion": "git version"
   },
-  "description": "Amazing tool",
-  "head": {
-    "short_commit_id": "short commit",
-    "refs": [
-      "main"
-    ]
-  },
-  "version": "tag1",
-  "created": "2000-01-02T00:00:00Z",
-  "languages": [
+  "infoFields": [
     {
-      "language": "Rust",
-      "percentage": 100.0
-    }
-  ],
-  "dependencies": "1 (Cargo)",
-  "authors": [
-    {
-      "name": "Author Four",
-      "email": "author4@example.org",
-      "nbr_of_commits": 1,
-      "contribution": 25
+      "ProjectInfo": {
+        "repoName": "repo",
+        "numberOfBranches": 0,
+        "numberOfTags": 1
+      }
     },
     {
-      "name": "Author One",
-      "email": "author1@example.org",
-      "nbr_of_commits": 1,
-      "contribution": 25
+      "DescriptionInfo": {
+        "description": "Amazing tool"
+      }
     },
     {
-      "name": "Author Three",
-      "email": "author3@example.org",
-      "nbr_of_commits": 1,
-      "contribution": 25
+      "HeadInfo": {
+        "headRefs": {
+          "shortCommitId": "short commit",
+          "refs": [
+            "main"
+          ]
+        }
+      }
+    },
+    {
+      "PendingInfo": {
+        "pendingChanges": "1+- 2+"
+      }
+    },
+    {
+      "VersionInfo": {
+        "version": "tag1"
+      }
+    },
+    {
+      "CreatedInfo": {
+        "creationDate": "2000-01-02T00:00:00Z"
+      }
+    },
+    {
+      "LanguagesInfo": {
+        "languagesWithPercentage": [
+          {
+            "language": "Rust",
+            "percentage": 100.0
+          }
+        ]
+      }
+    },
+    {
+      "DependenciesInfo": {
+        "dependencies": "1 (Cargo)"
+      }
+    },
+    {
+      "AuthorsInfo": {
+        "authors": [
+          {
+            "name": "Author Four",
+            "email": "author4@example.org",
+            "nbrOfCommits": 1,
+            "contribution": 25
+          },
+          {
+            "name": "Author One",
+            "email": "author1@example.org",
+            "nbrOfCommits": 1,
+            "contribution": 25
+          },
+          {
+            "name": "Author Three",
+            "email": "author3@example.org",
+            "nbrOfCommits": 1,
+            "contribution": 25
+          }
+        ]
+      }
+    },
+    {
+      "LastChangeInfo": {
+        "lastChange": "2000-01-02T00:00:00Z"
+      }
+    },
+    {
+      "ContributorsInfo": {
+        "numberOfContributors": 4
+      }
+    },
+    {
+      "UrlInfo": {
+        "repoUrl": "https://github.com/user/repo.git"
+      }
+    },
+    {
+      "CommitsInfo": {
+        "numberOfCommits": 4,
+        "isShallow": false
+      }
+    },
+    {
+      "LocInfo": {
+        "linesOfCode": 4
+      }
+    },
+    {
+      "SizeInfo": {
+        "repoSize": "22 B",
+        "fileCount": 1
+      }
+    },
+    {
+      "LicenseInfo": {
+        "license": "MIT"
+      }
     }
-  ],
-  "lastChange": "2000-01-02T00:00:00Z",
-  "contributors": 4,
-  "repoUrl": "https://github.com/user/repo.git",
-  "numberOfCommits": 4,
-  "linesOfCode": 4,
-  "repoSize": "22 B",
-  "license": "MIT"
+  ]
 }


### PR DESCRIPTION
Part 2 of #755, 

Now that all info fields implement the `InfoField` trait, we can put them inside a Vector and iterate over to simplify the `fmt()` method of `std::fmt::Display`.