### PR TITLE
Group clap dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,11 @@ version: 2
 updates:
   - package-ecosystem: cargo
     directory: "/"
+    groups:
+      clap:
+        patterns:
+          - "clap"
+          - "clap_*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
[Dependabot now supports grouping dependency updates](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/)

Since `clap_complete` is likely to be dependent on `clap`, it seemed like a good idea to group them.