### PR TITLE
Run tarpaulin against all packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           version: latest
 
       - name: Coverage with tarpaulin
-        run: cargo tarpaulin --out Lcov -- --test-threads 1
+        run: cargo tarpaulin --workspace --out Lcov -- --test-threads 1
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Part of #700. 

Currently, tarpaulin only runs tests against onefetch, but when it calculates test coverage, all source files including other packages are taken into consideration, which is why some files like `ascii/src/lib.rs` has 0 coverage even if test cases do exist. To fix this, tarpaulin needs an additional parameter `--workspace` to run tests in all packages in this repo.

Before:
```sh
$ cargo tarpaulin
...
|| Tested/Total Lines:
|| ascii/src/lib.rs: 0/119
...
54.87% coverage, 670/1221 lines covered
```

After:
```sh
$ cargo tarpaulin --workspace
...
|| Tested/Total Lines:
|| ascii/src/lib.rs: 90/119 +75.63%
...
63.06% coverage, 770/1221 lines covered, +8.19% change in coverage
```