### PR TITLE
Fix 050568f1: run unit tests in generated git repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,6 +2481,7 @@ dependencies = [
  "insta",
  "lazy_static",
  "num-format",
+ "onefetch",
  "onefetch-ascii",
  "onefetch-image",
  "onefetch-manifest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ gix-features-for-configuration-only = { package = "gix-features", version = "0.2
 gix = { version = "0.44.1", default-features = false, features = [
     "max-performance-safe",
 ] }
+gix-testtools = { version = "0.11.0", optional = true }
 git2 = { version = "0.17.1", default-features = false }
 human-panic = "1.1.4"
 image = "0.24.6"
@@ -52,13 +53,18 @@ yaml-rust = "0.4.5"
 
 [dev-dependencies]
 criterion = "0.4.0"
-gix-testtools = "0.11.0"
 insta = { version = "1.29.0", features = ["json", "redactions"] }
+onefetch = { path = ".", features = ["test-utils"] }
 pretty_assertions = "1.3.0"
 
 [[bench]]
 name = "repo"
 harness = false
+required-features = ["test-utils"]
+
+[[test]]
+name = "repo"
+required-features = ["test-utils"]
 
 [build-dependencies]
 lazy_static = "1"
@@ -75,3 +81,4 @@ enable-ansi-support = "0.2.1"
 
 [features]
 fail-on-deprecated = []
+test-utils = ["gix-testtools"]

--- a/benches/repo.rs
+++ b/benches/repo.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use onefetch::{cli::CliOptions, info::Info};
 use onefetch::utils::repo;
+use onefetch::{cli::CliOptions, info::Info};
 
 fn bench_repo_info(c: &mut Criterion) {
     let repo = repo("repo.sh").unwrap();

--- a/benches/repo.rs
+++ b/benches/repo.rs
@@ -1,11 +1,9 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use gix::{open, ThreadSafeRepository};
 use onefetch::{cli::CliOptions, info::Info};
+use onefetch::utils::repo;
 
 fn bench_repo_info(c: &mut Criterion) {
-    let name = "repo.sh".to_string();
-    let repo_path = gix_testtools::scripted_fixture_read_only(name).unwrap();
-    let repo = ThreadSafeRepository::open_opts(repo_path, open::Options::isolated()).unwrap();
+    let repo = repo("repo.sh").unwrap();
     let config: CliOptions = CliOptions {
         input: repo.path().to_path_buf(),
         ..Default::default()

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -354,9 +354,9 @@ mod tests {
     #[test]
     #[cfg(feature = "test-utils")]
     fn test_info_style_info() -> Result<()> {
-	let repo = repo("basic_repo.sh")?;
+        let repo = repo("basic_repo.sh")?;
         let config: CliOptions = CliOptions {
-	    input: repo.path().to_path_buf(),
+            input: repo.path().to_path_buf(),
             text_formatting: TextForamttingCliOptions {
                 text_colors: vec![0, 0, 0, 0, 0, 0],
                 ..Default::default()
@@ -378,9 +378,9 @@ mod tests {
     #[test]
     #[cfg(feature = "test-utils")]
     fn test_info_style_subtitle() -> Result<()> {
-	let repo = repo("basic_repo.sh")?;
+        let repo = repo("basic_repo.sh")?;
         let config: CliOptions = CliOptions {
-	    input: repo.path().to_path_buf(),
+            input: repo.path().to_path_buf(),
             text_formatting: TextForamttingCliOptions {
                 text_colors: vec![0, 0, 0, 0, 15, 0],
                 no_bold: false,

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -309,7 +309,10 @@ fn get_style(is_bold: bool, color: DynColors) -> Style {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "test-utils")]
     use crate::cli::TextForamttingCliOptions;
+    #[cfg(feature = "test-utils")]
+    use crate::utils::repo;
 
     use super::*;
     use owo_colors::AnsiColors;
@@ -349,8 +352,11 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "test-utils")]
     fn test_info_style_info() -> Result<()> {
+	let repo = repo("basic_repo.sh")?;
         let config: CliOptions = CliOptions {
+	    input: repo.path().to_path_buf(),
             text_formatting: TextForamttingCliOptions {
                 text_colors: vec![0, 0, 0, 0, 0, 0],
                 ..Default::default()
@@ -370,8 +376,11 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "test-utils")]
     fn test_info_style_subtitle() -> Result<()> {
+	let repo = repo("basic_repo.sh")?;
         let config: CliOptions = CliOptions {
+	    input: repo.path().to_path_buf(),
             text_formatting: TextForamttingCliOptions {
                 text_colors: vec![0, 0, 0, 0, 15, 0],
                 no_bold: false,

--- a/src/info/title.rs
+++ b/src/info/title.rs
@@ -86,9 +86,9 @@ impl std::fmt::Display for Title {
 #[cfg(test)]
 #[cfg(feature = "test-utils")]
 mod tests {
-    use anyhow::Result;
-    use crate::utils::repo;
     use super::*;
+    use crate::utils::repo;
+    use anyhow::Result;
     use owo_colors::AnsiColors;
 
     #[test]

--- a/src/info/title.rs
+++ b/src/info/title.rs
@@ -84,18 +84,12 @@ impl std::fmt::Display for Title {
     }
 }
 #[cfg(test)]
+#[cfg(feature = "test-utils")]
 mod tests {
-    use super::*;
     use anyhow::Result;
-    use gix::{open, Repository, ThreadSafeRepository};
+    use crate::utils::repo;
+    use super::*;
     use owo_colors::AnsiColors;
-
-    fn repo(name: &str) -> Result<Repository> {
-        let name = name.to_string();
-        let repo_path = gix_testtools::scripted_fixture_read_only(name).unwrap();
-        let safe_repo = ThreadSafeRepository::open_opts(repo_path, open::Options::isolated())?;
-        Ok(safe_repo.to_thread_local())
-    }
 
     #[test]
     fn test_get_git_username() -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,7 @@
 pub mod cli;
 pub mod info;
 pub mod ui;
+// Provide the git repo setup function for benchmarks, integration tests and
+// some unit tests via a library module to avoid code duplication.
+#[cfg(feature = "test-utils")]
+pub mod utils;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use gix::{open, Repository, ThreadSafeRepository};
+
+pub fn repo(name: &str) -> Result<Repository> {
+    let name = name.to_string();
+    let repo_path = gix_testtools::scripted_fixture_read_only(name).unwrap();
+    let safe_repo = ThreadSafeRepository::open_opts(repo_path, open::Options::isolated())?;
+    Ok(safe_repo.to_thread_local())
+}

--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -1,14 +1,7 @@
 use anyhow::Result;
-use gix::{open, Repository, ThreadSafeRepository};
 use onefetch::cli::{CliOptions, TextForamttingCliOptions};
 use onefetch::info::{get_work_dir, Info};
-
-fn repo(name: &str) -> Result<Repository> {
-    let name = name.to_string();
-    let repo_path = gix_testtools::scripted_fixture_read_only(name).unwrap();
-    let safe_repo = ThreadSafeRepository::open_opts(repo_path, open::Options::isolated())?;
-    Ok(safe_repo.to_thread_local())
-}
+use onefetch::utils::repo;
 
 #[test]
 fn test_bare_repo() -> Result<()> {


### PR DESCRIPTION
test_info_style_info() and test_info_style_subtitle() fail with `Error: Could not find a git repository in '.' or in any of its parents` if the current working directory is not a git repository. This breaks workflows of e.g. Linux distributions which download tarballs from Github.

Currently, the `fn repo(name: &str) -> Result<Repository>` git repository setup function is duplicated across benchmarking, integration and unit tests. This pull requests unifies it under an opt-in library function via the `test-utils` feature and fixes the aforementioned tests.

I chose to handle this with a feature, because when compiling integration tests, `#[cfg(test)]` [is not active ](https://stackoverflow.com/a/68877141) and the normally compiled lib gets linked against them.
[Using a workaround](https://github.com/rust-lang/cargo/issues/2911#issuecomment-1464060655), the `test-utils` feature and all tests depending on it, are enabled by default for testing and benchmarking.

As of now, it is not possible to add dependencies [based on optional features](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies), which is why I had to move `gix-testtools` to [dependencies].