### PR TITLE
feat(ascii): parse multi-byte unicode chars correctly + docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .DS_Store
 result
 **/generated-*
+**/.idea

--- a/ascii/README.md
+++ b/ascii/README.md
@@ -1,5 +1,8 @@
 # ascii
 
+[![crates.io](https://img.shields.io/crates/v/onefetch-ascii)](https://crates.io/crates/onefetch-ascii)
+[![docs.rs](https://img.shields.io/docsrs/onefetch-ascii)](https://docs.rs/onefetch-ascii)
+
 Provides the primary interface to display ascii art to the terminal.
 
 More info [here](https://github.com/o2sh/onefetch/wiki/ascii-art).

--- a/ascii/src/lib.rs
+++ b/ascii/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides the ascii template interface for [onefetch](https://github.com/o2sh/onefetch).
 //!
-//! ```rust
+//! ```rust,no_run
 //! use onefetch_ascii::AsciiArt;
 //! use owo_colors::{DynColors, AnsiColors};
 //!

--- a/ascii/src/lib.rs
+++ b/ascii/src/lib.rs
@@ -314,6 +314,12 @@ mod test {
             "\u{1b}[39;1m   \u{1b}[0m"
         );
 
+        // https://github.com/o2sh/onefetch/issues/935
+        assert_eq!(
+            Tokens("███").render(Vec::new().as_slice(), 0, 3, true),
+            "\u{1b}[39;1m███\u{1b}[0m"
+        );
+
         assert_eq!(
             Tokens("  {1} {5}  {9} a").render(&colors_shim, 4, 10, true),
             "\u{1b}[39;1m\u{1b}[0m\u{1b}[39;1m\u{1b}[0m\u{1b}[39;1m \u{1b}[0m\u{1b}[39;1m a\u{1b}[0m   "

--- a/ascii/src/lib.rs
+++ b/ascii/src/lib.rs
@@ -1,6 +1,52 @@
+//! # onefetch-ascii
+//!
+//! Provides the ascii template interface for [onefetch](https://github.com/
+//!
+//! ```rust
+//! use onefetch_ascii::AsciiArt;
+//! use owo_colors::{DynColors, AnsiColors};
+//!
+//! const ASCII: &str = r#"
+//! {2}            .:--::////::--.`
+//! {1}        `/yNMMNho{2}////////////:.
+//! {1}      `+NMMMMMMMMmy{2}/////////////:`
+//! {0}    `-:::{1}ohNMMMMMMMNy{2}/////////////:`
+//! {0}   .::::::::{1}odMMMMMMMNy{2}/////////////-
+//! {0}  -:::::::::::{1}/hMMMMMMMmo{2}////////////-
+//! {0} .::::::::::::::{1}oMMMMMMMMh{2}////////////-
+//! {0}`:::::::::::::{1}/dMMMMMMMMMMNo{2}///////////`
+//! {0}-::::::::::::{1}sMMMMMMmMMMMMMMy{2}//////////-
+//! {0}-::::::::::{1}/dMMMMMMs{0}:{1}+NMMMMMMd{2}/////////:
+//! {0}-:::::::::{1}+NMMMMMm/{0}:::{1}/dMMMMMMm+{2}///////:
+//! {0}-::::::::{1}sMMMMMMh{0}:::::::{1}dMMMMMMm+{2}//////-
+//! {0}`:::::::{1}sMMMMMMy{0}:::::::::{1}dMMMMMMm+{2}/////`
+//! {0} .:::::{1}sMMMMMMs{0}:::::::::::{1}mMMMMMMd{2}////-
+//! {0}  -:::{1}sMMMMMMy{0}::::::::::::{1}/NMMMMMMh{2}//-
+//! {0}   .:{1}+MMMMMMd{0}::::::::::::::{1}oMMMMMMMo{2}-
+//! {1}    `yMMMMMN/{0}:::::::::::::::{1}hMMMMMh.
+//! {1}      -yMMMo{0}::::::::::::::::{1}/MMMy-
+//! {1}        `/s{0}::::::::::::::::::{1}o/`
+//! {0}            ``.---::::---..`
+//! "#;
+//!
+//! let colors = vec![
+//!     DynColors::Ansi(AnsiColors::Blue),
+//!     DynColors::Ansi(AnsiColors::Default),
+//!     DynColors::Ansi(AnsiColors::BrightBlue)
+//! ];
+//!
+//! let art = AsciiArt::new(ASCII, colors.as_slice(), true);
+//!
+//! for line in art {
+//!     println!("{line}")
+//! }
+//! ```
+//!
+
 use owo_colors::{AnsiColors, DynColors, OwoColorize, Style};
 use std::fmt::Write;
 
+/// Renders an ascii template with the given colors truncated to the correct width.
 pub struct AsciiArt<'a> {
     content: Box<dyn 'a + Iterator<Item = &'a str>>,
     colors: &'a [DynColors],

--- a/ascii/src/lib.rs
+++ b/ascii/src/lib.rs
@@ -211,9 +211,10 @@ fn add_styled_segment(base: &mut String, segment: &str, color: DynColors, bold: 
 type ParseResult<'a, R> = Option<(&'a str, R)>;
 
 fn token<R>(s: &str, predicate: impl FnOnce(char) -> Option<R>) -> ParseResult<R> {
-    let token = s.chars().next()?;
+    let mut chars = s.chars();
+    let token = chars.next()?;
     let result = predicate(token)?;
-    Some((s.get(1..).unwrap(), result))
+    Some((chars.as_str(), result))
 }
 
 // Parsers

--- a/ascii/src/lib.rs
+++ b/ascii/src/lib.rs
@@ -1,6 +1,6 @@
 //! # onefetch-ascii
 //!
-//! Provides the ascii template interface for [onefetch](https://github.com/
+//! Provides the ascii template interface for [onefetch](https://github.com/o2sh/onefetch).
 //!
 //! ```rust
 //! use onefetch_ascii::AsciiArt;


### PR DESCRIPTION
# Why

resolves #935 

# What

- take next char and return the remainder, instead of pulling next char and returning a slice of the input
- add unicode render assertion to tests
- add `AsciiArt` usage example
- add badges to `ascii/README.md`

# Demo

## Usage

![image](https://user-images.githubusercontent.com/8976745/213484046-d1bd1898-6cf4-458d-9737-7b666a94884b.png)

## Docs

![image](https://user-images.githubusercontent.com/8976745/213483728-ccd030f7-7380-46a2-8023-4871e2ca9ad0.png)
