### PR TITLE
add help sections

### DIFF
--- a/benches/repo.rs
+++ b/benches/repo.rs
@@ -1,12 +1,12 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use gix::{open, ThreadSafeRepository};
-use onefetch::{cli::Config, info::Info};
+use onefetch::{cli::CliOptions, info::Info};
 
 fn bench_repo_info(c: &mut Criterion) {
     let name = "repo.sh".to_string();
     let repo_path = gix_testtools::scripted_fixture_read_only(name).unwrap();
     let repo = ThreadSafeRepository::open_opts(repo_path, open::Options::isolated()).unwrap();
-    let config: Config = Config {
+    let config: CliOptions = CliOptions {
         input: repo.path().to_path_buf(),
         ..Default::default()
     };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ use strum::IntoEnumIterator;
 const COLOR_RESOLUTIONS: [&str; 5] = ["16", "32", "64", "128", "256"];
 
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
-#[command(version, about)]
+#[command(disable_help_flag = true, about)]
 pub struct CliOptions {
     /// Run as if onefetch was started in <input> instead of the current working directory
     #[arg(default_value = ".", hide_default_value = true, value_hint = ValueHint::DirPath)]
@@ -137,8 +137,8 @@ pub struct ImageCliOptions {
     /// Path to the IMAGE file
     #[arg(long, short, value_hint = ValueHint::FilePath)]
     pub image: Option<PathBuf>,
-    /// Which image protocol to use
-    #[arg(long, value_enum, requires = "image")]
+    /// Which image PROTOCOL to use
+    #[arg(long, value_enum, requires = "image", value_name = "PROTOCOL")]
     pub image_protocol: Option<ImageProtocol>,
     /// VALUE of color resolution to use with SIXEL backend
     #[arg(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ use strum::IntoEnumIterator;
 const COLOR_RESOLUTIONS: [&str; 5] = ["16", "32", "64", "128", "256"];
 
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
-#[command(version, about, long_about = None, rename_all = "kebab-case")]
+#[command(version, about)]
 pub struct CliOptions {
     /// Run as if onefetch was started in <input> instead of the current working directory
     #[arg(default_value = ".", hide_default_value = true, value_hint = ValueHint::DirPath)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use crate::ui::printer::SerializationFormat;
 use anyhow::Result;
 use clap::builder::PossibleValuesParser;
 use clap::builder::TypedValueParser as _;
-use clap::{value_parser, Command, Parser, ValueHint};
+use clap::{value_parser, Args, Command, Parser, ValueHint};
 use clap_complete::{generate, Generator, Shell};
 use num_format::CustomFormat;
 use onefetch_image::ImageProtocol;
@@ -21,37 +21,29 @@ const COLOR_RESOLUTIONS: [&str; 5] = ["16", "32", "64", "128", "256"];
 
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
 #[command(version, about, long_about = None, rename_all = "kebab-case")]
-pub struct Config {
+pub struct CliOptions {
     /// Run as if onefetch was started in <input> instead of the current working directory
     #[arg(default_value = ".", hide_default_value = true, value_hint = ValueHint::DirPath)]
     pub input: PathBuf,
-    /// Takes a non-empty STRING as input to replace the ASCII logo
-    ///
-    /// It is possible to pass a generated STRING by command substitution
-    ///
-    /// For example:
-    ///
-    /// '--ascii-input "$(fortune | cowsay -W 25)"'
-    #[arg(long, value_name = "STRING", value_hint = ValueHint::CommandString)]
-    pub ascii_input: Option<String>,
-    /// Which LANGUAGE's ascii art to print
-    #[arg(
-        long,
-        short,
-        value_name = "LANGUAGE",
-        value_enum,
-        hide_possible_values = true
-    )]
-    pub ascii_language: Option<Language>,
-    /// Colors (X X X...) to print the ascii art
-    #[arg(
-        long,
-        num_args = 1..,
-        value_name = "X",
-        short = 'c',
-        value_parser = value_parser!(u8).range(..16),
-    )]
-    pub ascii_colors: Vec<u8>,
+    #[command(flatten)]
+    pub info: InfoCliOptions,
+    #[command(flatten)]
+    pub text_formatting: TextForamttingCliOptions,
+    #[command(flatten)]
+    pub color_blocks: ColorBlocksCliOptions,
+    #[command(flatten)]
+    pub ascii: AsciiCliOptions,
+    #[command(flatten)]
+    pub image: ImageCliOptions,
+    #[command(flatten)]
+    pub developer: DeveloperCliOptions,
+    #[command(flatten)]
+    pub other: OtherCliOptions,
+}
+
+#[derive(Clone, Debug, Args, PartialEq, Eq)]
+#[command(next_help_heading = "INFO")]
+pub struct InfoCliOptions {
     /// Allows you to disable FIELD(s) from appearing in the output
     #[arg(
         long,
@@ -62,6 +54,86 @@ pub struct Config {
         value_name = "FIELD"
     )]
     pub disabled_fields: Vec<InfoType>,
+    /// Hides the title
+    #[arg(long)]
+    pub no_title: bool,
+    /// Maximum NUM of authors to be shown
+    #[arg(long, default_value_t = 3usize, value_name = "NUM")]
+    pub number_of_authors: usize,
+    /// Maximum NUM of languages to be shown
+    #[arg(long, default_value_t = 6usize, value_name = "NUM")]
+    pub number_of_languages: usize,
+    /// Ignore all files & directories matching EXCLUDE
+    #[arg(long, short, num_args = 1.., value_hint = ValueHint::AnyPath)]
+    pub exclude: Vec<PathBuf>,
+    /// Exclude [bot] commits. Use <REGEX> to override the default pattern
+    #[arg(long, value_name = "REGEX")]
+    pub no_bots: Option<Option<MyRegex>>,
+    /// Ignores merge commits
+    #[arg(long)]
+    pub no_merges: bool,
+    /// Show the email address of each author
+    #[arg(long, short = 'E')]
+    pub email: bool,
+    /// Count hidden files and directories
+    #[arg(long)]
+    pub include_hidden: bool,
+    /// Filters output by language type
+    #[arg(
+        long,
+        num_args = 1..,
+        default_values = &["programming", "markup"],
+        short = 'T',
+        value_enum,
+    )]
+    pub r#type: Vec<LanguageType>,
+}
+
+#[derive(Clone, Debug, Args, PartialEq, Eq)]
+#[command(next_help_heading = "ASCII")]
+pub struct AsciiCliOptions {
+    /// Takes a non-empty STRING as input to replace the ASCII logo
+    ///
+    /// It is possible to pass a generated STRING by command substitution
+    ///
+    /// For example:
+    ///
+    /// '--ascii-input "$(fortune | cowsay -W 25)"'
+    #[arg(long, value_name = "STRING", value_hint = ValueHint::CommandString)]
+    pub ascii_input: Option<String>,
+    /// Colors (X X X...) to print the ascii art
+    #[arg(
+        long,
+        num_args = 1..,
+        value_name = "X",
+        short = 'c',
+        value_parser = value_parser!(u8).range(..16),
+    )]
+    pub ascii_colors: Vec<u8>,
+    /// Which LANGUAGE's ascii art to print
+    #[arg(
+        long,
+        short,
+        value_name = "LANGUAGE",
+        value_enum,
+        hide_possible_values = true
+    )]
+    pub ascii_language: Option<Language>,
+    /// Specify when to use true color
+    ///
+    /// If set to auto: true color will be enabled if supported by the terminal
+    #[arg(long, default_value = "auto", value_name = "WHEN", value_enum)]
+    pub true_color: When,
+    /// Specify when to show the logo
+    ///
+    /// If set to auto: the logo will be hidden if the terminal's width < 95
+    #[arg(long, default_value = "always", value_name = "WHEN", value_enum)]
+    pub show_logo: When,
+}
+
+#[derive(Clone, Debug, Args, PartialEq, Eq, Default)]
+#[command(next_help_heading = "IMAGE")]
+pub struct ImageCliOptions {
     /// Path to the IMAGE file
     #[arg(long, short, value_hint = ValueHint::FilePath)]
     pub image: Option<PathBuf>,
@@ -78,49 +150,20 @@ pub struct Config {
             .map(|s| s.parse::<usize>().unwrap())
     )]
     pub color_resolution: usize,
-    /// Turns off bold formatting
-    #[arg(long)]
-    pub no_bold: bool,
-    /// Ignores merge commits
-    #[arg(long)]
-    pub no_merges: bool,
-    /// Hides the color palette
-    #[arg(long)]
-    pub no_color_palette: bool,
-    /// Hides the title
-    #[arg(long)]
-    pub no_title: bool,
-    /// Maximum NUM of authors to be shown
-    #[arg(long, default_value_t = 3usize, value_name = "NUM")]
-    pub number_of_authors: usize,
-    /// Maximum NUM of languages to be shown
-    #[arg(long, default_value_t = 6usize, value_name = "NUM")]
-    pub number_of_languages: usize,
-    /// Ignore all files & directories matching EXCLUDE
-    #[arg(long, short, num_args = 1.., value_hint = ValueHint::AnyPath)]
-    pub exclude: Vec<PathBuf>,
-    /// Exclude [bot] commits. Use <REGEX> to override the default pattern
-    #[arg(long, value_name = "REGEX")]
-    pub no_bots: Option<Option<MyRegex>>,
-    /// Prints out supported languages
-    #[arg(long, short)]
-    pub languages: bool,
-    /// Prints out supported package managers
-    #[arg(long, short)]
-    pub package_managers: bool,
-    /// Outputs Onefetch in a specific format
-    #[arg(long, short, value_name = "FORMAT", value_enum)]
-    pub output: Option<SerializationFormat>,
-    /// Specify when to use true color
-    ///
-    /// If set to auto: true color will be enabled if supported by the terminal
-    #[arg(long, default_value = "auto", value_name = "WHEN", value_enum)]
-    pub true_color: When,
-    /// Specify when to show the logo
-    ///
-    /// If set to auto: the logo will be hidden if the terminal's width < 95
-    #[arg(long, default_value = "always", value_name = "WHEN", value_enum)]
-    pub show_logo: When,
+}
+
+#[derive(Clone, Debug, Args, PartialEq, Eq)]
+#[command(next_help_heading = "TEXT FORMATTING")]
+pub struct TextForamttingCliOptions {
+    /// Colors (X X X...) to print the ascii art
+    #[arg(
+        long,
+        num_args = 1..,
+        value_name = "X",
+        short = 'c',
+        value_parser = value_parser!(u8).range(..16),
+    )]
+    pub ascii_colors: Vec<u8>,
     /// Changes the text colors (X X X...)
     ///
     /// Goes in order of title, ~, underline, subtitle, colon, and info
@@ -142,57 +185,92 @@ pub struct Config {
     /// Which thousands SEPARATOR to use
     #[arg(long, value_name = "SEPARATOR", default_value = "plain", value_enum)]
     pub number_separator: NumberSeparator,
-    /// Show the email address of each author
-    #[arg(long, short = 'E')]
-    pub email: bool,
-    /// Count hidden files and directories
+    /// Turns off bold formatting
     #[arg(long)]
-    pub include_hidden: bool,
-    /// Filters output by language type
-    #[arg(
-        long,
-        num_args = 1..,
-        default_values = &["programming", "markup"],
-        short = 'T',
-        value_enum,
-    )]
-    pub r#type: Vec<LanguageType>,
+    pub no_bold: bool,
+}
+#[derive(Clone, Debug, Args, PartialEq, Eq, Default)]
+#[command(next_help_heading = "COLOR BLOCKS")]
+pub struct ColorBlocksCliOptions {
+    /// Hides the color palette
+    #[arg(long)]
+    pub no_color_palette: bool,
+}
+
+#[derive(Clone, Debug, Args, PartialEq, Eq, Default)]
+#[command(next_help_heading = "DEVELOPER")]
+pub struct DeveloperCliOptions {
+    /// Outputs Onefetch in a specific format
+    #[arg(long, short, value_name = "FORMAT", value_enum)]
+    pub output: Option<SerializationFormat>,
     /// If provided, outputs the completion file for given SHELL
     #[arg(long = "generate", value_name = "SHELL", value_enum)]
     pub completion: Option<Shell>,
 }
 
-impl Default for Config {
-    fn default() -> Config {
-        Config {
+#[derive(Clone, Debug, Args, PartialEq, Eq, Default)]
+#[command(next_help_heading = "OTHER")]
+pub struct OtherCliOptions {
+    /// Prints out supported languages
+    #[arg(long, short)]
+    pub languages: bool,
+    /// Prints out supported package managers
+    #[arg(long, short)]
+    pub package_managers: bool,
+}
+
+impl Default for CliOptions {
+    fn default() -> CliOptions {
+        CliOptions {
             input: PathBuf::from("."),
-            ascii_input: Default::default(),
-            ascii_language: Default::default(),
-            ascii_colors: Default::default(),
-            disabled_fields: Default::default(),
-            image: Default::default(),
-            image_protocol: Default::default(),
-            color_resolution: 16,
-            no_bold: Default::default(),
-            no_merges: Default::default(),
-            no_color_palette: Default::default(),
-            no_title: Default::default(),
+            info: InfoCliOptions::default(),
+            text_formatting: TextForamttingCliOptions::default(),
+            color_blocks: ColorBlocksCliOptions::default(),
+            ascii: AsciiCliOptions::default(),
+            image: ImageCliOptions::default(),
+            developer: DeveloperCliOptions::default(),
+            other: OtherCliOptions::default(),
+        }
+    }
+}
+
+impl Default for InfoCliOptions {
+    fn default() -> Self {
+        InfoCliOptions {
             number_of_authors: 3,
             number_of_languages: 6,
             exclude: Default::default(),
             no_bots: Default::default(),
-            languages: Default::default(),
-            package_managers: Default::default(),
-            output: Default::default(),
-            true_color: When::Auto,
-            show_logo: When::Always,
-            text_colors: Default::default(),
-            iso_time: Default::default(),
-            number_separator: NumberSeparator::Plain,
+            no_merges: Default::default(),
             email: Default::default(),
             include_hidden: Default::default(),
             r#type: vec![LanguageType::Programming, LanguageType::Markup],
-            completion: Default::default(),
+            disabled_fields: Default::default(),
+            no_title: Default::default(),
+        }
+    }
+}
+
+impl Default for TextForamttingCliOptions {
+    fn default() -> Self {
+        TextForamttingCliOptions {
+            ascii_colors: Default::default(),
+            text_colors: Default::default(),
+            iso_time: Default::default(),
+            number_separator: NumberSeparator::Plain,
+            no_bold: Default::default(),
+        }
+    }
+}
+
+impl Default for AsciiCliOptions {
+    fn default() -> Self {
+        AsciiCliOptions {
+            ascii_input: Default::default(),
+            ascii_colors: Default::default(),
+            ascii_language: Default::default(),
+            true_color: When::Auto,
+            show_logo: When::Always,
         }
     }
 }
@@ -272,26 +350,35 @@ mod test {
 
     #[test]
     fn test_default_config() {
-        let config: Config = Default::default();
-        assert_eq!(config, Config::parse_from(&["onefetch"]))
+        let config: CliOptions = Default::default();
+        assert_eq!(config, CliOptions::parse_from(&["onefetch"]))
     }
 
     #[test]
     fn test_custom_config() {
-        let config: Config = Config {
-            number_of_authors: 4,
+        let config: CliOptions = CliOptions {
             input: PathBuf::from("/tmp/folder"),
-            no_merges: true,
-            ascii_colors: vec![5, 0],
-            disabled_fields: vec![InfoType::Version, InfoType::URL],
-            show_logo: When::Never,
-            ascii_language: Some(Language::Lisp),
+            info: InfoCliOptions {
+                number_of_authors: 4,
+                no_merges: true,
+                disabled_fields: vec![InfoType::Version, InfoType::URL],
+                ..Default::default()
+            },
+            text_formatting: TextForamttingCliOptions {
+                ascii_colors: vec![5, 0],
+                ..Default::default()
+            },
+            ascii: AsciiCliOptions {
+                show_logo: When::Never,
+                ascii_language: Some(Language::Lisp),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
         assert_eq!(
             config,
-            Config::parse_from(&[
+            CliOptions::parse_from(&[
                 "onefetch",
                 "/tmp/folder",
                 "--number-of-authors",
@@ -313,22 +400,22 @@ mod test {
 
     #[test]
     fn test_config_with_image_protocol_but_no_image() {
-        assert!(Config::try_parse_from(&["onefetch", "--image-protocol", "sixel"]).is_err())
+        assert!(CliOptions::try_parse_from(&["onefetch", "--image-protocol", "sixel"]).is_err())
     }
 
     #[test]
     fn test_config_with_color_resolution_but_no_image() {
-        assert!(Config::try_parse_from(&["onefetch", "--color-resolution", "32"]).is_err())
+        assert!(CliOptions::try_parse_from(&["onefetch", "--color-resolution", "32"]).is_err())
     }
 
     #[test]
     fn test_config_with_ascii_colors_but_out_of_bounds() {
-        assert!(Config::try_parse_from(&["onefetch", "--ascii-colors", "17"]).is_err())
+        assert!(CliOptions::try_parse_from(&["onefetch", "--ascii-colors", "17"]).is_err())
     }
 
     #[test]
     fn test_config_with_text_colors_but_out_of_bounds() {
-        assert!(Config::try_parse_from(&["onefetch", "--text-colors", "17"]).is_err())
+        assert!(CliOptions::try_parse_from(&["onefetch", "--text-colors", "17"]).is_err())
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -131,7 +131,7 @@ pub struct AsciiCliOptions {
     pub show_logo: When,
 }
 
-#[derive(Clone, Debug, Args, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, Args, PartialEq, Eq)]
 #[command(next_help_heading = "IMAGE")]
 pub struct ImageCliOptions {
     /// Path to the IMAGE file
@@ -155,15 +155,6 @@ pub struct ImageCliOptions {
 #[derive(Clone, Debug, Args, PartialEq, Eq)]
 #[command(next_help_heading = "TEXT FORMATTING")]
 pub struct TextForamttingCliOptions {
-    /// Colors (X X X...) to print the ascii art
-    #[arg(
-        long,
-        num_args = 1..,
-        value_name = "X",
-        short = 'c',
-        value_parser = value_parser!(u8).range(..16),
-    )]
-    pub ascii_colors: Vec<u8>,
     /// Changes the text colors (X X X...)
     ///
     /// Goes in order of title, ~, underline, subtitle, colon, and info
@@ -254,7 +245,6 @@ impl Default for InfoCliOptions {
 impl Default for TextForamttingCliOptions {
     fn default() -> Self {
         TextForamttingCliOptions {
-            ascii_colors: Default::default(),
             text_colors: Default::default(),
             iso_time: Default::default(),
             number_separator: NumberSeparator::Plain,
@@ -271,6 +261,15 @@ impl Default for AsciiCliOptions {
             ascii_language: Default::default(),
             true_color: When::Auto,
             show_logo: When::Always,
+        }
+    }
+}
+impl Default for ImageCliOptions {
+    fn default() -> Self {
+        ImageCliOptions {
+            image: Default::default(),
+            image_protocol: Default::default(),
+            color_resolution: 16,
         }
     }
 }
@@ -364,11 +363,8 @@ mod test {
                 disabled_fields: vec![InfoType::Version, InfoType::URL],
                 ..Default::default()
             },
-            text_formatting: TextForamttingCliOptions {
-                ascii_colors: vec![5, 0],
-                ..Default::default()
-            },
             ascii: AsciiCliOptions {
+                ascii_colors: vec![5, 0],
                 show_logo: When::Never,
                 ascii_language: Some(Language::Lisp),
                 ..Default::default()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ use strum::IntoEnumIterator;
 const COLOR_RESOLUTIONS: [&str; 5] = ["16", "32", "64", "128", "256"];
 
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
-#[command(disable_help_flag = true, about)]
+#[command(version, about)]
 pub struct CliOptions {
     /// Run as if onefetch was started in <input> instead of the current working directory
     #[arg(default_value = ".", hide_default_value = true, value_hint = ValueHint::DirPath)]

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -18,7 +18,7 @@ use self::url::UrlInfo;
 use self::utils::git::Commits;
 use self::utils::info_field::{InfoField, InfoType};
 use self::version::VersionInfo;
-use crate::cli::{is_truecolor_terminal, Config, NumberSeparator, When};
+use crate::cli::{is_truecolor_terminal, CliOptions, NumberSeparator, When};
 use crate::ui::get_ascii_colors;
 use crate::ui::text_colors::TextColors;
 use anyhow::{Context, Result};
@@ -110,14 +110,14 @@ impl std::fmt::Display for Info {
 }
 
 impl Info {
-    pub fn new(config: &Config) -> Result<Self> {
-        let git_repo = gix::discover(&config.input)?;
+    pub fn new(cli_options: &CliOptions) -> Result<Self> {
+        let git_repo = gix::discover(&cli_options.input)?;
         let repo_path = get_work_dir(&git_repo)?;
 
         let loc_by_language_sorted_handle = std::thread::spawn({
-            let ignored_directories = config.exclude.clone();
-            let language_types = config.r#type.clone();
-            let include_hidden = config.include_hidden;
+            let ignored_directories = cli_options.info.exclude.clone();
+            let language_types = cli_options.info.r#type.clone();
+            let include_hidden = cli_options.info.include_hidden;
             let workdir = repo_path.clone();
             move || {
                 langs::get_loc_by_language_sorted(
@@ -134,25 +134,26 @@ impl Info {
             .ok()
             .context("BUG: panic in language statistics thread")??;
         let dominant_language = langs::get_main_language(&loc_by_language);
-        let true_color = match config.true_color {
+        let true_color = match cli_options.ascii.true_color {
             When::Always => true,
             When::Never => false,
             When::Auto => is_truecolor_terminal(),
         };
         let ascii_colors = get_ascii_colors(
-            &config.ascii_language,
+            &cli_options.ascii.ascii_language,
             &dominant_language,
-            &config.ascii_colors,
+            &cli_options.text_formatting.ascii_colors,
             true_color,
         );
 
-        let text_colors = TextColors::new(&config.text_colors, ascii_colors[0]);
+        let text_colors =
+            TextColors::new(&cli_options.text_formatting.text_colors, ascii_colors[0]);
         let title = Title::new(
             &git_repo,
             text_colors.title,
             text_colors.tilde,
             text_colors.underline,
-            !config.no_bold,
+            !cli_options.text_formatting.no_bold,
         );
         let manifest = get_manifest(&repo_path)?;
         let description = DescriptionInfo::new(manifest.as_ref());
@@ -162,34 +163,43 @@ impl Info {
             &git_repo,
             &repo_url.repo_url,
             manifest.as_ref(),
-            config.number_separator,
+            cli_options.text_formatting.number_separator,
         )?;
         let head = HeadInfo::new(&git_repo)?;
         let version = VersionInfo::new(&git_repo, manifest.as_ref())?;
-        let size = SizeInfo::new(&git_repo, config.number_separator);
+        let size = SizeInfo::new(&git_repo, cli_options.text_formatting.number_separator);
         let license = LicenseInfo::new(&repo_path, manifest.as_ref())?;
         let mut commits = Commits::new(
             git_repo,
-            config.no_merges,
-            &config.no_bots,
-            config.number_of_authors,
-            config.email,
-            config.number_separator,
+            cli_options.info.no_merges,
+            &cli_options.info.no_bots,
+            cli_options.info.number_of_authors,
+            cli_options.info.email,
+            cli_options.text_formatting.number_separator,
         )?;
-        let created = CreatedInfo::new(config.iso_time, &commits);
+        let created = CreatedInfo::new(cli_options.text_formatting.iso_time, &commits);
         let languages = LanguagesInfo::new(
             &loc_by_language,
             true_color,
-            config.number_of_languages,
+            cli_options.info.number_of_languages,
             text_colors.info,
         );
-        let dependencies = DependenciesInfo::new(manifest.as_ref(), config.number_separator);
+        let dependencies = DependenciesInfo::new(
+            manifest.as_ref(),
+            cli_options.text_formatting.number_separator,
+        );
         let authors = AuthorsInfo::new(text_colors.info, &mut commits);
-        let last_change = LastChangeInfo::new(config.iso_time, &commits);
-        let contributors =
-            ContributorsInfo::new(&commits, config.number_of_authors, config.number_separator);
-        let commits = CommitsInfo::new(&commits, config.number_separator);
-        let lines_of_code = LocInfo::new(&loc_by_language, config.number_separator);
+        let last_change = LastChangeInfo::new(cli_options.text_formatting.iso_time, &commits);
+        let contributors = ContributorsInfo::new(
+            &commits,
+            cli_options.info.number_of_authors,
+            cli_options.text_formatting.number_separator,
+        );
+        let commits = CommitsInfo::new(&commits, cli_options.text_formatting.number_separator);
+        let lines_of_code = LocInfo::new(
+            &loc_by_language,
+            cli_options.text_formatting.number_separator,
+        );
 
         let info_fields: Vec<Box<dyn InfoField>> = vec![
             Box::new(project),
@@ -212,13 +222,13 @@ impl Info {
         Ok(Self {
             title,
             info_fields,
-            disabled_fields: config.disabled_fields.clone(),
+            disabled_fields: cli_options.info.disabled_fields.clone(),
             text_colors,
             dominant_language,
             ascii_colors,
-            no_color_palette: config.no_color_palette,
-            no_title: config.no_title,
-            no_bold: config.no_bold,
+            no_color_palette: cli_options.color_blocks.no_color_palette,
+            no_title: cli_options.info.no_title,
+            no_bold: cli_options.text_formatting.no_bold,
         })
     }
 

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -142,7 +142,7 @@ impl Info {
         let ascii_colors = get_ascii_colors(
             &cli_options.ascii.ascii_language,
             &dominant_language,
-            &cli_options.text_formatting.ascii_colors,
+            &cli_options.ascii.ascii_colors,
             true_color,
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,24 +14,24 @@ fn main() -> Result<()> {
     #[cfg(windows)]
     let _ = enable_ansi_support::enable_ansi_support();
 
-    let config = cli::Config::parse();
+    let cli_options = cli::CliOptions::parse();
 
-    if config.languages {
+    if cli_options.other.languages {
         return cli::print_supported_languages();
     }
 
-    if config.package_managers {
+    if cli_options.other.package_managers {
         return cli::print_supported_package_managers();
     }
 
-    if let Some(generator) = config.completion {
-        let mut cmd = cli::Config::command();
+    if let Some(generator) = cli_options.developer.completion {
+        let mut cmd = cli::CliOptions::command();
         cli::print_completions(generator, &mut cmd);
         return Ok(());
     }
 
-    let info = Info::new(&config)?;
-    let mut printer = Printer::new(io::BufWriter::new(io::stdout()), info, config)?;
+    let info = Info::new(&cli_options)?;
+    let mut printer = Printer::new(io::BufWriter::new(io::stdout()), info, cli_options)?;
 
     printer.print()?;
 

--- a/src/ui/printer.rs
+++ b/src/ui/printer.rs
@@ -1,4 +1,4 @@
-use crate::cli::{Config, When};
+use crate::cli::{CliOptions, When};
 use crate::info::Info;
 use crate::ui::Language;
 use anyhow::{Context, Result};
@@ -32,8 +32,8 @@ pub struct Printer<W> {
 }
 
 impl<W: Write> Printer<W> {
-    pub fn new(writer: W, info: Info, config: Config) -> Result<Self> {
-        let art_off = match config.show_logo {
+    pub fn new(writer: W, info: Info, cli_options: CliOptions) -> Result<Self> {
+        let art_off = match cli_options.ascii.show_logo {
             When::Always => false,
             When::Never => true,
             When::Auto => {
@@ -44,13 +44,14 @@ impl<W: Write> Printer<W> {
                 }
             }
         };
-        let image = match config.image {
+        let image = match cli_options.image.image {
             Some(p) => Some(image::open(p).context("Could not load the specified image")?),
             None => None,
         };
 
         let image_backend = if image.is_some() {
-            config
+            cli_options
+                .image
                 .image_protocol
                 .map_or_else(onefetch_image::get_best_backend, |s| {
                     onefetch_image::get_image_backend(s)
@@ -62,14 +63,14 @@ impl<W: Write> Printer<W> {
         Ok(Self {
             writer,
             info,
-            output: config.output,
+            output: cli_options.developer.output,
             art_off,
             image,
             image_backend,
-            color_resolution: config.color_resolution,
-            no_bold: config.no_bold,
-            ascii_input: config.ascii_input,
-            ascii_language: config.ascii_language,
+            color_resolution: cli_options.image.color_resolution,
+            no_bold: cli_options.text_formatting.no_bold,
+            ascii_input: cli_options.ascii.ascii_input,
+            ascii_language: cli_options.ascii.ascii_language,
         })
     }
 

--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use gix::{open, Repository, ThreadSafeRepository};
-use onefetch::cli::Config;
+use onefetch::cli::{CliOptions, TextForamttingCliOptions};
 use onefetch::info::{get_work_dir, Info};
 
 fn repo(name: &str) -> Result<Repository> {
@@ -28,9 +28,12 @@ fn test_bare_repo() -> Result<()> {
 #[test]
 fn test_repo() -> Result<()> {
     let repo = repo("repo.sh")?;
-    let config: Config = Config {
+    let config: CliOptions = CliOptions {
         input: repo.path().to_path_buf(),
-        iso_time: true,
+        text_formatting: TextForamttingCliOptions {
+            iso_time: true,
+            ..Default::default()
+        },
         ..Default::default()
     };
     let info = Info::new(&config)?;
@@ -48,7 +51,7 @@ fn test_repo() -> Result<()> {
 #[test]
 fn test_repo_without_remote() -> Result<()> {
     let repo = repo("basic_repo.sh")?;
-    let config: Config = Config {
+    let config: CliOptions = CliOptions {
         input: repo.path().to_path_buf(),
         ..Default::default()
     };


### PR DESCRIPTION
Before:

```
Command-line Git information tool

Usage: onefetch [OPTIONS] [INPUT]

Arguments:
  [INPUT]  Run as if onefetch was started in <input> instead of the current working directory

Options:
      --ascii-input <STRING>
          Takes a non-empty STRING as input to replace the ASCII logo
  -a, --ascii-language <LANGUAGE>
          Which LANGUAGE's ascii art to print
  -c, --ascii-colors <X>...
          Colors (X X X...) to print the ascii art
  -d, --disabled-fields <FIELD>...
          Allows you to disable FIELD(s) from appearing in the output
  -i, --image <IMAGE>
          Path to the IMAGE file
      --image-protocol <IMAGE_PROTOCOL>
          Which image protocol to use [possible values: kitty, sixel, iterm]
      --color-resolution <VALUE>
          VALUE of color resolution to use with SIXEL backend [default: 16] [possible values: 16, 32, 64, 128, 256]
      --no-bold
          Turns off bold formatting
      --no-merges
          Ignores merge commits
      --no-color-palette
          Hides the color palette
      --no-title
          Hides the title
      --number-of-authors <NUM>
          Maximum NUM of authors to be shown [default: 3]
      --number-of-languages <NUM>
          Maximum NUM of languages to be shown [default: 6]
  -e, --exclude <EXCLUDE>...
          Ignore all files & directories matching EXCLUDE
      --no-bots [<REGEX>]
          Exclude [bot] commits. Use <REGEX> to override the default pattern
  -l, --languages
          Prints out supported languages
  -p, --package-managers
          Prints out supported package managers
  -o, --output <FORMAT>
          Outputs Onefetch in a specific format [possible values: json, yaml]
      --true-color <WHEN>
          Specify when to use true color [default: auto] [possible values: auto, never, always]
      --show-logo <WHEN>
          Specify when to show the logo [default: always] [possible values: auto, never, always]
  -t, --text-colors <X>...
          Changes the text colors (X X X...)
  -z, --iso-time
          Use ISO 8601 formatted timestamps
      --number-separator <SEPARATOR>
          Which thousands SEPARATOR to use [default: plain] [possible values: plain, comma, space, underscore]
  -E, --email
          Show the email address of each author
      --include-hidden
          Count hidden files and directories
  -T, --type <TYPE>...
          Filters output by language type [default: programming markup] [possible values: programming, markup, prose, data]
      --generate <SHELL>
          If provided, outputs the completion file for given SHELL [possible values: bash, elvish, fish, powershell, zsh]
  -h, --help
          Print help (see more with '--help')
  -V, --version
          Print version
```

After:

```
Command-line Git information tool

Usage: onefetch [OPTIONS] [INPUT]

Arguments:
  [INPUT]  Run as if onefetch was started in <input> instead of the current working directory

Options:
  -h, --help     Print help (see more with '--help')
  -V, --version  Print version

INFO:
  -d, --disabled-fields <FIELD>...  Allows you to disable FIELD(s) from appearing in the output
      --no-title                    Hides the title
      --number-of-authors <NUM>     Maximum NUM of authors to be shown [default: 3]
      --number-of-languages <NUM>   Maximum NUM of languages to be shown [default: 6]
  -e, --exclude <EXCLUDE>...        Ignore all files & directories matching EXCLUDE
      --no-bots [<REGEX>]           Exclude [bot] commits. Use <REGEX> to override the default pattern
      --no-merges                   Ignores merge commits
  -E, --email                       Show the email address of each author
      --include-hidden              Count hidden files and directories
  -T, --type <TYPE>...              Filters output by language type [default: programming markup] [possible values: programming, markup, prose, data]

TEXT FORMATTING:
  -t, --text-colors <X>...            Changes the text colors (X X X...)
  -z, --iso-time                      Use ISO 8601 formatted timestamps
      --number-separator <SEPARATOR>  Which thousands SEPARATOR to use [default: plain] [possible values: plain, comma, space, underscore]
      --no-bold                       Turns off bold formatting

COLOR BLOCKS:
      --no-color-palette  Hides the color palette

ASCII:
      --ascii-input <STRING>       Takes a non-empty STRING as input to replace the ASCII logo
  -c, --ascii-colors <X>...        Colors (X X X...) to print the ascii art
  -a, --ascii-language <LANGUAGE>  Which LANGUAGE's ascii art to print
      --true-color <WHEN>          Specify when to use true color [default: auto] [possible values: auto, never, always]
      --show-logo <WHEN>           Specify when to show the logo [default: always] [possible values: auto, never, always]

IMAGE:
  -i, --image <IMAGE>              Path to the IMAGE file
      --image-protocol <PROTOCOL>  Which image PROTOCOL to use [possible values: kitty, sixel, iterm]
      --color-resolution <VALUE>   VALUE of color resolution to use with SIXEL backend [default: 16] [possible values: 16, 32, 64, 128, 256]

DEVELOPER:
  -o, --output <FORMAT>   Outputs Onefetch in a specific format [possible values: json, yaml]
      --generate <SHELL>  If provided, outputs the completion file for given SHELL [possible values: bash, elvish, fish, powershell, zsh]

OTHER:
  -l, --languages         Prints out supported languages
  -p, --package-managers  Prints out supported package managers
```
