### PR TITLE
Add Coldfusion and ColdfusionScript support

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -291,6 +291,56 @@ CoffeeScript:
     ansi:
       - red
     chip: "#244776"
+ColdFusion:
+  type: programming
+  ascii: |
+    {0}CfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCf
+    {0}Cf                                    Cf
+    {0}Cf                                    Cf
+    {0}Cf                         CfCfCfCf   Cf
+    {0}Cf       CfCfCfCfCf     CfCfCfCfCf    Cf
+    {0}Cf      CfCfCfCfCf     CfCf           Cf
+    {0}Cf     CfCf           CfCf            Cf
+    {0}Cf    CfCf         CfCfCfCfCfCf       Cf
+    {0}Cf    CfCf            CfCf            Cf
+    {0}Cf    CfCf            CfCf            Cf
+    {0}Cf     CfCf           CfCf            Cf
+    {0}Cf      CfCfCfCfCf    CfCf            Cf
+    {0}Cf       CfCfCfCfCf   CfCf            Cf
+    {0}Cf                                    Cf
+    {0}Cf                                    Cf
+    {0}CfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCf
+  colors:
+    ansi:
+      - Cyan
+    hex:
+      - "#DFF0FD"
+    chip: "#ed2cd6"
+ColdFusionScript:
+  type: programming
+  ascii: |
+    {0}CfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCf
+    {0}Cf                                    Cf
+    {0}Cf                                    Cf
+    {0}Cf                         CfCfCfCf   Cf
+    {0}Cf       CfCfCfCfCf     CfCfCfCfCf    Cf
+    {0}Cf      CfCfCfCfCf     CfCf           Cf
+    {0}Cf     CfCf           CfCf            Cf
+    {0}Cf    CfCf         CfCfCfCfCfCf       Cf
+    {0}Cf    CfCf            CfCf            Cf
+    {0}Cf    CfCf            CfCf            Cf
+    {0}Cf     CfCf           CfCf            Cf
+    {0}Cf      CfCfCfCfCf    CfCf            Cf
+    {0}Cf       CfCfCfCfCf   CfCf            Cf
+    {0}Cf                                    Cf
+    {0}Cf                                    Cf
+    {0}CfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCfCf
+  colors:
+    ansi:
+      - Cyan
+    hex:
+      - "#DFF0FD"
+    chip: "#ed2cd6"
 Coq:
   type: programming
   ascii: |


### PR DESCRIPTION
Adds support for ColdFusion.
In Linguist and Tokei, they have "ColdFusion" and "ColdFusionScript" that collectively cover all ColdFusion files. 
Figured same ASCII art for both is ok. Open to suggestions and feedback though!

Supports this issue: https://github.com/o2sh/onefetch/issues/490
