### PR TITLE
Resolve a few duplicate authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,3 @@
-Ossama Hjaji <ossama-hjaji@live.fr> <ossama-hjaji@live.fr>
+Ossama Hjaji <ossama-hjaji@live.fr> <ossama.hjaji@serensia.com>
+Komeil Parseh <ahmdparsh129@gmail.com>
+Eduardo Broto <ebroto@tutanota.com>


### PR DESCRIPTION
This resolves a few authors who had multiple names and the same email
into one name.

The duplicates were found with a script found here, but with a a reversed format (`%aN - %aE`):
https://github.com/moby/moby/blob/e8346c53d93d2cddf3d09910e166cdd8874070b3/.mailmap#L6C5-L6C109

This doesn't resolve all duplicates because it wasn't as obvious which name was the canonical name.
