### PR TITLE
Resolve clippy warnings

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -385,7 +385,7 @@ mod test {
 
         assert_eq!(
             config,
-            CliOptions::parse_from(&[
+            CliOptions::parse_from([
                 "onefetch",
                 "/tmp/folder",
                 "--number-of-authors",
@@ -406,22 +406,22 @@ mod test {
 
     #[test]
     fn test_config_with_image_protocol_but_no_image() {
-        assert!(CliOptions::try_parse_from(&["onefetch", "--image-protocol", "sixel"]).is_err())
+        assert!(CliOptions::try_parse_from(["onefetch", "--image-protocol", "sixel"]).is_err())
     }
 
     #[test]
     fn test_config_with_color_resolution_but_no_image() {
-        assert!(CliOptions::try_parse_from(&["onefetch", "--color-resolution", "32"]).is_err())
+        assert!(CliOptions::try_parse_from(["onefetch", "--color-resolution", "32"]).is_err())
     }
 
     #[test]
     fn test_config_with_ascii_colors_but_out_of_bounds() {
-        assert!(CliOptions::try_parse_from(&["onefetch", "--ascii-colors", "17"]).is_err())
+        assert!(CliOptions::try_parse_from(["onefetch", "--ascii-colors", "17"]).is_err())
     }
 
     #[test]
     fn test_config_with_text_colors_but_out_of_bounds() {
-        assert!(CliOptions::try_parse_from(&["onefetch", "--text-colors", "17"]).is_err())
+        assert!(CliOptions::try_parse_from(["onefetch", "--text-colors", "17"]).is_err())
     }
 }
 


### PR DESCRIPTION
This removes unnecessary references (not raised by clippy, but fixed with `cargo clippy --fix`)
and simplifies the return type signatures.
