### PR TITLE
Automate publishing crates to crates.io

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,3 +61,24 @@ jobs:
           installers-regex: '\.exe$'
           version: ${{ github.event.release.tag_name }}
           token: ${{ secrets.WINGET_TOKEN }}
+
+  cargo-publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: clippy
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,23 +81,17 @@ jobs:
       - name: Publish to crates.io (ascii)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        working-directory:
-          ./ascii
-        run: cargo publish
+        run: cargo publish -p onefetch-ascii
 
       - name: Publish to crates.io (image)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        working-directory:
-          ./image
-        run: cargo publish
+        run: cargo publish -p onefetch-image
 
       - name: Publish to crates.io (manifest)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        working-directory:
-          ./manifest
-        run: cargo publish
+        run: cargo publish -p onefetch-manifest
 
       - name: Publish to crates.io
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,6 +78,27 @@ jobs:
           profile: minimal
           components: clippy
 
+      - name: Publish to crates.io (ascii)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        working-directory:
+          ./ascii
+        run: cargo publish
+
+      - name: Publish to crates.io (image)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        working-directory:
+          ./image
+        run: cargo publish
+
+      - name: Publish to crates.io (manifest)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        working-directory:
+          ./manifest
+        run: cargo publish
+
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,7 +69,7 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,10 +72,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-          profile: minimal
           components: clippy
 
       - name: Publish to crates.io (ascii)

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,8 @@ name: CD
 on:
   release:
     types: [published]
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   deploy:
@@ -65,8 +67,6 @@ jobs:
   cargo-publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This mostly reverts 5085c5b038c46ecb9fb16329caf5479b35a963c6, and attempts to support publishing workspace crates `onefetch-ascii`, `onefetch-image`, and `onefetch-manifest`. This would fix https://github.com/o2sh/onefetch/issues/1363 by ensuring crates are published on a platform that fully supports symbolic links.

I have little to no experience with GitHub Workflows, and I am unable to test this PR, but it still *seems* like it should do the job.