### PR TITLE
Bump devcontainer OS version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
-ARG VARIANT="buster"
-FROM mcr.microsoft.com/devcontainers/rust:1-${bookworm}
+ARG VARIANT="bookworm"
+FROM mcr.microsoft.com/devcontainers/rust:1-${VARIANT}
 RUN sudo apt update && sudo apt install -y cmake

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
 ARG VARIANT="buster"
-FROM mcr.microsoft.com/devcontainers/rust:1-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/rust:1-${bookworm}
 RUN sudo apt update && sudo apt install -y cmake

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "Rust",
   "build": {
     "dockerfile": "Dockerfile",
-    "args": { "VARIANT": "buster" }
+    "args": { "VARIANT": "bookworm" }
   },
   "postCreateCommand": "git config --global --add safe.directory $PWD && cargo install cargo-insta",
   "extensions": ["EditorConfig.EditorConfig"],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3885,9 +3885,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3917,9 +3917,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
`buster` is out-of-date and comes with an old version of Rust.