### PR TITLE
exclude files from churn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,12 +230,11 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "once_cell",
  "regex-automata",
  "serde",
 ]
@@ -1899,11 +1898,11 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+checksum = "1391ab1f92ffcc08911957149833e682aa3fe252b9f45f966d2ef972274c97df"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick 1.0.2",
  "bstr",
  "fnv",
  "log",
@@ -2536,6 +2535,7 @@ dependencies = [
  "gix",
  "gix-features 0.31.1",
  "gix-testtools",
+ "globset",
  "human-panic",
  "image",
  "insta",
@@ -2994,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ gix = { version = "0.48.0", default-features = false, features = [
     "max-performance-safe",
 ] }
 git2 = { version = "0.17.2", default-features = false }
+globset = "0.4.11"
 human-panic = "1.1.5"
 image = "0.24.6"
 num-format = "0.4.4"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,8 +73,8 @@ pub struct InfoCliOptions {
     #[arg(long, value_name = "NUM")]
     pub churn_pool_size: Option<usize>,
     /// Ignore all files & directories matching EXCLUDE
-    #[arg(long, short, num_args = 1.., value_hint = ValueHint::AnyPath)]
-    pub exclude: Vec<PathBuf>,
+    #[arg(long, short, num_args = 1..)]
+    pub exclude: Vec<String>,
     /// Exclude [bot] commits. Use <REGEX> to override the default pattern
     #[arg(long, value_name = "REGEX")]
     pub no_bots: Option<Option<MyRegex>>,

--- a/src/info/author.rs
+++ b/src/info/author.rs
@@ -6,7 +6,7 @@ use crate::{
 use serde::Serialize;
 use std::fmt::Write;
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Author {
     pub name: String,

--- a/src/info/churn.rs
+++ b/src/info/churn.rs
@@ -3,7 +3,7 @@ use crate::{cli::NumberSeparator, info::format_number};
 use serde::Serialize;
 use std::fmt::Write;
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct FileChurn {
     pub file_path: String,

--- a/src/info/langs/mod.rs
+++ b/src/info/langs/mod.rs
@@ -19,7 +19,6 @@ pub fn get_loc_by_language_sorted(
     language_types: &[LanguageType],
     include_hidden: bool,
 ) -> Result<Vec<(Language, usize)>> {
-    println!("{}", dir.to_str().unwrap());
     let stats = get_statistics(dir, globs_to_exclude, language_types, include_hidden);
 
     let loc_by_language =

--- a/src/info/langs/mod.rs
+++ b/src/info/langs/mod.rs
@@ -1,9 +1,7 @@
 use anyhow::{Context, Result};
 use language::{Language, LanguageType};
-use regex::Regex;
 use std::collections::HashMap;
 use std::path::Path;
-use std::path::PathBuf;
 use strum::IntoEnumIterator;
 
 pub mod language;
@@ -17,11 +15,12 @@ pub fn get_main_language(loc_by_language: &[(Language, usize)]) -> Language {
 /// The vector is sorted by loc in descending order.
 pub fn get_loc_by_language_sorted(
     dir: &Path,
-    ignored_directories: &[PathBuf],
+    globs_to_exclude: &[String],
     language_types: &[LanguageType],
     include_hidden: bool,
 ) -> Result<Vec<(Language, usize)>> {
-    let stats = get_statistics(dir, ignored_directories, language_types, include_hidden);
+    println!("{}", dir.to_str().unwrap());
+    let stats = get_statistics(dir, globs_to_exclude, language_types, include_hidden);
 
     let loc_by_language =
         get_loc_by_language(&stats).context("Could not find any source code in this repository")?;
@@ -65,7 +64,7 @@ pub fn get_total_loc(loc_by_language: &[(Language, usize)]) -> usize {
 
 fn get_statistics(
     dir: &Path,
-    ignored_directories: &[PathBuf],
+    globs_to_exclude: &[String],
     language_types: &[LanguageType],
     include_hidden: bool,
 ) -> tokei::Languages {
@@ -77,8 +76,7 @@ fn get_statistics(
         hidden: Some(include_hidden),
         ..tokei::Config::default()
     };
-    let user_ignored = get_ignored_directories(ignored_directories);
-    let ignored: Vec<&str> = user_ignored.iter().map(AsRef::as_ref).collect();
+    let ignored: Vec<&str> = globs_to_exclude.iter().map(AsRef::as_ref).collect();
     languages.get_statistics(&[&dir], &ignored, &tokei_config);
     languages
 }
@@ -88,23 +86,6 @@ fn filter_languages_on_type(types: &[LanguageType]) -> Vec<tokei::LanguageType> 
         .filter(|language| types.contains(&language.get_type()))
         .map(std::convert::Into::into)
         .collect()
-}
-
-fn get_ignored_directories(user_ignored_directories: &[PathBuf]) -> Vec<String> {
-    let mut ignored_directories = Vec::new();
-    if !user_ignored_directories.is_empty() {
-        let re = Regex::new(r"((.*)+/)+(.*)").unwrap();
-        for user_ignored_directory in user_ignored_directories {
-            let dir = user_ignored_directory.display().to_string();
-            if re.is_match(&dir) {
-                let prefix = if dir.starts_with('/') { "**" } else { "**/" };
-                ignored_directories.push(format!("{prefix}{dir}"));
-            } else {
-                ignored_directories.push(dir);
-            }
-        }
-    }
-    ignored_directories
 }
 
 #[cfg(test)]

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -134,14 +134,14 @@ pub fn build_info(cli_options: &CliOptions) -> Result<Info> {
     let repo_path = get_work_dir(&repo)?;
 
     let loc_by_language_sorted_handle = std::thread::spawn({
-        let ignored_directories = cli_options.info.exclude.clone();
+        let globs_to_exclude = cli_options.info.exclude.clone();
         let language_types = cli_options.info.r#type.clone();
         let include_hidden = cli_options.info.include_hidden;
         let workdir = repo_path.clone();
         move || {
             langs::get_loc_by_language_sorted(
                 &workdir,
-                &ignored_directories,
+                &globs_to_exclude,
                 &language_types,
                 include_hidden,
             )


### PR DESCRIPTION
As suggested in #1091 

I went for the simpler option of reusing the `--exclude` flag for the churn files.