### PR TITLE
Group all NPM dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,9 @@ updates:
       interval: "weekly"
   - package-ecosystem: npm
     directory: /docs/vercel
+    groups:
+      site:
+        patterns:
+          - "*"
     schedule:
       interval: monthly


### PR DESCRIPTION
https://github.com/o2sh/onefetch/pull/1101#pullrequestreview-1508986895

I don't see any harm in grouping them all, but we could potentially break them out into typescript-eslint, svelte, etc. if we want.

Although this has gotten me thinking how much we should even care about keeping the site's dependencies up-to-date :thinking: