### PR TITLE
Refactor and test info field styling

### DIFF
--- a/src/info/author.rs
+++ b/src/info/author.rs
@@ -126,6 +126,9 @@ impl InfoField for AuthorsInfo {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::ui::text_colors::TextColors;
+    use insta::assert_snapshot;
+    use owo_colors::DynColors;
 
     #[test]
     fn test_display_author() {
@@ -190,7 +193,7 @@ mod test {
     }
 
     #[test]
-    fn test_author_info_value_with_one_author() {
+    fn test_author_info_with_one_author() {
         let author = Author::new(
             "John Doe".into(),
             Some("john.doe@email.com".into()),
@@ -202,15 +205,17 @@ mod test {
         let authors_info = AuthorsInfo {
             authors: vec![author],
         };
+        let colors = TextColors::new(&[], DynColors::Rgb(0xFF, 0xFF, 0xFF));
+        let mut buffer = String::new();
+        authors_info
+            .write_styled(&mut buffer, false, &colors)
+            .unwrap();
 
-        assert_eq!(
-            authors_info.value(),
-            "75% John Doe <john.doe@email.com> 1500".to_string()
-        );
+        assert_snapshot!(buffer);
     }
 
     #[test]
-    fn test_author_info_value_with_two_authors() {
+    fn test_author_info_with_two_authors() {
         let author = Author::new(
             "John Doe".into(),
             Some("john.doe@email.com".into()),
@@ -231,16 +236,16 @@ mod test {
             authors: vec![author, author_2],
         };
 
-        assert!(authors_info
-            .value()
-            .contains(&"75% John Doe <john.doe@email.com> 1500".to_string()));
+        let colors = TextColors::new(&[], DynColors::Rgb(0xFF, 0xFF, 0xFF));
+        let mut buffer = String::new();
+        authors_info
+            .write_styled(&mut buffer, false, &colors)
+            .unwrap();
 
-        assert!(authors_info
-            .value()
-            .contains(&"80% Roberto Berto 240".to_string()));
+        assert_snapshot!(buffer);
     }
     #[test]
-    fn test_author_info_value_alignment_with_three_authors() {
+    fn test_author_info_alignment_with_three_authors() {
         let author = Author::new(
             "John Doe".into(),
             Some("john.doe@email.com".into()),
@@ -263,15 +268,12 @@ mod test {
             authors: vec![author, author_2, author_3],
         };
 
-        assert!(authors_info
-            .value()
-            .contains(&"75% John Doe <john.doe@email.com> 1500".to_string()));
+        let colors = TextColors::new(&[], DynColors::Rgb(0xFF, 0xFF, 0xFF));
+        let mut buffer = String::new();
+        authors_info
+            .write_styled(&mut buffer, false, &colors)
+            .unwrap();
 
-        assert!(authors_info
-            .value()
-            .contains(&"80% Roberto Berto 240".to_string()));
-
-        // Note the extra leading space to right-align the percentages
-        assert!(authors_info.value().contains(&" 1% Jane Doe 1".to_string()));
+        assert_snapshot!(buffer);
     }
 }

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -87,16 +87,7 @@ impl std::fmt::Display for Info {
 
         //Info lines
         for info_field in self.info_fields.iter() {
-            let info_field_value = info_field.value();
-            if !info_field_value.is_empty() {
-                write_styled_info_line(
-                    f,
-                    &info_field.title(),
-                    &info_field_value,
-                    self.no_bold,
-                    &self.text_colors,
-                )?;
-            }
+            info_field.write_styled(f, self.no_bold, &self.text_colors)?;
         }
 
         //Palette
@@ -418,43 +409,6 @@ impl InfoBuilder {
     }
 }
 
-fn write_styled_info_line(
-    f: &mut std::fmt::Formatter,
-    subtitle: &str,
-    info: &str,
-    no_bold: bool,
-    text_colors: &TextColors,
-) -> std::fmt::Result {
-    writeln!(
-        f,
-        "{} {}",
-        style_subtitle(subtitle, text_colors, no_bold),
-        style_info(info, text_colors)
-    )
-}
-
-fn style_info(info: &str, text_colors: &TextColors) -> String {
-    let info_lines: Vec<&str> = info.lines().collect();
-    let info_style = get_style(false, text_colors.info);
-
-    let styled_lines: Vec<String> = info_lines
-        .iter()
-        .map(|line| format!("{}", line.style(info_style)))
-        .collect();
-
-    styled_lines.join("\n")
-}
-
-fn style_subtitle(subtitle: &str, text_colors: &TextColors, no_bold: bool) -> String {
-    let subtitle_style = get_style(!no_bold, text_colors.subtitle);
-    let colon_style = get_style(!no_bold, text_colors.colon);
-    format!(
-        "{}{}",
-        subtitle.style(subtitle_style),
-        ":".style(colon_style)
-    )
-}
-
 fn get_style(is_bold: bool, color: DynColors) -> Style {
     let mut style = Style::new().color(color);
     if is_bold {
@@ -524,27 +478,6 @@ mod tests {
         assert_eq!(
             &format_number(&1_000_000, NumberSeparator::Plain),
             "1000000"
-        );
-    }
-
-    #[test]
-    fn test_info_style_info() {
-        let text_colors = TextColors::new(&[0, 0, 0, 0, 0, 0], DynColors::Ansi(AnsiColors::Blue));
-
-        let info_text = style_info("foo", &text_colors);
-        // Rendered text: black `foo`
-        assert_eq!(info_text, "\u{1b}[30mfoo\u{1b}[0m");
-    }
-
-    #[test]
-    fn test_info_style_subtitle() {
-        let text_colors = TextColors::new(&[0, 0, 0, 0, 15, 0], DynColors::Ansi(AnsiColors::Blue));
-
-        let subtitle_text = style_subtitle("foo", &text_colors, false);
-        assert_eq!(
-            subtitle_text,
-            // Rendered text: black `foo` and bright white colon
-            "\u{1b}[30;1mfoo\u{1b}[0m\u{1b}[97;1m:\u{1b}[0m"
         );
     }
 }

--- a/src/info/snapshots/onefetch__info__author__test__author_info_alignment_with_three_authors.snap
+++ b/src/info/snapshots/onefetch__info__author__test__author_info_alignment_with_three_authors.snap
@@ -1,0 +1,8 @@
+---
+source: src/info/author.rs
+expression: buffer
+---
+[38;2;255;255;255;1mAuthors[0m[39;1m:[0m [39m75% John Doe <john.doe@email.com> 1500[0m
+[39m         80% Roberto Berto 240[0m
+[39m          1% Jane Doe 1[0m
+

--- a/src/info/snapshots/onefetch__info__author__test__author_info_with_one_author.snap
+++ b/src/info/snapshots/onefetch__info__author__test__author_info_with_one_author.snap
@@ -1,0 +1,6 @@
+---
+source: src/info/author.rs
+expression: buffer
+---
+[38;2;255;255;255;1mAuthor[0m[39;1m:[0m [39m75% John Doe <john.doe@email.com> 1500[0m
+

--- a/src/info/snapshots/onefetch__info__author__test__author_info_with_two_authors.snap
+++ b/src/info/snapshots/onefetch__info__author__test__author_info_with_two_authors.snap
@@ -1,0 +1,7 @@
+---
+source: src/info/author.rs
+expression: buffer
+---
+[38;2;255;255;255;1mAuthors[0m[39;1m:[0m [39m75% John Doe <john.doe@email.com> 1500[0m
+[39m         80% Roberto Berto 240[0m
+

--- a/src/info/utils/info_field.rs
+++ b/src/info/utils/info_field.rs
@@ -1,7 +1,59 @@
+use super::super::get_style;
+use crate::ui::text_colors::TextColors;
+use owo_colors::OwoColorize;
+use std::fmt;
+
 #[typetag::serialize]
 pub trait InfoField {
     fn value(&self) -> String;
     fn title(&self) -> String;
+
+    /// Writes the styled info field. If the info doesn't have a value, nothing is
+    /// written.
+    fn write_styled(
+        &self,
+        w: &mut dyn fmt::Write,
+        no_bold: bool,
+        text_colors: &TextColors,
+    ) -> fmt::Result {
+        if let Some(styled_value) = self.style_value(text_colors) {
+            writeln!(
+                w,
+                "{} {}",
+                self.style_title(text_colors, no_bold),
+                styled_value
+            )
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Returns a styled version of the info field's title.
+    fn style_title(&self, text_colors: &TextColors, no_bold: bool) -> String {
+        let subtitle_style = get_style(!no_bold, text_colors.subtitle);
+        let colon_style = get_style(!no_bold, text_colors.colon);
+        format!(
+            "{}{}",
+            self.title().style(subtitle_style),
+            ":".style(colon_style)
+        )
+    }
+
+    /// Returns a styled version of the info field's value. This can be `None` if the
+    /// value is empty.
+    fn style_value(&self, text_colors: &TextColors) -> Option<String> {
+        let value = self.value();
+        if value.is_empty() {
+            return None;
+        }
+        let style = get_style(false, text_colors.info);
+        let styled_lines: Vec<String> = self
+            .value()
+            .lines()
+            .map(|line| format!("{}", line.style(style)))
+            .collect();
+        Some(styled_lines.join("\n"))
+    }
 }
 
 #[derive(Clone, clap::ValueEnum, Debug, Eq, PartialEq)]
@@ -27,6 +79,7 @@ pub enum InfoType {
 
 #[cfg(test)]
 mod test {
+    use owo_colors::DynColors;
     use serde::Serialize;
 
     use super::*;
@@ -50,5 +103,23 @@ mod test {
         let info = InfoFieldImpl("test");
         assert_eq!(info.title(), "title".to_string());
         assert_eq!(info.value(), "test".to_string());
+    }
+
+    #[test]
+    fn test_write_styled() {
+        let colors = TextColors::new(&[], DynColors::Rgb(0xFF, 0xFF, 0xFF));
+        let info = InfoFieldImpl("test");
+        let mut buffer = String::new();
+        info.write_styled(&mut buffer, false, &colors).unwrap();
+        insta::assert_snapshot!(buffer);
+    }
+
+    #[test]
+    fn test_write_styled_no_value() {
+        let colors = TextColors::new(&[], DynColors::Rgb(0xFF, 0xFF, 0xFF));
+        let info = InfoFieldImpl("");
+        let mut buffer = String::new();
+        info.write_styled(&mut buffer, false, &colors).unwrap();
+        assert_eq!(buffer, "", "It should not write anything");
     }
 }

--- a/src/info/utils/snapshots/onefetch__info__utils__info_field__test__write_styled.snap
+++ b/src/info/utils/snapshots/onefetch__info__utils__info_field__test__write_styled.snap
@@ -1,0 +1,6 @@
+---
+source: src/info/utils/info_field.rs
+expression: buffer
+---
+[38;2;255;255;255;1mtitle[0m[39;1m:[0m [39mtest[0m
+


### PR DESCRIPTION
This PR is to illustrate where we might want to switch to snapshot tests. With the change to alignment in #1207, for example, a snapshot test makes it much easier for a review to confirm proper alignment. "assert contains" isn't really an ideal test -- who knows how many leading or trailing characters there are from the test alone?

~~I'm leaving this as a draft right now because, as you can see, these snapshots look kind of weird. That's because they're testing `.value()`, which assumes that it will be preceded by a title. Thus, the `TODO` comment.~~

Edit: After working on this PR a bit to get more useful snapshot tests, I realized there was an opportunity to refactor a bit. This PR now moves the logic that styles info fields onto the `InfoField` trait, and then uses styled snapshot tests (you can view the styled output with `cat path/to/snapshot`) to test and visualize the outputs.