### PR TITLE
replace `--show-logo` with `--no-art`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,7 +2190,6 @@ dependencies = [
  "serde_yaml",
  "strum",
  "tera",
- "terminal_size",
  "time",
  "time-humanize",
  "tokei",
@@ -2982,16 +2981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
-dependencies = [
- "rustix",
- "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ serde_yaml = "0.9.19"
 # TODO With the new value parsers, we're really close to being able to eliminate
 # the strum dependency
 strum = { version = "0.24.1", features = ["derive"] }
-terminal_size = "0.2"
 time = { version = "0.3.17", features = ["formatting"] }
 time-humanize = { version = "0.1.3", features = ["time"] }
 tokei = "12.1.2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,11 +30,11 @@ pub struct CliOptions {
     #[command(flatten)]
     pub text_formatting: TextForamttingCliOptions,
     #[command(flatten)]
-    pub color_blocks: ColorBlocksCliOptions,
-    #[command(flatten)]
     pub ascii: AsciiCliOptions,
     #[command(flatten)]
     pub image: ImageCliOptions,
+    #[command(flatten)]
+    pub visuals: VisualsCliOptions,
     #[command(flatten)]
     pub developer: DeveloperCliOptions,
     #[command(flatten)]
@@ -124,11 +124,6 @@ pub struct AsciiCliOptions {
     /// If set to auto: true color will be enabled if supported by the terminal
     #[arg(long, default_value = "auto", value_name = "WHEN", value_enum)]
     pub true_color: When,
-    /// Specify when to show the logo
-    ///
-    /// If set to auto: the logo will be hidden if the terminal's width < 95
-    #[arg(long, default_value = "always", value_name = "WHEN", value_enum)]
-    pub show_logo: When,
 }
 
 #[derive(Clone, Debug, Args, PartialEq, Eq)]
@@ -181,11 +176,14 @@ pub struct TextForamttingCliOptions {
     pub no_bold: bool,
 }
 #[derive(Clone, Debug, Args, PartialEq, Eq, Default)]
-#[command(next_help_heading = "COLOR BLOCKS")]
-pub struct ColorBlocksCliOptions {
+#[command(next_help_heading = "VISUALS")]
+pub struct VisualsCliOptions {
     /// Hides the color palette
     #[arg(long)]
     pub no_color_palette: bool,
+    /// Hides the ascii art or image if provided
+    #[arg(long)]
+    pub no_art: bool,
 }
 
 #[derive(Clone, Debug, Args, PartialEq, Eq, Default)]
@@ -216,7 +214,7 @@ impl Default for CliOptions {
             input: PathBuf::from("."),
             info: InfoCliOptions::default(),
             text_formatting: TextForamttingCliOptions::default(),
-            color_blocks: ColorBlocksCliOptions::default(),
+            visuals: VisualsCliOptions::default(),
             ascii: AsciiCliOptions::default(),
             image: ImageCliOptions::default(),
             developer: DeveloperCliOptions::default(),
@@ -260,7 +258,6 @@ impl Default for AsciiCliOptions {
             ascii_colors: Default::default(),
             ascii_language: Default::default(),
             true_color: When::Auto,
-            show_logo: When::Always,
         }
     }
 }
@@ -365,8 +362,11 @@ mod test {
             },
             ascii: AsciiCliOptions {
                 ascii_colors: vec![5, 0],
-                show_logo: When::Never,
                 ascii_language: Some(Language::Lisp),
+                ..Default::default()
+            },
+            visuals: VisualsCliOptions {
+                no_art: true,
                 ..Default::default()
             },
             ..Default::default()
@@ -386,8 +386,7 @@ mod test {
                 "--disabled-fields",
                 "version",
                 "url",
-                "--show-logo",
-                "never",
+                "--no-art",
                 "--ascii-language",
                 "lisp"
             ])

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -226,7 +226,7 @@ impl Info {
             text_colors,
             dominant_language,
             ascii_colors,
-            no_color_palette: cli_options.color_blocks.no_color_palette,
+            no_color_palette: cli_options.visuals.no_color_palette,
             no_title: cli_options.info.no_title,
             no_bold: cli_options.text_formatting.no_bold,
         })

--- a/src/ui/printer.rs
+++ b/src/ui/printer.rs
@@ -1,4 +1,4 @@
-use crate::cli::{CliOptions, When};
+use crate::cli::CliOptions;
 use crate::info::Info;
 use crate::ui::Language;
 use anyhow::{Context, Result};
@@ -7,10 +7,8 @@ use onefetch_ascii::AsciiArt;
 use onefetch_image::ImageBackend;
 use std::fmt::Write as _;
 use std::io::Write;
-use terminal_size::{terminal_size, Width};
 
 const CENTER_PAD_LENGTH: usize = 3;
-const MAX_TERM_WIDTH: u16 = 95;
 
 #[derive(Clone, clap::ValueEnum, PartialEq, Eq, Debug)]
 pub enum SerializationFormat {
@@ -33,17 +31,6 @@ pub struct Printer<W> {
 
 impl<W: Write> Printer<W> {
     pub fn new(writer: W, info: Info, cli_options: CliOptions) -> Result<Self> {
-        let art_off = match cli_options.ascii.show_logo {
-            When::Always => false,
-            When::Never => true,
-            When::Auto => {
-                if let Some((Width(width), _)) = terminal_size() {
-                    width < MAX_TERM_WIDTH
-                } else {
-                    false
-                }
-            }
-        };
         let image = match cli_options.image.image {
             Some(p) => Some(image::open(p).context("Could not load the specified image")?),
             None => None,
@@ -64,7 +51,7 @@ impl<W: Write> Printer<W> {
             writer,
             info,
             output: cli_options.developer.output,
-            art_off,
+            art_off: cli_options.visuals.no_art,
             image,
             image_backend,
             color_resolution: cli_options.image.color_resolution,


### PR DESCRIPTION
Given the recent addition of #983, perhaps we could simplify the `--show-logo` option into a more straightforward Boolean flag, such as `--no-art`.

```
VISUALS:
      --no-color-palette  Hides the color palette
      --no-art            Hides the ascii art or image if provided
```