### PR TITLE
Detect Windows Terminal as a true color terminal

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -302,6 +302,8 @@ pub fn is_truecolor_terminal() -> bool {
     env::var("COLORTERM")
         .map(|colorterm| colorterm == "truecolor" || colorterm == "24bit")
         .unwrap_or(false)
+        // Windows Terminal
+        || env::var("WT_SESSION").is_ok()
 }
 
 pub fn get_git_version() -> String {


### PR DESCRIPTION
Windows terminal does not seem to set `COLORTERM`, but it is capable of
the full range of RGB values. This detects if the `WT_SESSION`
environment variable is set to determine if this session is in Windows
Terminal.

Fixes #1199
