### PR TITLE
Conclude `gitoxide` to `git2` transition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,19 +1125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
-name = "git2"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
-dependencies = [
- "bitflags 2.4.1",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "gix"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2601,18 +2588,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.16.2+1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,18 +2601,6 @@ checksum = "2468756f34903b582fe7154dc1ffdebd89d0562c4a43b53c621bb0f1b1043ccb"
 dependencies = [
  "cmake",
  "libc",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2853,7 +2816,6 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "enable-ansi-support",
- "git2",
  "gix",
  "gix-features 0.38.1",
  "gix-testtools",
@@ -4257,12 +4219,6 @@ checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.8",
@@ -908,18 +914,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fdeflate"
@@ -965,6 +962,12 @@ dependencies = [
  "pin-project",
  "spin",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -1136,47 +1139,49 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.58.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31887c304d9a935f3e5494fb5d6a0106c34e965168ec0db9b457424eedd0c741"
+checksum = "027b87106e07ab0965541f71dadd7db87be3f2b26feda3cce50028566a4dff0c"
 dependencies = [
- "gix-actor 0.30.0",
- "gix-attributes 0.22.0",
+ "gix-actor 0.31.0",
+ "gix-attributes 0.22.2",
  "gix-command",
- "gix-commitgraph 0.24.0",
+ "gix-commitgraph 0.24.2",
  "gix-config",
  "gix-date",
  "gix-diff",
- "gix-discover 0.29.0",
- "gix-features 0.38.0",
+ "gix-dir",
+ "gix-discover 0.31.0",
+ "gix-features 0.38.1",
  "gix-filter",
- "gix-fs 0.10.0",
- "gix-glob 0.16.0",
- "gix-hash 0.14.1",
- "gix-hashtable 0.5.1",
- "gix-ignore 0.11.0",
- "gix-index 0.29.0",
- "gix-lock 13.0.0",
+ "gix-fs 0.10.1",
+ "gix-glob 0.16.2",
+ "gix-hash 0.14.2",
+ "gix-hashtable 0.5.2",
+ "gix-ignore 0.11.2",
+ "gix-index 0.31.0",
+ "gix-lock 13.1.1",
  "gix-macros",
  "gix-mailmap",
- "gix-object 0.41.0",
+ "gix-object 0.42.0",
  "gix-odb",
  "gix-pack",
  "gix-path",
  "gix-pathspec",
- "gix-ref 0.41.0",
+ "gix-ref 0.43.0",
  "gix-refspec",
  "gix-revision",
- "gix-revwalk 0.12.0",
+ "gix-revwalk 0.13.0",
  "gix-sec",
+ "gix-status",
  "gix-submodule",
- "gix-tempfile 13.0.0",
+ "gix-tempfile 13.1.1",
  "gix-trace",
- "gix-traverse 0.37.0",
+ "gix-traverse 0.38.0",
  "gix-url",
  "gix-utils",
  "gix-validate",
- "gix-worktree 0.30.0",
+ "gix-worktree 0.32.0",
  "once_cell",
  "parking_lot 0.12.1",
  "smallvec",
@@ -1213,16 +1218,16 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7bb9fad6125c81372987c06469601d37e1a2d421511adb69971b9083517a8a"
+checksum = "3eb3230825b44deba727ec2e9c886c4ab350d34333ae17555973ceb5e5261471"
 dependencies = [
  "bstr",
- "btoi",
  "gix-date",
+ "gix-utils",
  "itoa",
  "thiserror",
- "winnow 0.5.27",
+ "winnow 0.6.5",
 ]
 
 [[package]]
@@ -1244,12 +1249,12 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214ee3792e504ee1ce206b36dcafa4f328ca313d1e2ac0b41433d68ef4e14260"
+checksum = "eefb48f42eac136a4a0023f49a54ec31be1c7a9589ed762c45dcb9b953f7ecc8"
 dependencies = [
  "bstr",
- "gix-glob 0.16.0",
+ "gix-glob 0.16.2",
  "gix-path",
  "gix-quote",
  "gix-trace",
@@ -1261,27 +1266,27 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b6cd0f246180034ddafac9b00a112f19178135b21eb031b3f79355891f7325"
+checksum = "a371db66cbd4e13f0ed9dc4c0fea712d7276805fccc877f77e96374d317e87ae"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003ec6deacf68076a0c157271a127e0bb2c031c1a41f7168cbe5d248d9b85c78"
+checksum = "45c8751169961ba7640b513c3b24af61aa962c967aaf04116734975cd5af0c52"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1ffc7db3fb50b7dae6ecd937a3527cb725f444614df2ad8988d81806f13f09"
+checksum = "f90009020dc4b3de47beed28e1334706e0a330ddd17f5cfeb097df3b15a54b77"
 dependencies = [
  "bstr",
  "gix-path",
@@ -1305,44 +1310,44 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.24.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82dbd7fb959862e3df2583331f0ad032ac93533e8a52f1b0694bc517f5d292bc"
+checksum = "f7b102311085da4af18823413b5176d7c500fb2272eaf391cfa8635d8bcb12c4"
 dependencies = [
  "bstr",
  "gix-chunk",
- "gix-features 0.38.0",
- "gix-hash 0.14.1",
+ "gix-features 0.38.1",
+ "gix-hash 0.14.2",
  "memmap2 0.9.0",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-config"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62bf2073b6ce3921ffa6d8326f645f30eec5fc4a8e8a4bc0fcb721a2f3f69dc"
+checksum = "62129c75e4b6229fe15fb9838cdc00c655e87105b651e4edd7c183fc5288b5d1"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.38.0",
- "gix-glob 0.16.0",
+ "gix-features 0.38.1",
+ "gix-glob 0.16.2",
  "gix-path",
- "gix-ref 0.41.0",
+ "gix-ref 0.43.0",
  "gix-sec",
  "memchr",
  "once_cell",
  "smallvec",
  "thiserror",
  "unicode-bom",
- "winnow 0.5.27",
+ "winnow 0.6.5",
 ]
 
 [[package]]
 name = "gix-config-value"
-version = "0.14.4"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e7bfb37a46ed0b8468db37a6d8a0a61d56bdbe4603ae492cb322e5f3958"
+checksum = "fbd06203b1a9b33a78c88252a625031b094d9e1b647260070c25b09910c0a804"
 dependencies = [
  "bitflags 2.4.1",
  "bstr",
@@ -1353,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7f3dfb72bebe3449b5e642be64e3c6ccbe9821c8b8f19f487cf5bfbbf4067e"
+checksum = "180b130a4a41870edfbd36ce4169c7090bca70e195da783dea088dd973daa59c"
 dependencies = [
  "bstr",
  "itoa",
@@ -1365,21 +1370,41 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdcb5e49c4b9729dd1c361040ae5c3cd7c497b2260b18c954f62db3a63e98cf"
+checksum = "78e605593c2ef74980a534ade0909c7dc57cca72baa30cbb67d2dda621f99ac4"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-filter",
- "gix-fs 0.10.0",
- "gix-hash 0.14.1",
- "gix-object 0.41.0",
+ "gix-fs 0.10.1",
+ "gix-hash 0.14.2",
+ "gix-object 0.42.0",
  "gix-path",
- "gix-tempfile 13.0.0",
+ "gix-tempfile 13.1.1",
  "gix-trace",
- "gix-worktree 0.30.0",
+ "gix-worktree 0.32.0",
  "imara-diff",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95fd43541d7214438ddfa3dc76c03acafb8c5708f3d6187cd225418cf71a377"
+dependencies = [
+ "bstr",
+ "gix-discover 0.31.0",
+ "gix-fs 0.10.1",
+ "gix-ignore 0.11.2",
+ "gix-index 0.31.0",
+ "gix-object 0.42.0",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree 0.32.0",
  "thiserror",
 ]
 
@@ -1400,16 +1425,16 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4669218f3ec0cbbf8f16857b32200890f8ca585f36f5817242e4115fe4551af"
+checksum = "64bab49087ed3710caf77e473dc0efc54ca33d8ccc6441359725f121211482b1"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.10.0",
- "gix-hash 0.14.1",
+ "gix-fs 0.10.1",
+ "gix-hash 0.14.2",
  "gix-path",
- "gix-ref 0.41.0",
+ "gix-ref 0.43.0",
  "gix-sec",
  "thiserror",
 ]
@@ -1443,14 +1468,14 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.38.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184f7f7d4e45db0e2a362aeaf12c06c5e84817d0ef91d08e8e90170dad9f0b07"
+checksum = "db4254037d20a247a0367aa79333750146a369719f0c6617fec4f5752cc62b37"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash 0.14.1",
+ "gix-hash 0.14.2",
  "gix-trace",
  "gix-utils",
  "jwalk",
@@ -1465,16 +1490,16 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9240862840fb740d209422937195e129e4ed3da49af212383260134bea8f6c1a"
+checksum = "bd71bf3e64d8fb5d5635d4166ca5a36fe56b292ffff06eab1d93ea47fd5beb89"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.22.0",
+ "gix-attributes 0.22.2",
  "gix-command",
- "gix-hash 0.14.1",
- "gix-object 0.41.0",
+ "gix-hash 0.14.2",
+ "gix-object 0.42.0",
  "gix-packetline-blocking",
  "gix-path",
  "gix-quote",
@@ -1504,11 +1529,11 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4436e883d5769f9fb18677b8712b49228357815f9e4104174a6fc2d8461a437b"
+checksum = "634b8a743b0aae03c1a74ee0ea24e8c5136895efac64ce52b3ea106e1c6f0613"
 dependencies = [
- "gix-features 0.38.0",
+ "gix-features 0.38.1",
  "gix-utils",
 ]
 
@@ -1526,13 +1551,13 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4965a1d06d0ab84a29d4a67697a97352ab14ae1da821084e5afb1fd6d8191ca0"
+checksum = "682bdc43cb3c00dbedfcc366de2a849b582efd8d886215dbad2ea662ec156bb5"
 dependencies = [
  "bitflags 2.4.1",
  "bstr",
- "gix-features 0.38.0",
+ "gix-features 0.38.1",
  "gix-path",
 ]
 
@@ -1548,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ed89cdc1dce26685c80271c4287077901de3c3dd90234d5fa47c22b2268653"
+checksum = "f93d7df7366121b5018f947a04d37f034717e113dcf9ccd85c34b58e57a74d5e"
 dependencies = [
  "faster-hex",
  "thiserror",
@@ -1563,18 +1588,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb61880816d7ec4f0b20606b498147d480860ddd9133ba542628df2f548d3ca"
 dependencies = [
  "gix-hash 0.13.3",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
  "parking_lot 0.12.1",
 ]
 
 [[package]]
 name = "gix-hashtable"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe47d8c0887f82355e2e9e16b6cecaa4d5e5346a7a474ca78ff94de1db35a5b"
+checksum = "7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242"
 dependencies = [
- "gix-hash 0.14.1",
- "hashbrown 0.14.0",
+ "gix-hash 0.14.2",
+ "hashbrown 0.14.3",
  "parking_lot 0.12.1",
 ]
 
@@ -1592,12 +1617,12 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7069aaca4a05784c4cb44e392f0eaf627c6e57e05d3100c0e2386a37a682f0"
+checksum = "640dbeb4f5829f9fc14d31f654a34a0350e43a24e32d551ad130d99bf01f63f1"
 dependencies = [
  "bstr",
- "gix-glob 0.16.0",
+ "gix-glob 0.16.2",
  "gix-path",
  "gix-trace",
  "unicode-bom",
@@ -1628,25 +1653,27 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7152181ba8f0a3addc5075dd612cea31fc3e252b29c8be8c45f4892bf87426"
+checksum = "8b7e07051ef3db0b124e0065e14b04f275d91a320fb7fadc273422ca91b87282"
 dependencies = [
  "bitflags 2.4.1",
  "bstr",
- "btoi",
  "filetime",
+ "fnv",
  "gix-bitmap",
- "gix-features 0.38.0",
- "gix-fs 0.10.0",
- "gix-hash 0.14.1",
- "gix-lock 13.0.0",
- "gix-object 0.41.0",
- "gix-traverse 0.37.0",
+ "gix-features 0.38.1",
+ "gix-fs 0.10.1",
+ "gix-hash 0.14.2",
+ "gix-lock 13.1.1",
+ "gix-object 0.42.0",
+ "gix-traverse 0.38.0",
+ "gix-utils",
+ "hashbrown 0.14.3",
  "itoa",
  "libc",
  "memmap2 0.9.0",
- "rustix 0.38.28",
+ "rustix 0.38.31",
  "smallvec",
  "thiserror",
 ]
@@ -1675,20 +1702,20 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "13.0.0"
+version = "13.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651e46174dc5e7d18b7b809d31937b6de3681b1debd78618c99162cc30fcf3e1"
+checksum = "e7c359f81f01b8352063319bcb39789b7ea0887b406406381106e38c4a34d049"
 dependencies = [
- "gix-tempfile 13.0.0",
+ "gix-tempfile 13.1.1",
  "gix-utils",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-macros"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75e7ab728059f595f6ddc1ad8771b8d6a231971ae493d9d5948ecad366ee8bb"
+checksum = "1dff438f14e67e7713ab9332f5fd18c8f20eb7eb249494f6c2bf170522224032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1697,12 +1724,12 @@ dependencies = [
 
 [[package]]
 name = "gix-mailmap"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8755c637aeeee7205fb605b4cfe5f8ff0ff48ad3d19b3ac98de7d0422538575"
+checksum = "28a62c86c08a65f99002013d58dd3312b2987705547436bdb90c507dcd9a41b1"
 dependencies = [
  "bstr",
- "gix-actor 0.30.0",
+ "gix-actor 0.31.0",
  "gix-date",
  "thiserror",
 ]
@@ -1747,35 +1774,35 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693ce9d30741506cb082ef2d8b797415b48e032cce0ab23eff894c19a7e4777b"
+checksum = "03e9e56e790cdd548dee951019b4f0575a00cdd95092d34ceddeb3294b34ef08"
 dependencies = [
  "bstr",
- "btoi",
- "gix-actor 0.30.0",
+ "gix-actor 0.31.0",
  "gix-date",
- "gix-features 0.38.0",
- "gix-hash 0.14.1",
+ "gix-features 0.38.1",
+ "gix-hash 0.14.2",
+ "gix-utils",
  "gix-validate",
  "itoa",
  "smallvec",
  "thiserror",
- "winnow 0.5.27",
+ "winnow 0.6.5",
 ]
 
 [[package]]
 name = "gix-odb"
-version = "0.57.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba2fa9e81f2461b78b4d81a807867667326c84cdab48e0aed7b73a593aa1be4"
+checksum = "81b55378c719693380f66d9dd21ce46721eed2981d8789fc698ec1ada6fa176e"
 dependencies = [
  "arc-swap",
  "gix-date",
- "gix-features 0.38.0",
- "gix-fs 0.10.0",
- "gix-hash 0.14.1",
- "gix-object 0.41.0",
+ "gix-features 0.38.1",
+ "gix-fs 0.10.1",
+ "gix-hash 0.14.2",
+ "gix-object 0.42.0",
  "gix-pack",
  "gix-path",
  "gix-quote",
@@ -1786,18 +1813,18 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.47.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da5f3e78c96b76c4e6fe5e8e06b76221e4a0ee9a255aa935ed1fdf68988dfd8"
+checksum = "6391aeaa030ad64aba346a9f5c69bb1c4e5c6fb4411705b03b40b49d8614ec30"
 dependencies = [
  "clru",
  "gix-chunk",
- "gix-features 0.38.0",
- "gix-hash 0.14.1",
- "gix-hashtable 0.5.1",
- "gix-object 0.41.0",
+ "gix-features 0.38.1",
+ "gix-hash 0.14.2",
+ "gix-hashtable 0.5.2",
+ "gix-object 0.42.0",
  "gix-path",
- "gix-tempfile 13.0.0",
+ "gix-tempfile 13.1.1",
  "memmap2 0.9.0",
  "parking_lot 0.12.1",
  "smallvec",
@@ -1819,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.5"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e9ad649bf5e109562d6acba657ca428661ec08e77eaf3a755d8fa55485be9c"
+checksum = "23623cf0f475691a6d943f898c4d0b89f5c1a2a64d0f92bce0e0322ee6528783"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1832,27 +1859,27 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbd49750edb26b0a691e5246fc635fa554d344da825cd20fa9ee0da9c1b761f"
+checksum = "9ca791acebbcb19703323c151115f029922fd8f91c5d187d50efbfe39447f6d8"
 dependencies = [
  "bitflags 2.4.1",
  "bstr",
- "gix-attributes 0.22.0",
+ "gix-attributes 0.22.2",
  "gix-config-value",
- "gix-glob 0.16.0",
+ "gix-glob 0.16.2",
  "gix-path",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-quote"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7dc10303d73a960d10fb82f81188b036ac3e6b11b5795b20b1a60b51d1321f"
+checksum = "cbff4f9b9ea3fa7a25a70ee62f545143abef624ac6aa5884344e70c8b0a1d9ff"
 dependencies = [
  "bstr",
- "btoi",
+ "gix-utils",
  "thiserror",
 ]
 
@@ -1879,34 +1906,34 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5818958994ad7879fa566f5441ebcc48f0926aa027b28948e6fbf6578894dc31"
+checksum = "fd4aba68b925101cb45d6df328979af0681364579db889098a0de75b36c77b65"
 dependencies = [
- "gix-actor 0.30.0",
+ "gix-actor 0.31.0",
  "gix-date",
- "gix-features 0.38.0",
- "gix-fs 0.10.0",
- "gix-hash 0.14.1",
- "gix-lock 13.0.0",
- "gix-object 0.41.0",
+ "gix-features 0.38.1",
+ "gix-fs 0.10.1",
+ "gix-hash 0.14.2",
+ "gix-lock 13.1.1",
+ "gix-object 0.42.0",
  "gix-path",
- "gix-tempfile 13.0.0",
+ "gix-tempfile 13.1.1",
  "gix-utils",
  "gix-validate",
  "memmap2 0.9.0",
  "thiserror",
- "winnow 0.5.27",
+ "winnow 0.6.5",
 ]
 
 [[package]]
 name = "gix-refspec"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613aa4d93034c5791d13bdc635e530f4ddab1412ddfb4a8215f76213177b61c7"
+checksum = "dde848865834a54fe4d9b4573f15d0e9a68eaf3d061b42d3ed52b4b8acf880b2"
 dependencies = [
  "bstr",
- "gix-hash 0.14.1",
+ "gix-hash 0.14.2",
  "gix-revision",
  "gix-validate",
  "smallvec",
@@ -1915,16 +1942,16 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288f6549d7666db74dc3f169a9a333694fc28ecd2f5aa7b2c979c89eb556751a"
+checksum = "9e34196e1969bd5d36e2fbc4467d893999132219d503e23474a8ad2b221cb1e8"
 dependencies = [
  "bstr",
  "gix-date",
- "gix-hash 0.14.1",
- "gix-hashtable 0.5.1",
- "gix-object 0.41.0",
- "gix-revwalk 0.12.0",
+ "gix-hash 0.14.2",
+ "gix-hashtable 0.5.2",
+ "gix-object 0.42.0",
+ "gix-revwalk 0.13.0",
  "gix-trace",
  "thiserror",
 ]
@@ -1946,24 +1973,24 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9b4d91dfc5c14fee61a28c65113ded720403b65a0f46169c0460f731a5d03c"
+checksum = "e0a7d393ae814eeaae41a333c0ff684b243121cc61ccdc5bbe9897094588047d"
 dependencies = [
- "gix-commitgraph 0.24.0",
+ "gix-commitgraph 0.24.2",
  "gix-date",
- "gix-hash 0.14.1",
- "gix-hashtable 0.5.1",
- "gix-object 0.41.0",
+ "gix-hash 0.14.2",
+ "gix-hashtable 0.5.2",
+ "gix-object 0.42.0",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-sec"
-version = "0.10.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d9bf462feaf05f2121cba7399dbc6c34d88a9cad58fc1e95027791d6a3c6d2"
+checksum = "fddc27984a643b20dd03e97790555804f98cf07404e0e552c0ad8133266a79a1"
 dependencies = [
  "bitflags 2.4.1",
  "gix-path",
@@ -1972,10 +1999,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-submodule"
-version = "0.8.0"
+name = "gix-status"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73182f6c1f5ed1ed94ba16581ac62593d5e29cd1c028b2af618f836283b8f8d4"
+checksum = "6e7b38b87242a05bacdde417455910e502b0360620ef423577b703b38b653b6a"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features 0.38.1",
+ "gix-filter",
+ "gix-fs 0.10.1",
+ "gix-hash 0.14.2",
+ "gix-index 0.31.0",
+ "gix-object 0.42.0",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree 0.32.0",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb7ea05666362472fecd44c1fc35fe48a5b9b841b431cc4f85b95e6f20c23ec"
 dependencies = [
  "bstr",
  "gix-config",
@@ -2016,12 +2065,12 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "13.0.0"
+version = "13.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d337955b7af00fb87120d053d87cdfb422a80b9ff7a3aa4057a99c79422dc30"
+checksum = "a761d76594f4443b675e85928e4902dec333273836bd386906f01e7e346a0d11"
 dependencies = [
  "dashmap 5.5.3",
- "gix-fs 0.10.0",
+ "gix-fs 0.10.1",
  "libc",
  "once_cell",
  "parking_lot 0.12.1",
@@ -2036,7 +2085,7 @@ checksum = "c77a0c519b75561e87ab6f800ab898b374535353ff93c5577b8da7c386bbf828"
 dependencies = [
  "bstr",
  "crc",
- "fastrand 2.0.0",
+ "fastrand",
  "fs_extra",
  "gix-discover 0.26.0",
  "gix-fs 0.8.1",
@@ -2056,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b202d766a7fefc596e2cc6a89cda8ad8ad733aed82da635ac120691112a9b1"
+checksum = "9b838b2db8f62c9447d483a4c28d251b67fee32741a82cb4d35e9eb4e9fdc5ab"
 
 [[package]]
 name = "gix-traverse"
@@ -2078,28 +2127,28 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc30c5b5e4e838683b59e1b0574ce6bc1c35916df9709aaab32bb7751daf08b"
+checksum = "95aef84bc777025403a09788b1e4815c06a19332e9e5d87a955e1ed7da9bf0cf"
 dependencies = [
- "gix-commitgraph 0.24.0",
+ "gix-commitgraph 0.24.2",
  "gix-date",
- "gix-hash 0.14.1",
- "gix-hashtable 0.5.1",
- "gix-object 0.41.0",
- "gix-revwalk 0.12.0",
+ "gix-hash 0.14.2",
+ "gix-hashtable 0.5.2",
+ "gix-object 0.42.0",
+ "gix-revwalk 0.13.0",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-url"
-version = "0.27.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f1981ecc700f4fd73ae62b9ca2da7c8816c8fd267f0185e3f8c21e967984ac"
+checksum = "8f0b24f3ecc79a5a53539de9c2e99425d0ef23feacdcf3faac983aa9a2f26849"
 dependencies = [
  "bstr",
- "gix-features 0.38.0",
+ "gix-features 0.38.1",
  "gix-path",
  "home",
  "thiserror",
@@ -2108,19 +2157,20 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e839f3d0798b296411263da6bee780a176ef8008a5dfc31287f7eda9266ab8"
+checksum = "0066432d4c277f9877f091279a597ea5331f68ca410efc874f0bdfb1cd348f92"
 dependencies = [
- "fastrand 2.0.0",
+ "bstr",
+ "fastrand",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "gix-validate"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac7cc36f496bd5d96cdca0f9289bb684480725d40db60f48194aa7723b883854"
+checksum = "e39fc6e06044985eac19dd34d474909e517307582e462b2eb4c8fa51b6241545"
 dependencies = [
  "bstr",
  "thiserror",
@@ -2146,19 +2196,19 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca36bb3dc54038c66507dc75c4d8edbee2d6d5cc45227b4eb508ad13dd60a006"
+checksum = "fe78e03af9eec168eb187e05463a981c57f0a915f64b1788685a776bd2ef969c"
 dependencies = [
  "bstr",
- "gix-attributes 0.22.0",
- "gix-features 0.38.0",
- "gix-fs 0.10.0",
- "gix-glob 0.16.0",
- "gix-hash 0.14.1",
- "gix-ignore 0.11.0",
- "gix-index 0.29.0",
- "gix-object 0.41.0",
+ "gix-attributes 0.22.2",
+ "gix-features 0.38.1",
+ "gix-fs 0.10.1",
+ "gix-glob 0.16.2",
+ "gix-hash 0.14.2",
+ "gix-ignore 0.11.2",
+ "gix-index 0.31.0",
+ "gix-object 0.42.0",
  "gix-path",
 ]
 
@@ -2243,9 +2293,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash 0.8.7",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -2394,7 +2448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -2542,9 +2596,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
@@ -2801,7 +2855,7 @@ dependencies = [
  "enable-ansi-support",
  "git2",
  "gix",
- "gix-features 0.38.0",
+ "gix-features 0.38.1",
  "gix-testtools",
  "globset",
  "human-panic",
@@ -3483,9 +3537,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -3777,16 +3831,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
- "autocfg",
  "cfg-if",
- "fastrand 1.9.0",
- "redox_syscall 0.3.5",
- "rustix 0.37.25",
- "windows-sys 0.48.0",
+ "fastrand",
+ "rustix 0.38.31",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4577,6 +4629,15 @@ name = "winnow"
 version = "0.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb877ca3232bec99a6472ed63f7241de2a250165260908b2d24c09d867907a85"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ gix = { version = "0.60.0", default-features = false, features = [
     "status"
 ] }
 gix-features = { version = "0.38.0", features = ["zlib-ng"] }
-git2 = { version = "0.18.1", default-features = false }
 globset = "0.4.14"
 human-panic = "1.2.1"
 image.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,12 @@ bytecount = "0.6.7"
 clap.workspace = true
 clap_complete = "4.4.10"
 crossbeam-channel = "0.5.9"
-gix = { version = "0.58.0", default-features = false, features = [
+gix = { version = "0.60.0", default-features = false, features = [
     "max-performance-safe",
     "blob-diff",
     "mailmap",
     "index",
+    "status"
 ] }
 gix-features = { version = "0.38.0", features = ["zlib-ng"] }
 git2 = { version = "0.18.1", default-features = false }


### PR DESCRIPTION
Fixes #628

I had to wait a long time for this PR to become possible, and finally here it is :)!

### Tasks

* [x] transition the status computation
* [x] remove `git2` dependency
* [x] Switch to new public release of `gix`


### Review Notes

* **Deviation**: I think it's better to *not* write the index back if any stat-changes are picked up to make `onefetch` truly read-only. 
  If there is disagreement, the index could be updated and written back - it will be valid, but won't write back all extensions that might
  have been present before. `git2` most certainly also didn't do it in a way that is 100% faithful to what Git would do.
* `renames_head_to_index()` was never functional, as the status was only obtained between the index and the worktree. If this must be present
   with the switch, then I have to hold off with this update as `gix status` doesn't yet support `HEAD->index` status.
* The binary size isn't positively affected by this change, unfortunately. The unstripped binary is now 17710984, up from 17023992, with the build settings of this project.


### Performance

In short, `onefetch` got a little bit faster, and speeds up with the size of the repositories measured by the amount of files in their worktrees.

<details><summary>WebKit</summary>

Here the faster `status` implementation is definitely visible.

```
❯ hyperfine -w1 -N -r3 onefetch /Users/byron/dev/github.com/o2sh/onefetch/target/release/onefetch
Benchmark 1: onefetch
  Time (mean ± σ):     22.839 s ±  1.328 s    [User: 80.878 s, System: 17.448 s]
  Range (min … max):   21.898 s … 24.358 s    3 runs

Benchmark 2: /Users/byron/dev/github.com/o2sh/onefetch/target/release/onefetch
  Time (mean ± σ):     18.506 s ±  0.145 s    [User: 77.921 s, System: 26.274 s]
  Range (min … max):   18.378 s … 18.663 s    3 runs

Summary
  /Users/byron/dev/github.com/o2sh/onefetch/target/release/onefetch ran
    1.23 ± 0.07 times faster than onefetch
```

</details>

<details><summary>Linux</summary>

For linux, the commit-aggregation is the most stressful part, and there is much less of a difference as `status` is just a small part of the overall runtime.

```
linux (ffc2532)
❯ hyperfine -w1 -N -r3 onefetch /Users/byron/dev/github.com/o2sh/onefetch/target/release/onefetch
Benchmark 1: onefetch
  Time (mean ± σ):     12.166 s ±  0.049 s    [User: 23.918 s, System: 2.509 s]
  Range (min … max):   12.110 s … 12.200 s    3 runs

Benchmark 2: /Users/byron/dev/github.com/o2sh/onefetch/target/release/onefetch
  Time (mean ± σ):     11.828 s ±  0.031 s    [User: 24.007 s, System: 2.904 s]
  Range (min … max):   11.801 s … 11.862 s    3 runs

Summary
  /Users/byron/dev/github.com/o2sh/onefetch/target/release/onefetch ran
    1.03 ± 0.00 times faster than onefetch
```

</details>


<details><summary>Git</summary>

Git is interesting as it doesn't have too many files in the worktree, yet it seems to greatly benefit from the new `status` implementation. Unfortunately, at ~200ms, the difference isn't really perceivable by a user.

```
❯ hyperfine -w1 -N -r3 onefetch /Users/byron/dev/github.com/o2sh/onefetch/target/release/onefetch
Benchmark 1: onefetch
  Time (mean ± σ):     237.5 ms ±   4.5 ms    [User: 883.7 ms, System: 223.4 ms]
  Range (min … max):   234.2 ms … 242.6 ms    3 runs

Benchmark 2: /Users/byron/dev/github.com/o2sh/onefetch/target/release/onefetch
  Time (mean ± σ):     213.7 ms ±   3.5 ms    [User: 872.6 ms, System: 235.9 ms]
  Range (min … max):   210.6 ms … 217.5 ms    3 runs

Summary
  /Users/byron/dev/github.com/o2sh/onefetch/target/release/onefetch ran
    1.11 ± 0.03 times faster than onefetch
```

</details>