### PR TITLE
upgrade `git-repository` 0.30 to `gix` 0.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,74 +997,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-chunk"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3090baa2f4a3fe488a9b3e31090b83259aaf930bf0634af34c18117274f8f1a8"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
-name = "git-command"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6b98a6312fef79b326c0a6e15d576c2bd30f7f9d0b7964998d166049e0d7b9e"
-dependencies = [
- "bstr 1.0.1",
-]
-
-[[package]]
-name = "git-config"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff189268cfb19d5151529ac30b6b708072ebfa1075643d785232675456ec320"
-dependencies = [
- "bstr 1.0.1",
- "git-config-value",
- "git-features 0.25.1",
- "git-glob",
- "git-path",
- "git-ref",
- "git-sec",
- "memchr",
- "nom",
- "once_cell",
- "smallvec",
- "thiserror",
- "unicode-bom",
-]
-
-[[package]]
-name = "git-config-value"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989a90c1c630513a153c685b4249b96fdf938afc75bf7ef2ae1ccbd3d799f5db"
-dependencies = [
- "bitflags",
- "bstr 1.0.1",
- "git-path",
- "libc",
- "thiserror",
-]
-
-[[package]]
-name = "git-credentials"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28da3d029be10258007699d002321a3b1ebe45e67b0e140a4cf464ba3ee79b32"
-dependencies = [
- "bstr 1.0.1",
- "git-command",
- "git-config-value",
- "git-path",
- "git-prompt",
- "git-sec",
- "git-url",
- "thiserror",
-]
-
-[[package]]
 name = "git-date"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,18 +1006,6 @@ dependencies = [
  "itoa",
  "thiserror",
  "time",
-]
-
-[[package]]
-name = "git-diff"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f30011a43908645c492dfbea7b004e10528be6bd667bf5cdc12ff4297fe1e3c"
-dependencies = [
- "git-hash 0.10.1",
- "git-object",
- "imara-diff",
- "thiserror",
 ]
 
 [[package]]
@@ -1113,18 +1039,9 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f98e6ede7b790dfba16bf3c62861ae75c3719485d675b522cf7d7e748a4011c"
 dependencies = [
- "crc32fast",
- "crossbeam-channel",
- "crossbeam-utils",
- "flate2",
  "git-hash 0.10.1",
- "jwalk",
  "libc",
- "num_cpus",
- "once_cell",
- "parking_lot 0.12.1",
- "prodash",
- "quick-error",
+ "prodash 22.1.0",
  "sha1_smol",
  "walkdir",
 ]
@@ -1203,17 +1120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-mailmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90e3ee2eaeebda8a12d17f4d99dff5b19d81536476020bcebb99ee121820466"
-dependencies = [
- "bstr 1.0.1",
- "git-actor",
- "quick-error",
-]
-
-[[package]]
 name = "git-object"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,68 +1139,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-odb"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55333419bbb25aa6d39e29155f747ad8e1777fe385f70f447be9d680824d23dd"
-dependencies = [
- "arc-swap",
- "git-features 0.25.1",
- "git-hash 0.10.1",
- "git-object",
- "git-pack",
- "git-path",
- "git-quote",
- "parking_lot 0.12.1",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "git-pack"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed3c9af66949553af9795b9eac9d450a5bdceee9959352cda468997ddce0d2f"
-dependencies = [
- "bytesize",
- "clru",
- "dashmap 5.3.3",
- "git-chunk",
- "git-diff",
- "git-features 0.25.1",
- "git-hash 0.10.1",
- "git-hashtable",
- "git-object",
- "git-path",
- "git-tempfile",
- "git-traverse",
- "memmap2 0.5.3",
- "parking_lot 0.12.1",
- "smallvec",
- "thiserror",
- "uluru",
-]
-
-[[package]]
 name = "git-path"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e40e68481a06da243d3f4dfd86a4be39c24eefb535017a862e845140dcdb878a"
 dependencies = [
  "bstr 1.0.1",
- "thiserror",
-]
-
-[[package]]
-name = "git-prompt"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3612a486e507dd431ef0f7108eeaafc8fd1ed7bd0f205a88554f6f91fe5dccbf"
-dependencies = [
- "git-command",
- "git-config-value",
- "nix",
- "parking_lot 0.12.1",
  "thiserror",
 ]
 
@@ -1329,77 +1179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-refspec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d478e9db0956d60cd386d3348b5ec093e3ae613105a7a75ff6084b886254eba8"
-dependencies = [
- "bstr 1.0.1",
- "git-hash 0.10.1",
- "git-revision",
- "git-validate",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "git-repository"
-version = "0.30.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1925a65a9fea6587e969a7a85cb239c8e1e438cf6dc520406df1b4c9d0e83bdc"
-dependencies = [
- "git-actor",
- "git-attributes",
- "git-config",
- "git-credentials",
- "git-date",
- "git-diff",
- "git-discover",
- "git-features 0.25.1",
- "git-glob",
- "git-hash 0.10.1",
- "git-hashtable",
- "git-index",
- "git-lock",
- "git-mailmap",
- "git-object",
- "git-odb",
- "git-pack",
- "git-path",
- "git-prompt",
- "git-ref",
- "git-refspec",
- "git-revision",
- "git-sec",
- "git-tempfile",
- "git-traverse",
- "git-url",
- "git-validate",
- "git-worktree",
- "log",
- "once_cell",
- "prodash",
- "signal-hook",
- "smallvec",
- "thiserror",
- "unicode-normalization",
-]
-
-[[package]]
-name = "git-revision"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7516b1db551756b4d3176c4b7d18ccc4b79d35dcc5e74f768c90f5bb11bb6c9"
-dependencies = [
- "bstr 1.0.1",
- "git-date",
- "git-hash 0.10.1",
- "git-hashtable",
- "git-object",
- "thiserror",
-]
-
-[[package]]
 name = "git-sec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,7 +1188,7 @@ dependencies = [
  "dirs 4.0.0",
  "git-path",
  "libc",
- "windows",
+ "windows 0.40.0",
 ]
 
 [[package]]
@@ -1464,20 +1243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-url"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8651924c9692a778f09141ca44d1bf2dada229fe9b240f1ff1bdecd9621a1a93"
-dependencies = [
- "bstr 1.0.1",
- "git-features 0.25.1",
- "git-path",
- "home",
- "thiserror",
- "url",
-]
-
-[[package]]
 name = "git-validate"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1281,515 @@ dependencies = [
  "libgit2-sys",
  "log",
  "url",
+]
+
+[[package]]
+name = "gix"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9b72a4d85749e43bf83973dcbf5fdd1f1fa4a45c10ddec6927f2123a23dc4"
+dependencies = [
+ "gix-actor",
+ "gix-attributes",
+ "gix-config",
+ "gix-credentials",
+ "gix-date",
+ "gix-diff",
+ "gix-discover",
+ "gix-features",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-index",
+ "gix-lock",
+ "gix-mailmap",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-prompt",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-sec",
+ "gix-tempfile",
+ "gix-traverse",
+ "gix-url",
+ "gix-validate",
+ "gix-worktree",
+ "log",
+ "once_cell",
+ "prodash 23.0.0",
+ "signal-hook",
+ "smallvec",
+ "thiserror",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65310ccef7c317373401a301e76899b2721f07e2d683e35782a0f51a58d084a4"
+dependencies = [
+ "bstr 1.0.1",
+ "btoi",
+ "gix-date",
+ "itoa",
+ "nom",
+ "quick-error",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15e59e1331c21bae0cfc0c778470984691694c5ed24c1ea262c70e6d3d3c356"
+dependencies = [
+ "bstr 1.0.1",
+ "compact_str",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5229fd26e288f417c8dd2385c5bc740415eb55aba4d6f529db7ad4b526771e06"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d39583cab06464b8bf73b3f1707458270f0e7383cb24c3c9c1a16e6f792978"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94361dd657304ce572162fbee6172bf6521c0babf2f53aeaac298b99f2ac4ac5"
+dependencies = [
+ "bstr 1.0.1",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a860fb7af40f84bd10d0cd28c930c27b4a0d94bd9d22276010d5a396bf9fba"
+dependencies = [
+ "bstr 1.0.1",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "nom",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693d4a4ba0531e46fe558459557a5b29fb86c3e4b2666c1c0861d93c7c678331"
+dependencies = [
+ "bitflags",
+ "bstr 1.0.1",
+ "gix-path",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0ad88fc6f1569005f4b4413aa68be501280071679b5565c62e08b8955fdcfe7"
+dependencies = [
+ "bstr 1.0.1",
+ "gix-command",
+ "gix-config-value",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd587bf0e5bec82bc90a15436a1274ef162e7c184b152a515b544c356ce737fb"
+dependencies = [
+ "bstr 1.0.1",
+ "itoa",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec3351a6cec2ddca29c1124afef8b4f3fad0b617dce8916148153541468117c"
+dependencies = [
+ "gix-hash",
+ "gix-object",
+ "imara-diff",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a99111861b26cff75cbff262913eb8a153d87b54c6d59870f1e1cd10629c47"
+dependencies = [
+ "bstr 1.0.1",
+ "dunce",
+ "gix-hash",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "305ade1187cb77759f9f159efa294c774117108f5236b227a3912fa0e93e8f53"
+dependencies = [
+ "crc32fast",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "flate2",
+ "gix-hash",
+ "jwalk",
+ "libc",
+ "num_cpus",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "prodash 23.0.0",
+ "quick-error",
+ "sha1_smol",
+ "walkdir",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f30e5d3048e99c3a6d1c9663b6dad445927e3e22cf920400b8efe8d7d22cd6"
+dependencies = [
+ "bitflags",
+ "bstr 1.0.1",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2b2398b0ebd1124897573785bbe058ad1509007acffb6d5d06b34f22486b395"
+dependencies = [
+ "hex",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a256cceeea0f0d7f42a0c3ac649535644a04395d9f415518f4008ef6bb331b5"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.13.1",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a50c215cf1b9e75f0233f9da0c923d2f9c96c7716699bef4a254fa633852e6f"
+dependencies = [
+ "atoi",
+ "bitflags",
+ "bstr 1.0.1",
+ "filetime",
+ "gix-bitmap",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "itoa",
+ "memmap2 0.5.3",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-lock"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5fe84f09afadec78a7227d80f58cb5412d216dbae4b7fa060b619c0ce62b55d"
+dependencies = [
+ "fastrand",
+ "gix-tempfile",
+ "quick-error",
+]
+
+[[package]]
+name = "gix-mailmap"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c8cfd39c3918f49c89cf536ad31326f090497fc7d6a6ee1fb2f7ca6a2761c1"
+dependencies = [
+ "bstr 1.0.1",
+ "gix-actor",
+ "quick-error",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50aa6cef257ce5fdbadf233b5c4dde95372a3398c78dd797e8544fb2ca8340a7"
+dependencies = [
+ "bstr 1.0.1",
+ "btoi",
+ "gix-actor",
+ "gix-features",
+ "gix-hash",
+ "gix-validate",
+ "hex",
+ "itoa",
+ "nom",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd81ab7cd13c0f78bd619f967509953094f415288f8693dbb63a084e5bb39c4"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-hash",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot 0.12.1",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1195622bf4a834d51ce4a9a09babd2b007348ebd4f0259f03d651325fb1063c"
+dependencies = [
+ "bytesize",
+ "clru",
+ "dashmap 5.3.3",
+ "gix-chunk",
+ "gix-diff",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-traverse",
+ "memmap2 0.5.3",
+ "parking_lot 0.12.1",
+ "smallvec",
+ "thiserror",
+ "uluru",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20d65ea92e9d9164a9bf68b4f46a52046e4ebd672eba949fa4170b450874346a"
+dependencies = [
+ "bstr 1.0.1",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20cebf73229debaa82574c4fd20dcaf00fa8d4bfce823a862c4e990d7a0b5b4"
+dependencies = [
+ "gix-command",
+ "gix-config-value",
+ "nix",
+ "parking_lot 0.12.1",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34c4b760c94207ac759395f8bcd408a38fce36823e12914ba51ea36569995d6"
+dependencies = [
+ "bstr 1.0.1",
+ "btoi",
+ "quick-error",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec528dcabc49516a903938c12ed63e698edf8d0cca11ef1c62d625aee6e49d3"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-validate",
+ "memmap2 0.5.3",
+ "nom",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc671b994c4bb8b19456af831e8bcc83bfca308130cc8e205c7f87920a00d94f"
+dependencies = [
+ "bstr 1.0.1",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878e67f0b8da0cb7a5a18135bc2bc765a49ea3f98946618ad2d713be1036e8eb"
+dependencies = [
+ "bstr 1.0.1",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ffa5bf0772f9b01de501c035b6b084cf9b8bb07dec41e3afc6a17336a65f47"
+dependencies = [
+ "bitflags",
+ "dirs 4.0.0",
+ "gix-path",
+ "libc",
+ "windows 0.43.0",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48590cb5de0b8feadee42466a90028877ba67b9fd894c5493b4b64f5e3217c17"
+dependencies = [
+ "dashmap 5.3.3",
+ "libc",
+ "once_cell",
+ "signal-hook",
+ "signal-hook-registry",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7ee7eee98b6e196fba1f34751d4399e0daa4e61892a78f634d0901e52dd739b"
+dependencies = [
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c0b9b6db2b17e233e08051cb4b5fab9b1eb143e8ed51b1f2edb339ddb0334d"
+dependencies = [
+ "bstr 1.0.1",
+ "gix-features",
+ "gix-path",
+ "home",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ac70b5ec6aacd32d8dfac59e0f362f39df4668c230465af849451b896e2e68"
+dependencies = [
+ "bstr 1.0.1",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc853a942e802533a6b83fbef066d8a285fb61c94519a656e66204ab190902c9"
+dependencies = [
+ "bstr 1.0.1",
+ "gix-attributes",
+ "gix-features",
+ "gix-glob",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "io-close",
+ "thiserror",
 ]
 
 [[package]]
@@ -2148,9 +2422,9 @@ dependencies = [
  "criterion",
  "enable-ansi-support",
  "git-features 0.23.1",
- "git-repository",
  "git-testtools",
  "git2",
+ "gix",
  "human-panic",
  "image",
  "insta",
@@ -2515,6 +2789,16 @@ name = "prodash"
 version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2b91fcc982d0d8ae5e9d477561c73e09c24c5c19bac4858e202f6f065a13e"
+dependencies = [
+ "bytesize",
+ "human_format",
+]
+
+[[package]]
+name = "prodash"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8c414345b4a98cbcd0e8d8829c8f54b47a7ed4fb771c45b7c5c6c0ae23dc4c"
 dependencies = [
  "bytesize",
  "dashmap 5.3.3",
@@ -3453,6 +3737,21 @@ dependencies = [
  "windows_x86_64_gnu 0.40.0",
  "windows_x86_64_gnullvm 0.40.0",
  "windows_x86_64_msvc 0.40.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.0",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm 0.42.0",
+ "windows_x86_64_msvc 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ clap_complete = "4.1.0"
 git-features-for-configuration-only = { package = "git-features", version = "0.23.1", features = [
     "zlib-ng-compat",
 ] }
-git-repository = { version = "0.30.2", default-features = false, features = [
+gix = { version = "0.36.0", default-features = false, features = [
     "max-performance-safe",
 ] }
 git2 = { version = "0.16.1", default-features = false }

--- a/benches/repo.rs
+++ b/benches/repo.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use git_repository::{open, ThreadSafeRepository};
+use gix::{open, ThreadSafeRepository};
 use onefetch::{cli::Config, info::Info};
 
 fn bench_repo_info(c: &mut Criterion) {

--- a/src/info/author.rs
+++ b/src/info/author.rs
@@ -6,7 +6,6 @@ use crate::{
         utils::info_field::{InfoField, InfoType},
     },
 };
-use git_repository as git;
 use owo_colors::{DynColors, OwoColorize};
 use serde::Serialize;
 use std::fmt::Write;
@@ -26,8 +25,8 @@ pub struct Author {
 
 impl Author {
     pub fn new(
-        name: git::bstr::BString,
-        email: git::bstr::BString,
+        name: gix::bstr::BString,
+        email: gix::bstr::BString,
         nbr_of_commits: usize,
         total_nbr_of_commits: usize,
         show_email: bool,

--- a/src/info/contributors.rs
+++ b/src/info/contributors.rs
@@ -59,7 +59,7 @@ mod test {
     #[test]
     fn test_display_contributors_info() {
         use crate::info::utils::git::Commits;
-        use git_repository::actor::Time;
+        use gix::actor::Time;
 
         let timestamp = Time::now_utc();
         let commits = Commits {

--- a/src/info/head.rs
+++ b/src/info/head.rs
@@ -1,6 +1,6 @@
 use crate::info::utils::info_field::{InfoField, InfoType};
 use anyhow::{Context, Result};
-use git_repository::{reference::Category, Reference, Repository};
+use gix::{reference::Category, Reference, Repository};
 use serde::Serialize;
 
 #[derive(Serialize)]

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -111,7 +111,7 @@ impl std::fmt::Display for Info {
 
 impl Info {
     pub fn new(config: &Config) -> Result<Self> {
-        let git_repo = git_repository::discover(&config.input)?;
+        let git_repo = gix::discover(&config.input)?;
         let repo_path = get_work_dir(&git_repo)?;
 
         let loc_by_language_sorted_handle = std::thread::spawn({
@@ -267,7 +267,7 @@ fn get_manifest(repo_path: &Path) -> Result<Option<Manifest>> {
     }
 }
 
-pub fn get_work_dir(repo: &git_repository::Repository) -> Result<std::path::PathBuf> {
+pub fn get_work_dir(repo: &gix::Repository) -> Result<std::path::PathBuf> {
     Ok(repo
         .work_dir()
         .context("please run onefetch inside of a non-bare git repository")?

--- a/src/info/pending.rs
+++ b/src/info/pending.rs
@@ -1,7 +1,7 @@
 use crate::info::utils::info_field::{InfoField, InfoType};
 use anyhow::Result;
 use git2::{Status, StatusOptions, StatusShow};
-use git_repository::Repository;
+use gix::Repository;
 use serde::Serialize;
 
 #[derive(Serialize)]

--- a/src/info/project.rs
+++ b/src/info/project.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 use anyhow::Result;
-use git_repository::{bstr::ByteSlice, Repository};
+use gix::{bstr::ByteSlice, Repository};
 use onefetch_manifest::Manifest;
 use serde::Serialize;
 use std::ffi::OsStr;
@@ -44,8 +44,8 @@ fn get_repo_name(repo_url: &str, manifest: Option<&Manifest>) -> Result<String> 
     if repo_url.is_empty() {
         return Ok(String::default());
     }
-    let url = git_repository::url::parse(repo_url.into())?;
-    let path = git_repository::path::from_bstr(url.path.as_bstr());
+    let url = gix::url::parse(repo_url.into())?;
+    let path = gix::path::from_bstr(url.path.as_bstr());
     let repo_name = path
         .with_extension("")
         .file_name()

--- a/src/info/size.rs
+++ b/src/info/size.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 use byte_unit::Byte;
-use git_repository::Repository;
+use gix::Repository;
 use serde::Serialize;
 
 #[derive(Serialize)]

--- a/src/info/title.rs
+++ b/src/info/title.rs
@@ -1,6 +1,6 @@
 use super::get_style;
 use crate::cli;
-use git_repository::Repository;
+use gix::Repository;
 use owo_colors::{DynColors, OwoColorize};
 use serde::Serialize;
 
@@ -41,6 +41,8 @@ impl Title {
 }
 pub fn get_git_username(repo: &Repository) -> String {
     repo.committer()
+        .map(Result::ok)
+        .flatten()
         .map(|c| c.name.to_string())
         .unwrap_or_default()
 }
@@ -86,7 +88,7 @@ impl std::fmt::Display for Title {
 mod tests {
     use super::*;
     use anyhow::Result;
-    use git_repository::{open, Repository, ThreadSafeRepository};
+    use gix::{open, Repository, ThreadSafeRepository};
     use owo_colors::AnsiColors;
 
     fn repo(name: &str) -> Result<Repository> {

--- a/src/info/url.rs
+++ b/src/info/url.rs
@@ -1,6 +1,6 @@
 use crate::info::utils::info_field::{InfoField, InfoType};
 use anyhow::Result;
-use git_repository::Repository;
+use gix::Repository;
 use serde::Serialize;
 
 #[derive(Serialize)]

--- a/src/info/utils/git.rs
+++ b/src/info/utils/git.rs
@@ -1,9 +1,8 @@
 use crate::cli::{MyRegex, NumberSeparator};
 use crate::info::author::Author;
 use anyhow::Result;
-use git::bstr::BString;
-use git_repository as git;
-use git_repository::bstr::ByteSlice;
+use gix::bstr::BString;
+use gix::bstr::ByteSlice;
 use regex::Regex;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -14,25 +13,25 @@ pub struct Commits {
     pub num_commits: usize,
     /// false if we have found the first commit that started it all, true if the repository is shallow.
     pub is_shallow: bool,
-    pub time_of_most_recent_commit: git::actor::Time,
-    pub time_of_first_commit: git::actor::Time,
+    pub time_of_most_recent_commit: gix::actor::Time,
+    pub time_of_first_commit: gix::actor::Time,
 }
 
 #[derive(Hash, PartialOrd, Ord, Eq, PartialEq)]
 pub struct Sig {
-    name: git::bstr::BString,
-    email: git::bstr::BString,
+    name: gix::bstr::BString,
+    email: gix::bstr::BString,
 }
 
-impl From<git::actor::Signature> for Sig {
-    fn from(git::actor::Signature { name, email, .. }: git::actor::Signature) -> Self {
+impl From<gix::actor::Signature> for Sig {
+    fn from(gix::actor::Signature { name, email, .. }: gix::actor::Signature) -> Self {
         Self { name, email }
     }
 }
 
 impl Commits {
     pub fn new(
-        mut repo: git::Repository,
+        mut repo: gix::Repository,
         no_merges: bool,
         no_bots: &Option<Option<MyRegex>>,
         number_of_authors_to_display: usize,

--- a/src/info/utils/mod.rs
+++ b/src/info/utils/mod.rs
@@ -1,4 +1,4 @@
-use git_repository::actor::Time;
+use gix::actor::Time;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use time_humanize::HumanTime;
 

--- a/src/info/version.rs
+++ b/src/info/version.rs
@@ -1,6 +1,6 @@
 use crate::info::utils::info_field::{InfoField, InfoType};
 use anyhow::Result;
-use git_repository::Repository;
+use gix::Repository;
 use onefetch_manifest::Manifest;
 use serde::Serialize;
 

--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use git_repository::{open, Repository, ThreadSafeRepository};
+use gix::{open, Repository, ThreadSafeRepository};
 use onefetch::cli::Config;
 use onefetch::info::{get_work_dir, Info};
 


### PR DESCRIPTION
This upgrade is mainly to benefit from the new names of all `git-*` crates which now share the `gix-` prefix, with `gix` naturally being what was formerly `git-repository`.

Now there is no need anymore to rename crates in order to get the `git` namespace, instead we refer to `gitoxide` as `gix` from the get-go.
