### PR TITLE
Set snapshot language to plain text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 docs/vercel/** linguist-documentation
+**.snap linguist-language=Plain-Text


### PR DESCRIPTION
This is a small change that removes the unusual syntax highlighting on snapshots. GitHub assumes that snapshots are *Jest* snapshots, which are similar to JavaScript.