### PR TITLE
don't fail when computing diff on partial clones

### DIFF
--- a/src/info/git/mod.rs
+++ b/src/info/git/mod.rs
@@ -180,7 +180,11 @@ fn get_churn_channel(
             let mut number_of_diffs_computed = 0;
             while let Ok(commit_id) = rx.recv() {
                 let commit = repo.find_object(commit_id)?.into_commit();
-                compute_diff_with_parent(&mut number_of_commits_by_file_path, &commit, &repo)?;
+                if compute_diff_with_parent(&mut number_of_commits_by_file_path, &commit, &repo)
+                    .is_err()
+                {
+                    continue;
+                };
                 number_of_diffs_computed += 1;
                 if should_break(
                     has_commit_graph_traversal_ended.load(Ordering::Relaxed),

--- a/src/info/git/mod.rs
+++ b/src/info/git/mod.rs
@@ -180,11 +180,7 @@ fn get_churn_channel(
             let mut number_of_diffs_computed = 0;
             while let Ok(commit_id) = rx.recv() {
                 let commit = repo.find_object(commit_id)?.into_commit();
-                if compute_diff_with_parent(&mut number_of_commits_by_file_path, &commit, &repo)
-                    .is_err()
-                {
-                    continue;
-                };
+                compute_diff_with_parent(&mut number_of_commits_by_file_path, &commit, &repo)?;
                 number_of_diffs_computed += 1;
                 if should_break(
                     has_commit_graph_traversal_ended.load(Ordering::Relaxed),
@@ -253,6 +249,7 @@ fn compute_diff_with_parent(
             .into_tree()
             .changes()?
             .track_path()
+            .track_rewrites(None)
             .for_each_to_obtain_tree(&commit.tree()?, |change| {
                 let is_file_change = match change.event {
                     Event::Addition { entry_mode, .. } | Event::Modification { entry_mode, .. } => {

--- a/tests/fixtures/make_partial_repo.sh
+++ b/tests/fixtures/make_partial_repo.sh
@@ -18,6 +18,14 @@ mkdir base
     git add code.rs
     git commit -q -m c4
     echo more >> code.rs
+    git mv code.rs renamed.rs
+    echo change >> renamed.rs
+    git commit -q -am c5
+
+    git config uploadpack.allowfilter true
 )
 
 git clone --filter=blob:none file://$PWD/base partial
+(cd partial
+    git config diff.renames true
+)

--- a/tests/fixtures/make_partial_repo.sh
+++ b/tests/fixtures/make_partial_repo.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eu -o pipefail
+
+mkdir base
+(cd base
+    git init -q
+    git checkout -b main
+    touch code.rs
+    git add code.rs
+    git commit -q -m c1
+    echo hello >> code.rs
+    git add code.rs
+    git commit -q -m c2
+    echo world >> code.rs
+    git add code.rs
+    git commit -q -m c3
+    echo something >> code.rs
+    git add code.rs
+    git commit -q -m c4
+    echo more >> code.rs
+)
+
+git clone --filter=blob:none file://$PWD/base partial

--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -80,8 +80,6 @@ fn test_partial_repo() -> Result<()> {
         input: repo.path().to_path_buf(),
         ..Default::default()
     };
-    let info = build_info(&config);
-    assert!(info.is_ok());
-
+    let _info = build_info(&config).expect("no error");
     Ok(())
 }

--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -4,8 +4,15 @@ use onefetch::cli::{CliOptions, InfoCliOptions, TextForamttingCliOptions};
 use onefetch::info::{build_info, get_work_dir};
 
 fn repo(name: &str) -> Result<Repository> {
-    let name = name.to_string();
     let repo_path = gix_testtools::scripted_fixture_read_only(name).unwrap();
+    let safe_repo = ThreadSafeRepository::open_opts(repo_path, open::Options::isolated())?;
+    Ok(safe_repo.to_thread_local())
+}
+
+pub fn named_repo(fixture: &str, name: &str) -> Result<Repository> {
+    let repo_path = gix_testtools::scripted_fixture_read_only(fixture)
+        .unwrap()
+        .join(name);
     let safe_repo = ThreadSafeRepository::open_opts(repo_path, open::Options::isolated())?;
     Ok(safe_repo.to_thread_local())
 }
@@ -56,6 +63,19 @@ fn test_repo() -> Result<()> {
 #[test]
 fn test_repo_without_remote() -> Result<()> {
     let repo = repo("basic_repo.sh")?;
+    let config: CliOptions = CliOptions {
+        input: repo.path().to_path_buf(),
+        ..Default::default()
+    };
+    let info = build_info(&config);
+    assert!(info.is_ok());
+
+    Ok(())
+}
+
+#[test]
+fn test_partial_repo() -> Result<()> {
+    let repo = named_repo("make_partial_repo.sh", "partial")?;
     let config: CliOptions = CliOptions {
         input: repo.path().to_path_buf(),
         ..Default::default()


### PR DESCRIPTION
fix for #1092 

I tested it manually on the repo that caused the issue `git clone --filter=blob:none https://github.com/sharkdp/fd` and it seems to work fine. 

However, I couldn't reproduce the bug with an integration test (cf. comment below)😢