### PR TITLE
Drop unused shebangs from repo test fixture scripts

### DIFF
--- a/tests/fixtures/make_bare_repo.sh
+++ b/tests/fixtures/make_bare_repo.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 set -eu -o pipefail
 
 git init -q --bare

--- a/tests/fixtures/make_partial_repo.sh
+++ b/tests/fixtures/make_partial_repo.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 set -eu -o pipefail
 
 mkdir base

--- a/tests/fixtures/make_pre_epoch_repo.sh
+++ b/tests/fixtures/make_pre_epoch_repo.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 set -eu -o pipefail
 
 git init -q

--- a/tests/fixtures/make_repo.sh
+++ b/tests/fixtures/make_repo.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 set -eu -o pipefail
 
 git init -q

--- a/tests/fixtures/make_repo_without_remote.sh
+++ b/tests/fixtures/make_repo_without_remote.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 set -eu -o pipefail
 
 git init -q


### PR DESCRIPTION
These are not really doing any harm, but they are not doing any good either, and are perhaps slightly misleading:

- Since the scripts do not have executable filesystem permissions, the shebang (`#!`) line is not used
- For non-executable scripts like this, `gix-testtool` always executes them with `bash`: https://github.com/Byron/gitoxide/blob/a807dd1ffb05efd177700d065095249e6c4b3c68/tests/tools/src/lib.rs#L555-L560

An alternative would be to `chmod a+x tests/fixtures/*.sh` so that the shebang lines *can* be useful – and *are* used, if I read the `gix-testtools` code correctly.