### PR TITLE
Fix Markdown / Jupyter markup not getting counted

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,12 @@ CSharp: # required, this will be the name of the enum variant for the language a
   serialization: c# # required only if the Enum name `CSharp` doesn't match the display name `C#`
 ```
 
+_**NOTE**: An additional field, `line_types` can also be set on a language's attributes. It has been excluded because_
+_it is not necessary for the majority of languages. By default, only a language's lines of code are counted, but this_
+_field can be used to count other lines, too. For example, `line_types: [code, comments]`. This is useful in langauges_
+_like Markdown, where the significant lines are mostly comments. A list of available fields to be used can be found in_
+_[tokei's documentation](https://docs.rs/tokei/latest/tokei/struct.Language.html#fields)._
+
 - link 1: https://github.com/XAMPPRocky/tokei#supported-languages
 - link 2: https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
 

--- a/languages.yaml
+++ b/languages.yaml
@@ -1311,7 +1311,6 @@ Jupyter:
       - "#9E9E9E"
     chip: "#DA5B0B"
   serialization: jupyter-notebooks
-  line_types: [code, comments]
 Kotlin:
   type: programming
   ascii: |

--- a/languages.yaml
+++ b/languages.yaml
@@ -1311,7 +1311,7 @@ Jupyter:
       - "#9E9E9E"
     chip: "#DA5B0B"
   serialization: jupyter-notebooks
-  tokei_line_types: [code, comments]
+  line_types: [code, comments]
 Kotlin:
   type: programming
   ascii: |
@@ -1484,7 +1484,7 @@ Markdown:
       - white
       - red
     chip: "#083FA1"
-  tokei_line_types: [code, comments]
+  line_types: [code, comments]
 Nim:
   type: programming
   ascii: |

--- a/languages.yaml
+++ b/languages.yaml
@@ -1311,6 +1311,7 @@ Jupyter:
       - "#9E9E9E"
     chip: "#DA5B0B"
   serialization: jupyter-notebooks
+  tokei_line_types: [code, comments]
 Kotlin:
   type: programming
   ascii: |
@@ -1483,6 +1484,7 @@ Markdown:
       - white
       - red
     chip: "#083FA1"
+  tokei_line_types: [code, comments]
 Nim:
   type: programming
   ascii: |

--- a/src/info/langs/language.rs
+++ b/src/info/langs/language.rs
@@ -1,6 +1,7 @@
 use crate::info::info_field::{InfoField, InfoType};
 use owo_colors::OwoColorize;
 use serde::Serialize;
+use tokei;
 
 include!(concat!(env!("OUT_DIR"), "/language.rs"));
 
@@ -151,6 +152,27 @@ impl InfoField for LanguagesInfo {
     fn should_color(&self) -> bool {
         false
     }
+}
+
+/// Counts the lines-of-code of a tokei `Language`. Takes into
+/// account that a prose language's comments *are* its code.
+pub fn loc(language_type: &tokei::LanguageType, language: &tokei::Language) -> usize {
+    __loc(language_type, language)
+        + language
+            .children
+            .iter()
+            .fold(0, |sum, (lang_type, reports)| {
+                sum + reports
+                    .iter()
+                    .fold(0, |sum, report| sum + stats_loc(lang_type, &report.stats))
+            })
+}
+
+/// Counts the lines-of-code of a tokei `Report`. This is the child of a
+/// `tokei::CodeStats`.
+pub fn stats_loc(language_type: &tokei::LanguageType, stats: &tokei::CodeStats) -> usize {
+    let stats = stats.summarise();
+    __stats_loc(language_type, &stats)
 }
 
 #[cfg(test)]

--- a/src/info/langs/language.tera
+++ b/src/info/langs/language.tera
@@ -5,7 +5,6 @@ use owo_colors::{
 use std::fmt;
 use std::fmt::Write;
 use strum::EnumIter;
-use tokei;
 
 pub struct Colors {
     basic_colors: Vec<DynColors>,
@@ -110,25 +109,18 @@ impl Language {
     }
 }
 
-/// Counts the lines-of-code of a tokei `Language`. Takes into
-/// account that a prose language's comments *are* its code.
-pub fn loc(language_type: &tokei::LanguageType, language: &tokei::Language) -> usize {
-    let loc = match language_type {
+fn __loc(language_type: &tokei::LanguageType, language: &tokei::Language) -> usize {
+    match language_type {
         {% for language, attrs in languages -%}
             {%- set line_types = attrs.line_types | default(value=['code']) -%}
             tokei::LanguageType::{{ language }} => language.{{ line_types.0 }}{% for line_type in line_types | slice(start=1) %} + language.{{ line_type }}{% endfor %},
         {% endfor %}
         _ => unimplemented!("Language Type {:?}", language_type),
-    };
-    loc + language.children.iter().fold(0, |sum, (lang_type, reports)| {
-        sum + reports.iter().fold(0, |sum, report| sum + stats_loc(lang_type, &report.stats))
-    })
+    }
 }
 
-/// Counts the lines-of-code of a tokei `Report`. This is the child of a
-/// `tokei::CodeStats`.
-pub fn stats_loc(language_type: &tokei::LanguageType, stats: &tokei::CodeStats) -> usize {
-    let stats = stats.summarise();
+
+fn __stats_loc(language_type: &tokei::LanguageType, stats: &tokei::CodeStats) -> usize {
     match language_type {
         {% for language, attrs in languages -%}
             {%- set line_types = attrs.line_types | default(value=['code']) -%}

--- a/src/info/langs/language.tera
+++ b/src/info/langs/language.tera
@@ -115,7 +115,7 @@ impl Language {
 pub fn loc(language_type: &tokei::LanguageType, language: &tokei::Language) -> usize {
     match language_type {
         {% for language, attrs in languages -%}
-            {%- set line_types = attrs.tokei_line_types | default(value=['code']) -%}
+            {%- set line_types = attrs.line_types | default(value=['code']) -%}
             tokei::LanguageType::{{ language }} => language.{{ line_types.0 }}{% for line_type in line_types | slice(start=1) %} + language.{{ line_type }}{% endfor %},
         {% endfor %}
         _ => unimplemented!("Language Type {:?}", language_type),

--- a/src/info/langs/language.tera
+++ b/src/info/langs/language.tera
@@ -128,14 +128,14 @@ pub fn loc(language_type: &tokei::LanguageType, language: &tokei::Language) -> u
 /// Counts the lines-of-code of a tokei `Report`. This is the child of a
 /// `tokei::CodeStats`.
 pub fn stats_loc(language_type: &tokei::LanguageType, stats: &tokei::CodeStats) -> usize {
-    let loc = match language_type {
+    let stats = stats.summarise();
+    match language_type {
         {% for language, attrs in languages -%}
             {%- set line_types = attrs.line_types | default(value=['code']) -%}
             tokei::LanguageType::{{ language }} => stats.{{ line_types.0 }}{% for line_type in line_types | slice(start=1) %} + stats.{{ line_type }}{% endfor %},
         {% endfor %}
         _ => unimplemented!("Language Type {:?}", language_type),
-    };
-    loc + stats.blobs.iter().fold(0, |sum, (lang_type, stats)| sum + stats_loc(lang_type, stats))
+    }
 }
 
 {% for language, attrs in languages -%}

--- a/src/info/langs/language.tera
+++ b/src/info/langs/language.tera
@@ -5,6 +5,7 @@ use owo_colors::{
 use std::fmt;
 use std::fmt::Write;
 use strum::EnumIter;
+use tokei;
 
 pub struct Colors {
     basic_colors: Vec<DynColors>,
@@ -106,6 +107,20 @@ impl Language {
                 Language::{{ language }} => Rgb({{ rgb.r }}, {{ rgb.g }}, {{ rgb.b }}),
             {% endfor %}
         }
+    }
+}
+
+/// Compiles the top-level lines-of-code of a tokei `Language`. Takes into
+/// account that a prose language's comments *are* its code.
+pub fn compile_tokei_loc(language_type: &tokei::LanguageType, language: &tokei::Language) -> usize {
+    match language_type {
+        {% for language, attrs in languages -%}
+            tokei::LanguageType::{{ language }} => {
+                {% set line_types = attrs.tokei_line_types | default(value=['code']) %}
+                language.{{ line_types.0 }}{% for line_type in line_types | slice(start=1) %} + language.{{ line_type }}{% endfor %}
+            },
+        {% endfor %}
+        _ => unimplemented!("Language Type {:?}", language_type),
     }
 }
 

--- a/src/info/langs/language.tera
+++ b/src/info/langs/language.tera
@@ -110,16 +110,32 @@ impl Language {
     }
 }
 
-/// Counts the top-level lines-of-code of a tokei `Language`. Takes into
+/// Counts the lines-of-code of a tokei `Language`. Takes into
 /// account that a prose language's comments *are* its code.
 pub fn loc(language_type: &tokei::LanguageType, language: &tokei::Language) -> usize {
-    match language_type {
+    let loc = match language_type {
         {% for language, attrs in languages -%}
             {%- set line_types = attrs.line_types | default(value=['code']) -%}
             tokei::LanguageType::{{ language }} => language.{{ line_types.0 }}{% for line_type in line_types | slice(start=1) %} + language.{{ line_type }}{% endfor %},
         {% endfor %}
         _ => unimplemented!("Language Type {:?}", language_type),
-    }
+    };
+    loc + language.children.iter().fold(0, |sum, (lang_type, reports)| {
+        sum + reports.iter().fold(0, |sum, report| sum + stats_loc(lang_type, &report.stats))
+    })
+}
+
+/// Counts the lines-of-code of a tokei `Report`. This is the child of a
+/// `tokei::CodeStats`.
+pub fn stats_loc(language_type: &tokei::LanguageType, stats: &tokei::CodeStats) -> usize {
+    let loc = match language_type {
+        {% for language, attrs in languages -%}
+            {%- set line_types = attrs.line_types | default(value=['code']) -%}
+            tokei::LanguageType::{{ language }} => stats.{{ line_types.0 }}{% for line_type in line_types | slice(start=1) %} + stats.{{ line_type }}{% endfor %},
+        {% endfor %}
+        _ => unimplemented!("Language Type {:?}", language_type),
+    };
+    loc + stats.blobs.iter().fold(0, |sum, (lang_type, stats)| sum + stats_loc(lang_type, stats))
 }
 
 {% for language, attrs in languages -%}

--- a/src/info/langs/language.tera
+++ b/src/info/langs/language.tera
@@ -110,9 +110,9 @@ impl Language {
     }
 }
 
-/// Compiles the top-level lines-of-code of a tokei `Language`. Takes into
+/// Counts the top-level lines-of-code of a tokei `Language`. Takes into
 /// account that a prose language's comments *are* its code.
-pub fn compile_tokei_loc(language_type: &tokei::LanguageType, language: &tokei::Language) -> usize {
+pub fn loc(language_type: &tokei::LanguageType, language: &tokei::Language) -> usize {
     match language_type {
         {% for language, attrs in languages -%}
             tokei::LanguageType::{{ language }} => {

--- a/src/info/langs/language.tera
+++ b/src/info/langs/language.tera
@@ -115,10 +115,8 @@ impl Language {
 pub fn loc(language_type: &tokei::LanguageType, language: &tokei::Language) -> usize {
     match language_type {
         {% for language, attrs in languages -%}
-            tokei::LanguageType::{{ language }} => {
-                {% set line_types = attrs.tokei_line_types | default(value=['code']) %}
-                language.{{ line_types.0 }}{% for line_type in line_types | slice(start=1) %} + language.{{ line_type }}{% endfor %}
-            },
+            {%- set line_types = attrs.tokei_line_types | default(value=['code']) -%}
+            tokei::LanguageType::{{ language }} => language.{{ line_types.0 }}{% for line_type in line_types | slice(start=1) %} + language.{{ line_type }}{% endfor %},
         {% endfor %}
         _ => unimplemented!("Language Type {:?}", language_type),
     }

--- a/src/info/langs/mod.rs
+++ b/src/info/langs/mod.rs
@@ -65,11 +65,9 @@ fn get_language_distribution(languages: &tokei::Languages) -> Option<HashMap<Lan
 }
 
 fn get_total_loc(languages: &tokei::Languages) -> usize {
-    languages
-        .values()
-        .collect::<Vec<&tokei::Language>>()
-        .iter()
-        .fold(0, |sum, val| sum + val.code)
+    languages.iter().fold(0, |sum, (lang_type, lang)| {
+        sum + language::loc(lang_type, lang)
+    })
 }
 
 fn get_statistics(

--- a/src/info/langs/mod.rs
+++ b/src/info/langs/mod.rs
@@ -31,23 +31,23 @@ fn get_language_distribution(languages: &tokei::Languages) -> Option<HashMap<Lan
     let mut language_distribution = HashMap::new();
 
     for (language_name, language) in languages.iter() {
-        let mut code = language::compile_tokei_loc(language_name, language);
+        let mut loc = language::loc(language_name, language);
 
         let has_children = !language.children.is_empty();
 
         if has_children {
             for reports in language.children.values() {
                 for stats in reports.iter().map(|r| r.stats.summarise()) {
-                    code += stats.code;
+                    loc += stats.code;
                 }
             }
         }
 
-        if code == 0 {
+        if loc == 0 {
             continue;
         }
 
-        language_distribution.insert(Language::from(*language_name), code as f64);
+        language_distribution.insert(Language::from(*language_name), loc as f64);
     }
 
     let total: f64 = language_distribution.values().sum();

--- a/src/info/langs/mod.rs
+++ b/src/info/langs/mod.rs
@@ -147,4 +147,29 @@ mod test {
         assert_eq!(language_distribution[&Language::JavaScript], 25_f64);
         assert_eq!(language_distribution[&Language::Markdown], 75_f64);
     }
+
+    #[test]
+    fn get_total_loc_counts_md_comments() {
+        let js = tokei::Language {
+            blanks: 25,
+            comments: 50,
+            code: 100,
+            ..Default::default()
+        };
+        let js_type = tokei::LanguageType::JavaScript;
+
+        let md = tokei::Language {
+            blanks: 50,
+            comments: 200,
+            code: 100,
+            ..Default::default()
+        };
+        let md_type = tokei::LanguageType::Markdown;
+
+        let mut languages = tokei::Languages::new();
+        languages.insert(js_type, js);
+        languages.insert(md_type, md);
+
+        assert_eq!(get_total_loc(&languages), 400);
+    }
 }

--- a/src/info/langs/mod.rs
+++ b/src/info/langs/mod.rs
@@ -162,4 +162,34 @@ mod test {
 
         assert_eq!(get_total_loc(&languages), 400);
     }
+
+    #[test]
+    fn deeply_nested_total_loc() {
+        let mut bash_code_stats = tokei::CodeStats::new();
+        // NOTE: When inside Markdown, comments should be counted as code
+        bash_code_stats.code = 5;
+        bash_code_stats.blanks = 1;
+        bash_code_stats.comments = 2;
+
+        let mut md_code_stats = tokei::CodeStats::new();
+        md_code_stats.code = 10;
+        md_code_stats.blanks = 2;
+        md_code_stats.comments = 4;
+        md_code_stats
+            .blobs
+            .insert(tokei::LanguageType::Bash, bash_code_stats);
+        // NOTE: This may break if tokei ever does more than just assign `name` to a field
+        let mut md_report = tokei::Report::new("/tmp/file.ipynb".into());
+        md_report.stats = md_code_stats;
+
+        let mut jupyter_notebook = tokei::Language::default();
+        jupyter_notebook
+            .children
+            .insert(tokei::LanguageType::Markdown, vec![md_report]);
+
+        let mut languages = tokei::Languages::new();
+        languages.insert(tokei::LanguageType::Jupyter, jupyter_notebook);
+
+        assert_eq!(get_total_loc(&languages), 21);
+    }
 }

--- a/src/info/langs/mod.rs
+++ b/src/info/langs/mod.rs
@@ -31,17 +31,7 @@ fn get_language_distribution(languages: &tokei::Languages) -> Option<HashMap<Lan
     let mut language_distribution = HashMap::new();
 
     for (language_name, language) in languages.iter() {
-        let mut loc = language::loc(language_name, language);
-
-        let has_children = !language.children.is_empty();
-
-        if has_children {
-            for reports in language.children.values() {
-                for stats in reports.iter().map(|r| r.stats.summarise()) {
-                    loc += stats.code;
-                }
-            }
-        }
+        let loc = language::loc(language_name, language);
 
         if loc == 0 {
             continue;


### PR DESCRIPTION
This allows an optional definition of the line type for a language. If it is defined, it will sum them together. Defaults to using `.code`. By using this definition, comments are included in the type of lines of code to be summed for Markdown and Jupyter Notebooks.

This also changes the summing of child languages to be recursive, so that deeply nested code (e.g. Bash in Markdown in Jupyter) can be counted.

Fixes #933