### PR TITLE
Refactoring git metrics module

### DIFF
--- a/src/info/authors.rs
+++ b/src/info/authors.rs
@@ -1,10 +1,10 @@
-use super::git::metrics::GitMetrics;
+use super::git::sig::Sig;
 use crate::{
     cli::NumberSeparator,
     info::utils::{format_number, info_field::InfoField},
 };
 use serde::Serialize;
-use std::fmt::Write;
+use std::{collections::HashMap, fmt::Write};
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -66,8 +66,20 @@ pub struct AuthorsInfo {
 }
 
 impl AuthorsInfo {
-    pub fn new(git_metrics: &GitMetrics) -> Self {
-        let authors = git_metrics.authors_to_display.clone();
+    pub fn new(
+        number_of_commits_by_signature: &HashMap<Sig, usize>,
+        total_number_of_commits: usize,
+        number_of_authors_to_display: usize,
+        show_email: bool,
+        number_separator: NumberSeparator,
+    ) -> Self {
+        let authors = compute_authors(
+            number_of_commits_by_signature,
+            total_number_of_commits,
+            number_of_authors_to_display,
+            show_email,
+            number_separator,
+        );
         Self { authors }
     }
 
@@ -77,6 +89,40 @@ impl AuthorsInfo {
         }
         0
     }
+}
+
+fn compute_authors(
+    number_of_commits_by_signature: &HashMap<Sig, usize>,
+    total_number_of_commits: usize,
+    number_of_authors_to_display: usize,
+    show_email: bool,
+    number_separator: NumberSeparator,
+) -> Vec<Author> {
+    let mut signature_with_number_of_commits_sorted: Vec<(&Sig, &usize)> =
+        Vec::from_iter(number_of_commits_by_signature);
+
+    signature_with_number_of_commits_sorted.sort_by(|(sa, a_count), (sb, b_count)| {
+        b_count.cmp(a_count).then_with(|| sa.name.cmp(&sb.name))
+    });
+
+    let authors: Vec<Author> = signature_with_number_of_commits_sorted
+        .into_iter()
+        .map(|(author, author_nbr_of_commits)| {
+            Author::new(
+                author.name.to_string(),
+                if show_email {
+                    Some(author.email.to_string())
+                } else {
+                    None
+                },
+                *author_nbr_of_commits,
+                total_number_of_commits,
+                number_separator,
+            )
+        })
+        .take(number_of_authors_to_display)
+        .collect();
+    authors
 }
 
 fn digit_difference(num1: usize, num2: usize) -> usize {
@@ -284,5 +330,49 @@ mod test {
     fn test_digit_difference(#[case] num1: usize, #[case] num2: usize, #[case] expected: usize) {
         let result = digit_difference(num1, num2);
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_compute_authors() {
+        let mut number_of_commits_by_signature: HashMap<Sig, usize> = HashMap::new();
+        number_of_commits_by_signature.insert(
+            Sig {
+                name: "John Doe".into(),
+                email: "johndoe@example.com".into(),
+            },
+            30,
+        );
+        number_of_commits_by_signature.insert(
+            Sig {
+                name: "Jane Doe".into(),
+                email: "janedoe@example.com".into(),
+            },
+            20,
+        );
+        number_of_commits_by_signature.insert(
+            Sig {
+                name: "Ellen Smith".into(),
+                email: "ellensmith@example.com".into(),
+            },
+            50,
+        );
+        let total_number_of_commits = 100;
+        let number_of_authors_to_display = 2;
+        let show_email = false;
+        let number_separator = NumberSeparator::Comma;
+
+        let actual = compute_authors(
+            &number_of_commits_by_signature,
+            total_number_of_commits,
+            number_of_authors_to_display,
+            show_email,
+            number_separator,
+        );
+
+        let expected = vec![
+            Author::new(String::from("Ellen Smith"), None, 50, 100, number_separator),
+            Author::new(String::from("John Doe"), None, 30, 100, number_separator),
+        ];
+        assert_eq!(actual, expected);
     }
 }

--- a/src/info/churn.rs
+++ b/src/info/churn.rs
@@ -45,6 +45,7 @@ pub struct ChurnInfo {
     pub file_churns: Vec<FileChurn>,
     pub churn_pool_size: usize,
 }
+
 impl ChurnInfo {
     pub fn new(
         number_of_commits_by_file_path: &HashMap<BString, usize>,

--- a/src/info/contributors.rs
+++ b/src/info/contributors.rs
@@ -1,4 +1,4 @@
-use super::{git::metrics::GitMetrics, utils::format_number};
+use super::utils::format_number;
 use crate::{cli::NumberSeparator, info::utils::info_field::InfoField};
 use serde::Serialize;
 
@@ -14,12 +14,12 @@ pub struct ContributorsInfo {
 
 impl ContributorsInfo {
     pub fn new(
-        git_metrics: &GitMetrics,
+        total_number_of_authors: usize,
         number_of_authors_to_display: usize,
         number_separator: NumberSeparator,
     ) -> Self {
         Self {
-            total_number_of_authors: git_metrics.total_number_of_authors,
+            total_number_of_authors,
             number_of_authors_to_display,
             number_separator,
         }
@@ -44,22 +44,10 @@ impl InfoField for ContributorsInfo {
 #[cfg(test)]
 mod test {
     use super::*;
-    use gix::date::Time;
 
     #[test]
     fn test_display_contributors_info() {
-        let timestamp = Time::now_utc();
-        let git_metrics = GitMetrics {
-            authors_to_display: vec![],
-            file_churns_to_display: vec![],
-            total_number_of_authors: 12,
-            total_number_of_commits: 2,
-            churn_pool_size: 0,
-            time_of_most_recent_commit: timestamp,
-            time_of_first_commit: timestamp,
-        };
-
-        let contributors_info = ContributorsInfo::new(&git_metrics, 2, NumberSeparator::Plain);
+        let contributors_info = ContributorsInfo::new(12, 2, NumberSeparator::Plain);
         assert_eq!(contributors_info.value(), "12".to_string());
         assert_eq!(contributors_info.title(), "Contributors".to_string());
     }

--- a/src/info/git/metrics.rs
+++ b/src/info/git/metrics.rs
@@ -1,16 +1,12 @@
 use super::sig::Sig;
-use crate::cli::{CliOptions, NumberSeparator};
-use crate::info::authors::Author;
-use crate::info::churn::FileChurn;
 use anyhow::Result;
 use gix::bstr::BString;
 use gix::date::Time;
-use globset::{Glob, GlobSetBuilder};
 use std::collections::HashMap;
 
 pub struct GitMetrics {
-    pub authors_to_display: Vec<Author>,
-    pub file_churns_to_display: Vec<FileChurn>,
+    pub number_of_commits_by_signature: HashMap<Sig, usize>,
+    pub number_of_commits_by_file_path: HashMap<BString, usize>,
     pub total_number_of_authors: usize,
     pub total_number_of_commits: usize,
     pub churn_pool_size: usize,
@@ -25,23 +21,9 @@ impl GitMetrics {
         churn_pool_size: usize,
         time_of_first_commit: Option<Time>,
         time_of_most_recent_commit: Option<Time>,
-        options: &CliOptions,
     ) -> Result<Self> {
         let total_number_of_commits = number_of_commits_by_signature.values().sum();
-        let (authors_to_display, total_number_of_authors) = compute_authors(
-            number_of_commits_by_signature,
-            total_number_of_commits,
-            options.info.number_of_authors,
-            options.info.email,
-            options.text_formatting.number_separator,
-        );
-
-        let file_churns_to_display = compute_file_churns(
-            number_of_commits_by_file_path,
-            options.info.number_of_file_churns,
-            options.text_formatting.number_separator,
-            &options.info.exclude,
-        )?;
+        let total_number_of_authors = number_of_commits_by_signature.len();
 
         // This could happen if a branch pointed to non-commit object, so no traversal actually happens.
         let (time_of_first_commit, time_of_most_recent_commit) = time_of_first_commit
@@ -49,162 +31,13 @@ impl GitMetrics {
             .unwrap_or_default();
 
         Ok(Self {
-            authors_to_display,
-            file_churns_to_display,
+            number_of_commits_by_signature,
+            number_of_commits_by_file_path,
             total_number_of_authors,
             total_number_of_commits,
             churn_pool_size,
             time_of_first_commit,
             time_of_most_recent_commit,
         })
-    }
-}
-
-fn compute_file_churns(
-    number_of_commits_by_file_path: HashMap<BString, usize>,
-    number_of_file_churns_to_display: usize,
-    number_separator: NumberSeparator,
-    globs_to_exclude: &[String],
-) -> Result<Vec<FileChurn>> {
-    let mut builder = GlobSetBuilder::new();
-    for glob in globs_to_exclude {
-        builder.add(Glob::new(glob)?);
-    }
-    let glob_set = builder.build()?;
-    let mut number_of_commits_by_file_path_sorted = Vec::from_iter(number_of_commits_by_file_path);
-
-    number_of_commits_by_file_path_sorted
-        .sort_by(|(_, a_count), (_, b_count)| b_count.cmp(a_count));
-
-    Ok(number_of_commits_by_file_path_sorted
-        .into_iter()
-        .filter_map(|(file_path, nbr_of_commits)| {
-            if !glob_set.is_match(file_path.to_string()) {
-                Some(FileChurn::new(
-                    file_path.to_string(),
-                    nbr_of_commits,
-                    number_separator,
-                ))
-            } else {
-                None
-            }
-        })
-        .take(number_of_file_churns_to_display)
-        .collect())
-}
-
-fn compute_authors(
-    number_of_commits_by_signature: HashMap<Sig, usize>,
-    total_number_of_commits: usize,
-    number_of_authors_to_display: usize,
-    show_email: bool,
-    number_separator: NumberSeparator,
-) -> (Vec<Author>, usize) {
-    let total_number_of_authors = number_of_commits_by_signature.len();
-    let mut signature_with_number_of_commits_sorted: Vec<(Sig, usize)> =
-        number_of_commits_by_signature.into_iter().collect();
-
-    signature_with_number_of_commits_sorted.sort_by(|(sa, a_count), (sb, b_count)| {
-        b_count.cmp(a_count).then_with(|| sa.name.cmp(&sb.name))
-    });
-
-    let authors: Vec<Author> = signature_with_number_of_commits_sorted
-        .into_iter()
-        .map(|(author, author_nbr_of_commits)| {
-            Author::new(
-                author.name.to_string(),
-                if show_email {
-                    Some(author.email.to_string())
-                } else {
-                    None
-                },
-                author_nbr_of_commits,
-                total_number_of_commits,
-                number_separator,
-            )
-        })
-        .take(number_of_authors_to_display)
-        .collect();
-    (authors, total_number_of_authors)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_compute_authors() {
-        let mut number_of_commits_by_signature: HashMap<Sig, usize> = HashMap::new();
-        number_of_commits_by_signature.insert(
-            Sig {
-                name: "John Doe".into(),
-                email: "johndoe@example.com".into(),
-            },
-            30,
-        );
-        number_of_commits_by_signature.insert(
-            Sig {
-                name: "Jane Doe".into(),
-                email: "janedoe@example.com".into(),
-            },
-            20,
-        );
-        number_of_commits_by_signature.insert(
-            Sig {
-                name: "Ellen Smith".into(),
-                email: "ellensmith@example.com".into(),
-            },
-            50,
-        );
-        let total_number_of_commits = 100;
-        let number_of_authors_to_display = 2;
-        let show_email = false;
-        let number_separator = NumberSeparator::Comma;
-
-        let (actual, total_number_of_authors) = compute_authors(
-            number_of_commits_by_signature,
-            total_number_of_commits,
-            number_of_authors_to_display,
-            show_email,
-            number_separator,
-        );
-
-        assert_eq!(total_number_of_authors, 3);
-        let expected = vec![
-            Author::new(String::from("Ellen Smith"), None, 50, 100, number_separator),
-            Author::new(String::from("John Doe"), None, 30, 100, number_separator),
-        ];
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_compute_file_churns() -> Result<()> {
-        let mut number_of_commits_by_file_path = HashMap::new();
-        number_of_commits_by_file_path.insert("path/to/file1.txt".into(), 2);
-        number_of_commits_by_file_path.insert("path/to/file2.txt".into(), 5);
-        number_of_commits_by_file_path.insert("path/to/file3.txt".into(), 3);
-        number_of_commits_by_file_path.insert("path/to/file4.txt".into(), 7);
-        number_of_commits_by_file_path.insert("foo/x/y/file.txt".into(), 70);
-        number_of_commits_by_file_path.insert("foo/x/file.txt".into(), 10);
-
-        let number_of_file_churns_to_display = 3;
-        let number_separator = NumberSeparator::Comma;
-        let globs_to_exclude = vec![
-            "foo/**/file.txt".to_string(),
-            "path/to/file2.txt".to_string(),
-        ];
-        let actual = compute_file_churns(
-            number_of_commits_by_file_path,
-            number_of_file_churns_to_display,
-            number_separator,
-            &globs_to_exclude,
-        )?;
-        let expected = vec![
-            FileChurn::new(String::from("path/to/file4.txt"), 7, number_separator),
-            FileChurn::new(String::from("path/to/file3.txt"), 3, number_separator),
-            FileChurn::new(String::from("path/to/file1.txt"), 2, number_separator),
-        ];
-        assert_eq!(actual, expected);
-        Ok(())
     }
 }

--- a/src/info/langs/language.rs
+++ b/src/info/langs/language.rs
@@ -20,7 +20,7 @@ pub struct LanguagesInfo {
     #[serde(skip_serializing)]
     true_color: bool,
     #[serde(skip_serializing)]
-    number_of_languages: usize,
+    number_of_languages_to_display: usize,
     #[serde(skip_serializing)]
     info_color: DynColors,
 }
@@ -29,7 +29,7 @@ impl LanguagesInfo {
     pub fn new(
         loc_by_language: &[(Language, usize)],
         true_color: bool,
-        number_of_languages: usize,
+        number_of_languages_to_display: usize,
         info_color: DynColors,
     ) -> Self {
         let total: usize = loc_by_language.iter().map(|(_, v)| v).sum();
@@ -54,7 +54,7 @@ impl LanguagesInfo {
         Self {
             languages_with_percentage,
             true_color,
-            number_of_languages,
+            number_of_languages_to_display,
             info_color,
         }
     }
@@ -125,10 +125,12 @@ fn prepare_languages(
                 (language.to_string(), percentage, circle_color)
             },
         );
-    if languages_info.languages_with_percentage.len() > languages_info.number_of_languages {
+    if languages_info.languages_with_percentage.len()
+        > languages_info.number_of_languages_to_display
+    {
         let mut languages = iter
             .by_ref()
-            .take(languages_info.number_of_languages)
+            .take(languages_info.number_of_languages_to_display)
             .collect::<Vec<_>>();
         let other_perc = iter.fold(0.0, |acc, x| acc + x.1);
         languages.push((
@@ -208,7 +210,7 @@ mod test {
                 percentage: 100_f64,
             }],
             true_color: false,
-            number_of_languages: 6,
+            number_of_languages_to_display: 6,
             info_color: DynColors::Ansi(AnsiColors::White),
         };
         let expected_languages_info = format!(
@@ -246,7 +248,7 @@ mod test {
                 },
             ],
             true_color: false,
-            number_of_languages: 2,
+            number_of_languages_to_display: 2,
             info_color: DynColors::Ansi(AnsiColors::White),
         };
 
@@ -316,7 +318,7 @@ mod test {
                 },
             ],
             true_color: false,
-            number_of_languages: 2,
+            number_of_languages_to_display: 2,
             info_color: DynColors::Ansi(AnsiColors::White),
         };
 

--- a/src/info/license.rs
+++ b/src/info/license.rs
@@ -99,9 +99,8 @@ impl InfoField for LicenseInfo {
 
 #[cfg(test)]
 mod test {
-    use onefetch_manifest::ManifestType;
-
     use super::*;
+    use onefetch_manifest::ManifestType;
 
     #[test]
     fn test_get_license() -> Result<()> {

--- a/src/info/loc.rs
+++ b/src/info/loc.rs
@@ -1,10 +1,8 @@
+use super::utils::format_number;
 use crate::info::langs::get_total_loc;
 use crate::info::langs::language::Language;
-use serde::Serialize;
-
 use crate::{cli::NumberSeparator, info::utils::info_field::InfoField};
-
-use super::utils::format_number;
+use serde::Serialize;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/info/utils/info_field.rs
+++ b/src/info/utils/info_field.rs
@@ -78,10 +78,9 @@ pub enum InfoType {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use owo_colors::DynColors;
     use serde::Serialize;
-
-    use super::*;
 
     #[derive(Serialize)]
     struct InfoFieldImpl(&'static str);

--- a/src/info/utils/mod.rs
+++ b/src/info/utils/mod.rs
@@ -1,12 +1,10 @@
-use std::time::{Duration, SystemTime};
-
+use crate::cli::NumberSeparator;
 use gix::date::Time;
 use num_format::ToFormattedString;
 use owo_colors::{DynColors, Style};
+use std::time::{Duration, SystemTime};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use time_humanize::HumanTime;
-
-use crate::cli::NumberSeparator;
 
 pub mod info_field;
 
@@ -59,10 +57,9 @@ pub fn get_style(is_bold: bool, color: DynColors) -> Style {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use owo_colors::AnsiColors;
     use rstest::rstest;
-
-    use super::*;
     use std::time::{Duration, SystemTime};
 
     #[test]


### PR DESCRIPTION
For a better separation of concerns, I've moved the `compute_authors` and `compute_file_churns` functions into their respective info field modules. Moreover, they won't be called if the user chooses to disable the corresponding info line -> better performance.