### PR TITLE
treat multiple name entries with the same email as one author

### DIFF
--- a/src/info/utils/git.rs
+++ b/src/info/utils/git.rs
@@ -86,32 +86,27 @@ impl Commits {
         let mut authors_by_number_of_commits: Vec<(Sig, usize)> = email_to_names
             .into_iter()
             .map(|(email, name_to_nbr_of_commits)| {
-                let mut author_nbr_of_commits = 0;
-
-                let most_frequent_name = name_to_nbr_of_commits
-                    .into_iter()
-                    .fold(None, |acc, x| {
-                        author_nbr_of_commits += x.1;
-
-                        match acc {
-                            None => Some(x),
-                            Some(e) => {
-                                if x.1 > e.1 {
-                                    Some(x)
-                                } else {
-                                    Some(e)
-                                }
+                let (most_frequent_name, total_commits) = name_to_nbr_of_commits.into_iter().fold(
+                    (None, 0),
+                    |(acc_common_name, total_commits), (curr_name, curr_commits)| {
+                        let next_common_name = match acc_common_name {
+                            Some((acc_name, acc_commits)) if acc_commits > curr_commits => {
+                                Some((acc_name, acc_commits))
                             }
-                        }
-                    })
-                    .unwrap();
+
+                            _ => Some((curr_name, curr_commits)),
+                        };
+
+                        (next_common_name, total_commits + curr_commits)
+                    },
+                );
 
                 (
                     Sig {
                         email,
-                        name: most_frequent_name.0.clone(),
+                        name: most_frequent_name.unwrap().0.clone(),
                     },
-                    author_nbr_of_commits,
+                    total_commits,
                 )
             })
             .collect();

--- a/src/info/utils/git.rs
+++ b/src/info/utils/git.rs
@@ -2,20 +2,11 @@ use crate::cli::{MyRegex, NumberSeparator};
 use crate::info::author::Author;
 use anyhow::Result;
 use gix::bstr::BString;
+use gix::bstr::BStr;
 use gix::bstr::ByteSlice;
 use regex::Regex;
 use std::collections::HashMap;
 use std::str::FromStr;
-
-pub struct Commits {
-    pub authors: Vec<Author>,
-    pub total_num_authors: usize,
-    pub num_commits: usize,
-    /// false if we have found the first commit that started it all, true if the repository is shallow.
-    pub is_shallow: bool,
-    pub time_of_most_recent_commit: gix::actor::Time,
-    pub time_of_first_commit: gix::actor::Time,
-}
 
 #[derive(Hash, PartialOrd, Ord, Eq, PartialEq)]
 pub struct Sig {
@@ -27,6 +18,16 @@ impl From<gix::actor::Signature> for Sig {
     fn from(gix::actor::Signature { name, email, .. }: gix::actor::Signature) -> Self {
         Self { name, email }
     }
+}
+
+pub struct Commits {
+    pub authors: Vec<Author>,
+    pub total_num_authors: usize,
+    pub num_commits: usize,
+    /// false if we have found the first commit that started it all, true if the repository is shallow.
+    pub is_shallow: bool,
+    pub time_of_most_recent_commit: gix::actor::Time,
+    pub time_of_first_commit: gix::actor::Time,
 }
 
 impl Commits {
@@ -48,8 +49,7 @@ impl Commits {
         let mut commit_iter = repo.head_commit()?.ancestors().all()?;
         let mut commit_iter_peekable = commit_iter.by_ref().peekable();
 
-        let mailmap = repo.open_mailmap();
-        let mut author_to_number_of_commits: HashMap<Sig, usize> = HashMap::new();
+        let mut email_to_names: HashMap<BString, HashMap<BString, usize>> = HashMap::new();
         let mut total_nbr_of_commits = 0;
 
         let mut num_commits = 0;
@@ -61,15 +61,20 @@ impl Commits {
                 continue;
             }
 
-            let sig = Sig::from(mailmap.resolve(commit.author));
-
-            if is_bot(&sig.name, &bot_regex_pattern) {
+            if is_bot(&commit.author.name, &bot_regex_pattern) {
                 continue;
             }
+
             num_commits += 1;
 
-            let author_nbr_of_commits = author_to_number_of_commits.entry(sig).or_insert(0);
-            *author_nbr_of_commits += 1;
+            let email_names = email_to_names
+                .entry(BString::from(commit.author.email))
+                .or_insert(HashMap::new());
+
+            let name_nbr_of_commits = (*email_names)
+                .entry(BString::from(commit.author.name))
+                .or_insert(0);
+            *name_nbr_of_commits += 1;
             total_nbr_of_commits += 1;
 
             time_of_most_recent_commit.get_or_insert_with(|| commit.time());
@@ -78,8 +83,27 @@ impl Commits {
             }
         }
 
-        let mut authors_by_number_of_commits: Vec<(Sig, usize)> =
-            author_to_number_of_commits.into_iter().collect();
+        let mut authors_by_number_of_commits: Vec<(Sig, usize)> = Vec::new();
+        for (e, name_to_nbr_of_commits) in email_to_names.into_iter() {
+
+            let mut most_frequent_name: Option<BString> = None;
+            let mut highest_nbr_of_commits = 0;
+            let mut author_nbr_of_commits = 0;
+
+            for (n, c) in name_to_nbr_of_commits.into_iter() {
+
+                author_nbr_of_commits += c;
+
+                if c > highest_nbr_of_commits {
+                    highest_nbr_of_commits = c;
+                    most_frequent_name.insert(n.clone());
+                }
+            }
+
+            let sig = Sig { email: e, name: most_frequent_name.unwrap().clone() };
+            authors_by_number_of_commits.push((sig, author_nbr_of_commits));
+        }
+
 
         let total_num_authors = authors_by_number_of_commits.len();
         authors_by_number_of_commits.sort_by(|(sa, a_count), (sb, b_count)| {
@@ -135,7 +159,7 @@ fn get_no_bots_regex(no_bots: &Option<Option<MyRegex>>) -> Result<Option<MyRegex
     Ok(reg)
 }
 
-fn is_bot(author_name: &BString, bot_regex_pattern: &Option<MyRegex>) -> bool {
+fn is_bot(author_name: &BStr, bot_regex_pattern: &Option<MyRegex>) -> bool {
     bot_regex_pattern
         .as_ref()
         .map(|regex| regex.0.is_match(author_name.to_str_lossy().as_ref()))


### PR DESCRIPTION
Sometimes, there are multiple entries (as per `git shortlog -nse`) with the same email but different names. This results in them being treated as separate authors when in reality they're not. With this change, authors are grouped according to their email address and the displayed name is the one that occurs the most. 

Disclaimer: I'm Rust newbie, therefore code may be far from optimal.