### PR TITLE
Refactoring of `info/langs/mod.rs`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 /.github/ @spenserblack @o2sh
 /image/src/ @CephalonRho @yoichi
-/src/info/git.rs @Byron
-/src/info/repo/ @o2sh
+/src/info/utils/git.rs @Byron
+/src/info/ @o2sh
 /languages.yaml @spenserblack @o2sh
 /src/info/langs/language.tera @spenserblack
 /src/cli.rs @spenserblack @o2sh

--- a/src/info/langs/language.rs
+++ b/src/info/langs/language.rs
@@ -27,12 +27,24 @@ pub struct LanguagesInfo {
 
 impl LanguagesInfo {
     pub fn new(
-        languages: Vec<(Language, f64)>,
+        loc_by_language: &[(Language, usize)],
         true_color: bool,
         number_of_languages: usize,
         info_color: DynColors,
     ) -> Self {
-        let languages_with_percentage = languages
+        let total: usize = loc_by_language.iter().map(|(_, v)| v).sum();
+
+        let weight_by_language: Vec<(Language, f64)> = loc_by_language
+            .iter()
+            .map(|(k, v)| {
+                let mut val = *v as f64;
+                val /= total as f64;
+                val *= 100_f64;
+                (*k, val)
+            })
+            .collect();
+
+        let languages_with_percentage = weight_by_language
             .into_iter()
             .map(|(language, percentage)| LanguageWithPercentage {
                 language,

--- a/src/info/langs/mod.rs
+++ b/src/info/langs/mod.rs
@@ -12,6 +12,9 @@ pub fn get_main_language(loc_by_language: &[(Language, usize)]) -> Language {
     loc_by_language[0].0
 }
 
+/// Returns a vector of tuples containing all the languages detected inside the repository.
+/// Each tuple is composed of the language and its corresponding loc (lines of code).
+/// The vector is sorted by loc in descending order.
 pub fn get_loc_by_language_sorted(
     dir: &Path,
     ignored_directories: &[PathBuf],

--- a/src/info/langs/mod.rs
+++ b/src/info/langs/mod.rs
@@ -8,27 +8,34 @@ use strum::IntoEnumIterator;
 
 pub mod language;
 
-pub fn get_dominant_language(languages_stat_vec: &[(Language, f64)]) -> Language {
-    languages_stat_vec[0].0
+pub fn get_main_language(loc_by_language: &[(Language, usize)]) -> Language {
+    loc_by_language[0].0
 }
 
-pub fn get_language_statistics(
+pub fn get_loc_by_language_sorted(
     dir: &Path,
     ignored_directories: &[PathBuf],
     language_types: &[LanguageType],
     include_hidden: bool,
-) -> Result<(Vec<(Language, f64)>, usize)> {
+) -> Result<Vec<(Language, usize)>> {
     let stats = get_statistics(dir, ignored_directories, language_types, include_hidden);
-    let language_distribution = get_language_distribution(&stats)
-        .context("Could not find any source code in this repository")?;
-    let mut language_distribution_vec: Vec<(_, _)> = language_distribution.into_iter().collect();
-    language_distribution_vec.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap().reverse());
-    let loc = get_total_loc(&stats);
-    Ok((language_distribution_vec, loc))
+
+    let loc_by_language =
+        get_loc_by_language(&stats).context("Could not find any source code in this repository")?;
+
+    let loc_by_language_sorted = sort_by_loc(loc_by_language);
+
+    Ok(loc_by_language_sorted)
 }
 
-fn get_language_distribution(languages: &tokei::Languages) -> Option<HashMap<Language, f64>> {
-    let mut language_distribution = HashMap::new();
+fn sort_by_loc(map: HashMap<Language, usize>) -> Vec<(Language, usize)> {
+    let mut vec: Vec<(Language, usize)> = map.into_iter().collect();
+    vec.sort_by(|a, b| b.1.cmp(&a.1));
+    vec
+}
+
+fn get_loc_by_language(languages: &tokei::Languages) -> Option<HashMap<Language, usize>> {
+    let mut loc_by_language = HashMap::new();
 
     for (language_name, language) in languages.iter() {
         let loc = language::loc(language_name, language);
@@ -37,27 +44,20 @@ fn get_language_distribution(languages: &tokei::Languages) -> Option<HashMap<Lan
             continue;
         }
 
-        language_distribution.insert(Language::from(*language_name), loc as f64);
+        loc_by_language.insert(Language::from(*language_name), loc);
     }
 
-    let total: f64 = language_distribution.values().sum();
-
-    if total.abs() < f64::EPSILON {
+    let total_loc: usize = loc_by_language.values().sum();
+    if total_loc == 0 {
         None
     } else {
-        for (_, val) in language_distribution.iter_mut() {
-            *val /= total;
-            *val *= 100_f64;
-        }
-
-        Some(language_distribution)
+        Some(loc_by_language)
     }
 }
 
-fn get_total_loc(languages: &tokei::Languages) -> usize {
-    languages.iter().fold(0, |sum, (lang_type, lang)| {
-        sum + language::loc(lang_type, lang)
-    })
+pub fn get_total_loc(loc_by_language: &[(Language, usize)]) -> usize {
+    let total_loc: usize = loc_by_language.iter().map(|(_, v)| v).sum();
+    total_loc
 }
 
 fn get_statistics(
@@ -110,7 +110,7 @@ mod test {
     use tokei;
 
     #[test]
-    fn get_language_distribution_counts_md_comments() {
+    fn get_loc_by_language_counts_md_comments() {
         let js = tokei::Language {
             blanks: 25,
             comments: 50,
@@ -131,36 +131,11 @@ mod test {
         languages.insert(js_type, js);
         languages.insert(md_type, md);
 
-        let language_distribution = get_language_distribution(&languages).unwrap();
+        let loc_by_language = get_loc_by_language(&languages).unwrap();
 
-        // NOTE: JS is 25% with 100 lines of code, MD is 75% with 300 lines of code + comments
-        assert_eq!(language_distribution[&Language::JavaScript], 25_f64);
-        assert_eq!(language_distribution[&Language::Markdown], 75_f64);
-    }
-
-    #[test]
-    fn get_total_loc_counts_md_comments() {
-        let js = tokei::Language {
-            blanks: 25,
-            comments: 50,
-            code: 100,
-            ..Default::default()
-        };
-        let js_type = tokei::LanguageType::JavaScript;
-
-        let md = tokei::Language {
-            blanks: 50,
-            comments: 200,
-            code: 100,
-            ..Default::default()
-        };
-        let md_type = tokei::LanguageType::Markdown;
-
-        let mut languages = tokei::Languages::new();
-        languages.insert(js_type, js);
-        languages.insert(md_type, md);
-
-        assert_eq!(get_total_loc(&languages), 400);
+        // NOTE: JS  with 100 lines of code, MD with 300 lines of code + comments
+        assert_eq!(loc_by_language[&Language::JavaScript], 100);
+        assert_eq!(loc_by_language[&Language::Markdown], 300);
     }
 
     #[test]
@@ -190,6 +165,35 @@ mod test {
         let mut languages = tokei::Languages::new();
         languages.insert(tokei::LanguageType::Jupyter, jupyter_notebook);
 
-        assert_eq!(get_total_loc(&languages), 21);
+        let loc_by_language = get_loc_by_language(&languages).unwrap();
+
+        assert_eq!(loc_by_language[&Language::Jupyter], 21);
+    }
+
+    #[test]
+    fn test_get_loc_by_language_sorted() {
+        let mut map = HashMap::new();
+        map.insert(Language::Ada, 300);
+        map.insert(Language::Java, 40);
+        map.insert(Language::Rust, 1200);
+        map.insert(Language::Go, 8);
+
+        let sorted_map = sort_by_loc(map);
+
+        let expected_order = vec![
+            (Language::Rust, 1200),
+            (Language::Ada, 300),
+            (Language::Java, 40),
+            (Language::Go, 8),
+        ];
+        let actual_order: Vec<_> = sorted_map.into_iter().collect();
+
+        assert_eq!(expected_order, actual_order);
+    }
+
+    #[test]
+    fn test_get_total_loc() {
+        let loc_by_language = [(Language::JavaScript, 100), (Language::Markdown, 300)];
+        assert_eq!(get_total_loc(&loc_by_language), 400);
     }
 }

--- a/src/info/loc.rs
+++ b/src/info/loc.rs
@@ -1,3 +1,5 @@
+use crate::info::langs::get_total_loc;
+use crate::info::langs::language::Language;
 use serde::Serialize;
 
 use crate::{
@@ -17,7 +19,8 @@ pub struct LocInfo {
 }
 
 impl LocInfo {
-    pub fn new(lines_of_code: usize, number_separator: NumberSeparator) -> Self {
+    pub fn new(loc_by_language: &[(Language, usize)], number_separator: NumberSeparator) -> Self {
+        let lines_of_code = get_total_loc(loc_by_language);
         Self {
             lines_of_code,
             number_separator,

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -114,7 +114,7 @@ impl Info {
         let git_repo = git_repository::discover(&config.input)?;
         let repo_path = get_work_dir(&git_repo)?;
 
-        let loc_by_language_handle = std::thread::spawn({
+        let loc_by_language_sorted_handle = std::thread::spawn({
             let ignored_directories = config.exclude.clone();
             let language_types = config.r#type.clone();
             let include_hidden = config.include_hidden;
@@ -129,7 +129,7 @@ impl Info {
             }
         });
 
-        let loc_by_language = loc_by_language_handle
+        let loc_by_language = loc_by_language_sorted_handle
             .join()
             .ok()
             .context("BUG: panic in language statistics thread")??;

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -114,13 +114,13 @@ impl Info {
         let git_repo = git_repository::discover(&config.input)?;
         let repo_path = get_work_dir(&git_repo)?;
 
-        let languages_handle = std::thread::spawn({
+        let loc_by_language_handle = std::thread::spawn({
             let ignored_directories = config.exclude.clone();
             let language_types = config.r#type.clone();
             let include_hidden = config.include_hidden;
             let workdir = repo_path.clone();
             move || {
-                langs::get_language_statistics(
+                langs::get_loc_by_language_sorted(
                     &workdir,
                     &ignored_directories,
                     &language_types,
@@ -129,11 +129,11 @@ impl Info {
             }
         });
 
-        let (languages, lines_of_code) = languages_handle
+        let loc_by_language = loc_by_language_handle
             .join()
             .ok()
             .context("BUG: panic in language statistics thread")??;
-        let dominant_language = langs::get_dominant_language(&languages);
+        let dominant_language = langs::get_main_language(&loc_by_language);
         let true_color = match config.true_color {
             When::Always => true,
             When::Never => false,
@@ -178,7 +178,7 @@ impl Info {
         )?;
         let created = CreatedInfo::new(config.iso_time, &commits);
         let languages = LanguagesInfo::new(
-            languages,
+            &loc_by_language,
             true_color,
             config.number_of_languages,
             text_colors.info,
@@ -189,7 +189,7 @@ impl Info {
         let contributors =
             ContributorsInfo::new(&commits, config.number_of_authors, config.number_separator);
         let commits = CommitsInfo::new(&commits, config.number_separator);
-        let lines_of_code = LocInfo::new(lines_of_code, config.number_separator);
+        let lines_of_code = LocInfo::new(&loc_by_language, config.number_separator);
 
         let info_fields: Vec<Box<dyn InfoField>> = vec![
             Box::new(project),


### PR DESCRIPTION
Folllowing #937, I couldn't help but notice that [`info/langs/mod.rs`](https://github.com/o2sh/onefetch/blob/main/src/info/langs/mod.rs) could need some refactoring for better readability but also for performance reasons.

Covered in this PR:

- `language::loc`  is called only in `get_loc_by_language` and reused in `get_total_loc`
- Better naming for the methods and simplified signatures - up for discussion.
- Extract some of the code logic from [`info/langs/mod.rs`](https://github.com/o2sh/onefetch/blob/main/src/info/langs/mod.rs) into their respective info fields: [`LanguageInfo`](https://github.com/o2sh/onefetch/blob/main/src/info/langs/language.rs) and [`LocInfo`](https://github.com/o2sh/onefetch/blob/main/src/info/loc.rs)

