### PR TITLE
feat(vercel): add section links

### DIFF
--- a/docs/vercel/package.json
+++ b/docs/vercel/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "format": "prettier -w .",
     "preview": "vite preview",
     "check": "check:svelte && check:prettier && check:eslint",
     "check:svelte": "svelte-check --tsconfig ./tsconfig.json",

--- a/docs/vercel/public/sakura.css
+++ b/docs/vercel/public/sakura.css
@@ -99,6 +99,12 @@ a:hover {
   border-bottom: 2px solid #222222;
 }
 
+h3 a,
+h3 a:hover,
+h3 a:visited {
+  color: #222222;
+}
+
 ul {
   padding-left: 1.4em;
   margin-top: 0px;

--- a/docs/vercel/public/sakura.css
+++ b/docs/vercel/public/sakura.css
@@ -99,12 +99,6 @@ a:hover {
   border-bottom: 2px solid #222222;
 }
 
-h3 a,
-h3 a:hover,
-h3 a:visited {
-  color: #222222;
-}
-
 ul {
   padding-left: 1.4em;
   margin-top: 0px;

--- a/docs/vercel/src/lib/AsciiPreview.svelte
+++ b/docs/vercel/src/lib/AsciiPreview.svelte
@@ -74,7 +74,7 @@
   .title-link,
   .title-link:hover,
   .title-link:visited {
-      color: #222222;
+    color: #222222;
   }
 
   pre {

--- a/docs/vercel/src/lib/AsciiPreview.svelte
+++ b/docs/vercel/src/lib/AsciiPreview.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Chip from './Chip.svelte';
+  import TitleLink from './TitleLink.svelte';
 
   export let name: string;
   export let ansi: string[];
@@ -35,7 +36,7 @@
 <div class="title-row">
   <div class="language-name">
     <Chip id={name} color={chip} width={24} height={24} />
-    <h3 id={name}><a href="#{name}" class="title-link">{name}</a></h3>
+    <TitleLink {name} />
   </div>
   <div class="checkbox">
     <input id="dark-checkbox-{name}" type="checkbox" bind:checked={dark} />
@@ -69,12 +70,6 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: baseline;
-  }
-
-  .title-link,
-  .title-link:hover,
-  .title-link:visited {
-    color: #222222;
   }
 
   pre {

--- a/docs/vercel/src/lib/AsciiPreview.svelte
+++ b/docs/vercel/src/lib/AsciiPreview.svelte
@@ -35,7 +35,7 @@
 <div class="title-row">
   <div class="language-name">
     <Chip id={name} color={chip} width={24} height={24} />
-    <h3 id={name}><a href="#{name}">{name}</a></h3>
+    <h3 id={name}><a href="#{name}" class="title-link">{name}</a></h3>
   </div>
   <div class="checkbox">
     <input id="dark-checkbox-{name}" type="checkbox" bind:checked={dark} />
@@ -69,6 +69,12 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: baseline;
+  }
+
+  .title-link,
+  .title-link:hover,
+  .title-link:visited {
+      color: #222222;
   }
 
   pre {

--- a/docs/vercel/src/lib/AsciiPreview.svelte
+++ b/docs/vercel/src/lib/AsciiPreview.svelte
@@ -35,7 +35,7 @@
 <div class="title-row">
   <div class="language-name">
     <Chip id={name} color={chip} width={24} height={24} />
-    <h3>{name}</h3>
+    <h3 id={name}><a href=#{name}>{name}</a></h3>
   </div>
   <div class="checkbox">
     <input id="dark-checkbox-{name}" type="checkbox" bind:checked={dark} />

--- a/docs/vercel/src/lib/AsciiPreview.svelte
+++ b/docs/vercel/src/lib/AsciiPreview.svelte
@@ -35,7 +35,7 @@
 <div class="title-row">
   <div class="language-name">
     <Chip id={name} color={chip} width={24} height={24} />
-    <h3 id={name}><a href=#{name}>{name}</a></h3>
+    <h3 id={name}><a href="#{name}">{name}</a></h3>
   </div>
   <div class="checkbox">
     <input id="dark-checkbox-{name}" type="checkbox" bind:checked={dark} />

--- a/docs/vercel/src/lib/TitleLink.svelte
+++ b/docs/vercel/src/lib/TitleLink.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  export let name: string;
+</script>
+
+<h3 id={name}><a href="#{name}" class="title-link">{name}</a></h3>
+
+<style>
+  .title-link,
+  .title-link:hover,
+  .title-link:visited {
+    color: #222;
+  }
+</style>


### PR DESCRIPTION
# What

- Adds section links to the vercel website 
- didn't see a npm script for running prettier, so I added one

# Demo

Jumping via section link https://vercel-hw8vz6ref-o2sh.vercel.app/#Makefile

![image](https://user-images.githubusercontent.com/8976745/211163012-87c79311-b785-46d8-831f-3f1c154c0dc8.png)

`npm run format`:

![image](https://user-images.githubusercontent.com/8976745/211162963-2b44a729-d537-44d9-9d25-918c9fabc8ee.png)
