### PR TITLE
Fix path to language template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 /src/info/git.rs @Byron
 /src/info/repo @o2sh
 /languages.yaml @spenserblack @o2sh
-/templates/language.rs @spenserblack
+/src/info/langs/language.tera @spenserblack
 /src/cli.rs @spenserblack @o2sh
 /vercel/ @spenserblack


### PR DESCRIPTION
Codeowners file was pointing to an old path that doesn't exist.