### PR TITLE
Add CLI flag to hide token from repository URL

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,6 +87,9 @@ pub struct InfoCliOptions {
     /// Display repository URL as HTTP
     #[arg(long)]
     pub http_url: bool,
+    /// Hide token in repository URL
+    #[arg(long)]
+    pub hide_token: bool,
     /// Count hidden files and directories
     #[arg(long)]
     pub include_hidden: bool,
@@ -247,6 +250,7 @@ impl Default for InfoCliOptions {
             no_merges: Default::default(),
             email: Default::default(),
             http_url: Default::default(),
+            hide_token: Default::default(),
             include_hidden: Default::default(),
             r#type: vec![LanguageType::Programming, LanguageType::Markup],
             disabled_fields: Vec::default(),

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -143,7 +143,11 @@ pub fn build_info(cli_options: &CliOptions) -> Result<Info> {
         .ok()
         .context("BUG: panic in language statistics thread")??;
     let manifest = get_manifest(&repo_path)?;
-    let repo_url = get_repo_url(&repo, cli_options.info.http_url);
+    let repo_url = get_repo_url(
+        &repo,
+        cli_options.info.hide_token,
+        cli_options.info.http_url,
+    );
 
     let git_metrics = traverse_commit_graph(
         &repo,

--- a/src/info/url.rs
+++ b/src/info/url.rs
@@ -80,9 +80,8 @@ impl InfoField for UrlInfo {
 
 #[cfg(test)]
 mod test {
-    use rstest::rstest;
-
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn test_display_url_info() {

--- a/src/info/url.rs
+++ b/src/info/url.rs
@@ -120,6 +120,18 @@ mod test {
         true,
         "https://gitlab.com/user/repo"
     )]
+    #[case(
+        "https://github.com/user/repo",
+        true,
+        true,
+        "https://github.com/user/repo"
+    )]
+    #[case(
+        "https://username:token@github.com/user/repo",
+        false,
+        false,
+        "https://username:token@github.com/user/repo"
+    )]
     fn test_format_url(
         #[case] url: &str,
         #[case] hide_token: bool,

--- a/src/info/url.rs
+++ b/src/info/url.rs
@@ -130,17 +130,17 @@ mod test {
         assert_eq!(format_url(url, hide_token, http_url), expected);
     }
 
-    #[rstest]
-    #[case(
-        "https://username:token@github.com/user/repo",
-        "https://github.com/user/repo"
-    )]
-    fn test_remove_token_from_url(#[case] url: &str, #[case] expected: &str) {
-        assert_eq!(remove_token_from_url(url), expected);
+    #[test]
+    fn test_remove_token_from_url() {
+        assert_eq!(
+            remove_token_from_url("https://username:token@github.com/user/repo"),
+            "https://github.com/user/repo"
+        );
     }
 
     #[rstest]
     #[case("git@github.com:user/repo.git", "https://github.com/user/repo.git")]
+    #[case("git@gitlab.com:user/repo", "https://gitlab.com/user/repo")]
     fn test_create_http_url_from_ssh(#[case] url: &str, #[case] expected: &str) {
         assert_eq!(create_http_url_from_ssh(url), expected);
     }

--- a/src/info/url.rs
+++ b/src/info/url.rs
@@ -80,6 +80,8 @@ impl InfoField for UrlInfo {
 
 #[cfg(test)]
 mod test {
+    use rstest::rstest;
+
     use super::*;
 
     #[test]
@@ -94,69 +96,52 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_format_url_http() {
-        let remote_url_github =
-            "https://1234567890abcdefghijklmnopqrstuvwxyz@github.com/0spotter0/onefetch.git";
-        let res_url_github = format_url(remote_url_github, true, true);
-        assert_eq!("https://github.com/0spotter0/onefetch.git", res_url_github);
-
-        let remote_url_gitlab =
-            "https://john:abc123personaltoken@gitlab.com/0spotter0/onefetch.git";
-        let res_url_gitlab = format_url(remote_url_gitlab, true, true);
-        assert_eq!("https://gitlab.com/0spotter0/onefetch.git", res_url_gitlab);
+    #[rstest]
+    #[case(
+        "https://username:token@github.com/user/repo",
+        true,
+        false,
+        "https://github.com/user/repo"
+    )]
+    #[case(
+        "https://user:token@gitlab.com/user/repo",
+        true,
+        false,
+        "https://gitlab.com/user/repo"
+    )]
+    #[case(
+        "git@github.com:user/repo.git",
+        false,
+        true,
+        "https://github.com/user/repo.git"
+    )]
+    #[case(
+        "git@gitlab.com:user/repo",
+        false,
+        true,
+        "https://gitlab.com/user/repo"
+    )]
+    fn test_format_url(
+        #[case] url: &str,
+        #[case] hide_token: bool,
+        #[case] http_url: bool,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(format_url(url, hide_token, http_url), expected);
     }
 
-    #[test]
-    fn test_format_url_ssh() {
-        let remote_url_github = "git@github.com:0spotter0/onefetch.git";
-        let res_url_github_force_http_true = format_url(remote_url_github, false, true);
-        let res_url_github_force_http_false = format_url(remote_url_github, false, false);
-        assert_eq!(
-            "https://github.com/0spotter0/onefetch.git",
-            res_url_github_force_http_true
-        );
-        assert_eq!(
-            "git@github.com:0spotter0/onefetch.git",
-            res_url_github_force_http_false
-        );
-
-        let remote_url_gitlab = "git@gitlab.com:0spotter0/onefetch.git";
-        let res_url_gitlab_force_http_true = format_url(remote_url_gitlab, false, true);
-        let res_url_gitlab_force_http_false = format_url(remote_url_gitlab, false, false);
-        assert_eq!(
-            "https://gitlab.com/0spotter0/onefetch.git",
-            res_url_gitlab_force_http_true
-        );
-        assert_eq!(
-            "git@gitlab.com:0spotter0/onefetch.git",
-            res_url_gitlab_force_http_false
-        );
+    #[rstest]
+    #[case(
+        "https://username:token@github.com/user/repo",
+        "https://github.com/user/repo"
+    )]
+    fn test_remove_token_from_url(#[case] url: &str, #[case] expected: &str) {
+        assert_eq!(remove_token_from_url(url), expected);
     }
 
-    #[test]
-    fn test_token_removal_github() {
-        let remote_url =
-            "https://1234567890abcdefghijklmnopqrstuvwxyz@github.com/jim4067/onefetch.git";
-        let res_url = remove_token_from_url(remote_url);
-        assert_eq!("https://github.com/jim4067/onefetch.git", res_url);
-    }
-
-    #[test]
-    fn test_token_removal_gitlab() {
-        let remote_url = "https://john:abc123personaltoken@gitlab.com/jim4067/myproject.git";
-        let res_url = remove_token_from_url(remote_url);
-        assert_eq!("https://gitlab.com/jim4067/myproject.git", res_url);
-    }
-
-    #[test]
-    fn test_create_http_url_from_ssh() {
-        let remote_url_github = "git@github.com:0spotter0/onefetch.git";
-        let res_url_github = create_http_url_from_ssh(remote_url_github);
-        assert_eq!("https://github.com/0spotter0/onefetch.git", res_url_github);
-
-        let remote_url_gitlab = "git@gitlab.com:0spotter0/onefetch.git";
-        let res_url_gitlab = create_http_url_from_ssh(remote_url_gitlab);
-        assert_eq!("https://gitlab.com/0spotter0/onefetch.git", res_url_gitlab);
+    #[rstest]
+    #[case("git@github.com:user/repo.git", "https://github.com/user/repo.git")]
+    fn test_create_http_url_from_ssh(#[case] url: &str, #[case] expected: &str) {
+        assert_eq!(create_http_url_from_ssh(url), expected);
     }
 }


### PR DESCRIPTION
Following https://github.com/o2sh/onefetch/pull/1314#issuecomment-2078259382

This PR introduces a CLI flag to enable the option of hiding the token from the repository URL, making it an opt-in mechanism rather than the default behavior.

CC @jim4067 @asciimoth @t-h2o