### PR TITLE
show future commit dates without panicking

### DIFF
--- a/src/info/utils/mod.rs
+++ b/src/info/utils/mod.rs
@@ -103,24 +103,22 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "Achievement unlocked: time travel! Check your system clock and commit dates."
-    )]
-    fn should_panic_when_display_human_time_and_commit_date_in_the_future() {
+    fn handle_display_human_time_and_commit_date_in_the_future() {
         let day = Duration::from_secs(60 * 60 * 24);
         let current_time = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap();
         let tomorrow = current_time + day;
         let time = Time::new(tomorrow.as_secs() as gix::date::SecondsSinceUnixEpoch, 0);
-        format_time(time, false);
+        let result = format_time(time, false);
+        assert_eq!(result, "in a day");
     }
 
     #[test]
     fn display_time_before_epoch() {
         let time = Time::new(gix::date::SecondsSinceUnixEpoch::MIN, 0);
         let result = to_human_time(time);
-        assert_eq!(result, "<before UNIX epoch>");
+        assert!(result.ends_with(" years ago"));
     }
 
     #[rstest]


### PR DESCRIPTION
Fixes #1306.

Sorry for the long wait! This is the lamest solution I found, the tool will simply display the time as `in 5 days`. The library `time_humanize` can already handle this.

Thanks!