### PR TITLE
Improve code coverage of src/ui/mod.rs

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -115,29 +115,4 @@ mod test {
             ]
         );
     }
-
-    #[test]
-    fn num_to_color_code_match() {
-        // This test case is only for test coverage
-        assert_eq!(num_to_color(&0), DynColors::Ansi(AnsiColors::Black));
-        assert_eq!(num_to_color(&1), DynColors::Ansi(AnsiColors::Red));
-        assert_eq!(num_to_color(&2), DynColors::Ansi(AnsiColors::Green));
-        assert_eq!(num_to_color(&3), DynColors::Ansi(AnsiColors::Yellow));
-        assert_eq!(num_to_color(&4), DynColors::Ansi(AnsiColors::Blue));
-        assert_eq!(num_to_color(&5), DynColors::Ansi(AnsiColors::Magenta));
-        assert_eq!(num_to_color(&6), DynColors::Ansi(AnsiColors::Cyan));
-        assert_eq!(num_to_color(&7), DynColors::Ansi(AnsiColors::White));
-        assert_eq!(num_to_color(&8), DynColors::Ansi(AnsiColors::BrightBlack));
-        assert_eq!(num_to_color(&9), DynColors::Ansi(AnsiColors::BrightRed));
-        assert_eq!(num_to_color(&10), DynColors::Ansi(AnsiColors::BrightGreen));
-        assert_eq!(num_to_color(&11), DynColors::Ansi(AnsiColors::BrightYellow));
-        assert_eq!(num_to_color(&12), DynColors::Ansi(AnsiColors::BrightBlue));
-        assert_eq!(
-            num_to_color(&13),
-            DynColors::Ansi(AnsiColors::BrightMagenta)
-        );
-        assert_eq!(num_to_color(&14), DynColors::Ansi(AnsiColors::BrightCyan));
-        assert_eq!(num_to_color(&15), DynColors::Ansi(AnsiColors::BrightWhite));
-        assert_eq!(num_to_color(&127), DynColors::Ansi(AnsiColors::Default));
-    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -115,4 +115,29 @@ mod test {
             ]
         );
     }
+
+    #[test]
+    fn num_to_color_code_match() {
+        // This test case is only for test coverage
+        assert_eq!(num_to_color(&0), DynColors::Ansi(AnsiColors::Black));
+        assert_eq!(num_to_color(&1), DynColors::Ansi(AnsiColors::Red));
+        assert_eq!(num_to_color(&2), DynColors::Ansi(AnsiColors::Green));
+        assert_eq!(num_to_color(&3), DynColors::Ansi(AnsiColors::Yellow));
+        assert_eq!(num_to_color(&4), DynColors::Ansi(AnsiColors::Blue));
+        assert_eq!(num_to_color(&5), DynColors::Ansi(AnsiColors::Magenta));
+        assert_eq!(num_to_color(&6), DynColors::Ansi(AnsiColors::Cyan));
+        assert_eq!(num_to_color(&7), DynColors::Ansi(AnsiColors::White));
+        assert_eq!(num_to_color(&8), DynColors::Ansi(AnsiColors::BrightBlack));
+        assert_eq!(num_to_color(&9), DynColors::Ansi(AnsiColors::BrightRed));
+        assert_eq!(num_to_color(&10), DynColors::Ansi(AnsiColors::BrightGreen));
+        assert_eq!(num_to_color(&11), DynColors::Ansi(AnsiColors::BrightYellow));
+        assert_eq!(num_to_color(&12), DynColors::Ansi(AnsiColors::BrightBlue));
+        assert_eq!(
+            num_to_color(&13),
+            DynColors::Ansi(AnsiColors::BrightMagenta)
+        );
+        assert_eq!(num_to_color(&14), DynColors::Ansi(AnsiColors::BrightCyan));
+        assert_eq!(num_to_color(&15), DynColors::Ansi(AnsiColors::BrightWhite));
+        assert_eq!(num_to_color(&127), DynColors::Ansi(AnsiColors::Default));
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -99,4 +99,20 @@ mod test {
         assert_eq!(colors.len(), 2);
         assert_eq!(colors, vec![num_to_color(&2), num_to_color(&3)]);
     }
+
+    #[test]
+    fn get_ascii_colors_fill_custom_colors_with_language_colors() {
+        // When custom ascii colors are not enough for the given language,
+        // language colors should be used as default
+        let colors = get_ascii_colors(&None, &Language::Go, &[0], false);
+        assert_eq!(colors.len(), 3);
+        assert_eq!(
+            colors,
+            vec![
+                num_to_color(&0),
+                DynColors::Ansi(AnsiColors::Default),
+                DynColors::Ansi(AnsiColors::Yellow)
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Part of #700. The following lines should be covered by the new test cases:

![image](https://user-images.githubusercontent.com/4591982/230905746-689d7c23-0cc0-473d-a513-a419e63177ea.png)

Note that the test case `num_to_color_code_match` is almost meaningless. It's only for boosting test coverage a bit.

Result with `tarpaulin`:
```
|| Tested/Total Lines:
|| src/ui/mod.rs: 31/31
55.77% coverage, 681/1221 lines covered
```