### PR TITLE
docs: add a `cmd.exe` version of the `cd` snippet

### DIFF
--- a/.github/wiki/Getting-Started.md
+++ b/.github/wiki/Getting-Started.md
@@ -66,6 +66,15 @@ funcsave cd
 funcsave check_directory_for_new_repository
 ```
 
+By [**@mataha**](https://github.com/mataha)
+
+An adaptation of the above snippet suited for Windows's `cmd.exe`,
+specifically for inclusion in `AutoRun` or DOSKEY scripts:
+```cmd
+@set LAST_REPOSITORY=
+@doskey cd = @(if "$*"=="" (chdir /d "%%HOMEDRIVE%%%%HOMEPATH%%") else (chdir /d $*)) ^&^& (for /f "usebackq tokens=* delims=" %%i in (`"git rev-parse --show-toplevel 2$Gnul"`) do @(if not "%%~i"=="" if not "%%~i"=="%%LAST_REPOSITORY%%" (onefetch ^& set "LAST_REPOSITORY=%%~i")))
+```
+
 By @mbrehin
 ```sh
 # Add Git alias for onefetch.

--- a/.github/wiki/Getting-Started.md
+++ b/.github/wiki/Getting-Started.md
@@ -14,12 +14,12 @@ Onefetch is installed, then what?
 
 ### Misc
 
-By @spenserblack
+By [**@spenserblack**](https://github.com/spenserblack)
 ```sh
 # Runs `onefetch -a Assembly`, `onefetch -a C`, etc.
 onefetch -l | tr "[:upper:] " "[:lower:]-" | while read line; do echo "$line"; onefetch -a $line; done;
 ```
-By @quazar-omega
+By [**@quazar-omega**](https://github.com/quazar-omega)
 
 A script to put in your `.bashrc` - or `.zshrc` - to run onefetch whenever you open a shell into a repository or `cd` into a repository, making sure that it's different from the last one you were in:
 ```sh
@@ -44,7 +44,7 @@ cd() {
 check_directory_for_new_repository
 ```
 
-By @TheSast
+By [**@TheSast**](https://github.com/TheSast)
 
 A fish adaptation of the previous script, run it once in your shell to save it:
 ```fish
@@ -72,10 +72,10 @@ An adaptation of the above snippet suited for Windows's `cmd.exe`,
 specifically for inclusion in `AutoRun` or DOSKEY scripts:
 ```cmd
 @set LAST_REPOSITORY=
-@doskey cd = @(if "$*"=="" (chdir /d "%%HOMEDRIVE%%%%HOMEPATH%%") else (chdir /d $*)) ^&^& (for /f "usebackq tokens=* delims=" %%i in (`"git rev-parse --show-toplevel 2$Gnul"`) do @(if not "%%~i"=="" if not "%%~i"=="%%LAST_REPOSITORY%%" (onefetch ^& set "LAST_REPOSITORY=%%~i")))
+@doskey cd = @(if "$*"=="" (chdir /d "%%USERPROFILE%%") else (chdir /d $*)) ^&^& (for /f "usebackq tokens=* delims=" %%i in (`"git rev-parse --show-toplevel 2$Gnul"`) do @(if not "%%~i"=="" if not "%%~i"=="%%LAST_REPOSITORY%%" (onefetch ^& set "LAST_REPOSITORY=%%~i")))
 ```
 
-By @mbrehin
+By [**@mbrehin**](https://github.com/mbrehin)
 ```sh
 # Add Git alias for onefetch.
 git config --global alias.project-summary '!which onefetch && onefetch'


### PR DESCRIPTION
Hello,

I would like to include a snippet that presents usage of git combined with `onefetch` in `cmd.exe`, as I felt Windows shells were heavily underrepresented on that front.

It is suited for use in `AutoRun` scripts (something akin to `.bashrc` or `.bash_profile`, but isn't enabled by default).