### PR TITLE
Add -L/--logo-only option

### DIFF
--- a/docs/onefetch.1
+++ b/docs/onefetch.1
@@ -143,6 +143,10 @@ If set to auto: true color will be enabled if supported by the terminal
 .IP
 [default: auto]
 [possible values: auto, never, always]
+.HP
+\fB\-L\fR, \fB\-\-logo\-only\fR
+.IP
+Only print the ascii art without retrieving any info
 .SS "IMAGE:"
 .HP
 \fB\-i\fR, \fB\-\-image\fR <IMAGE>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use clap::builder::TypedValueParser as _;
 use clap::{value_parser, Args, Command, Parser, ValueHint};
 use clap_complete::{generate, Generator, Shell};
 use num_format::CustomFormat;
+use onefetch_ascii::AsciiArt;
 use onefetch_image::ImageProtocol;
 use onefetch_manifest::ManifestType;
 use regex::Regex;
@@ -146,6 +147,9 @@ pub struct AsciiCliOptions {
     /// If set to auto: true color will be enabled if supported by the terminal
     #[arg(long, default_value = "auto", value_name = "WHEN", value_enum)]
     pub true_color: When,
+    /// Only print the ascii art without retrieving any info
+    #[arg(long, short = 'L')]
+    pub logo_only: bool,
 }
 
 #[derive(Clone, Debug, Args, PartialEq, Eq)]
@@ -289,6 +293,7 @@ impl Default for AsciiCliOptions {
             ascii_colors: Vec::default(),
             ascii_language: Option::default(),
             true_color: When::Auto,
+            logo_only: false,
         }
     }
 }
@@ -313,6 +318,26 @@ pub fn print_supported_languages() -> Result<()> {
 pub fn print_supported_package_managers() -> Result<()> {
     for p in ManifestType::iter() {
         println!("{p}");
+    }
+
+    Ok(())
+}
+
+pub fn print_language(cli: CliOptions) -> Result<()> {
+    match cli.ascii.ascii_language {
+        Some(language) => {
+            let ascii_art = language.get_ascii_art();
+            let colors = language.get_colors(match cli.ascii.true_color {
+                When::Always => true,
+                When::Never => false,
+                When::Auto => is_truecolor_terminal(),
+            });
+            let art = AsciiArt::new(ascii_art, colors.as_slice(), !cli.text_formatting.no_bold);
+            for line in art {
+                println!("{line}")
+            }
+        }
+        None => println!("You need to provide a language with the --ascii-language/-a option."),
     }
 
     Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -323,26 +323,6 @@ pub fn print_supported_package_managers() -> Result<()> {
     Ok(())
 }
 
-pub fn print_language(cli: CliOptions) -> Result<()> {
-    match cli.ascii.ascii_language {
-        Some(language) => {
-            let ascii_art = language.get_ascii_art();
-            let colors = language.get_colors(match cli.ascii.true_color {
-                When::Always => true,
-                When::Never => false,
-                When::Auto => is_truecolor_terminal(),
-            });
-            let art = AsciiArt::new(ascii_art, colors.as_slice(), !cli.text_formatting.no_bold);
-            for line in art {
-                println!("{line}")
-            }
-        }
-        None => println!("You need to provide a language with the --ascii-language/-a option."),
-    }
-
-    Ok(())
-}
-
 pub fn is_truecolor_terminal() -> bool {
     env::var("COLORTERM")
         .map(|colorterm| colorterm == "truecolor" || colorterm == "24bit")

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -178,6 +178,10 @@ pub fn build_info(cli_options: &CliOptions) -> Result<Info> {
     let globs_to_exclude = &cli_options.info.exclude;
     let show_email = cli_options.info.email;
 
+    if cli_options.ascii.logo_only {
+        return Ok(InfoBuilder::new(cli_options).build(cli_options, text_colors, dominant_language, ascii_colors));
+    }
+
     Ok(InfoBuilder::new(cli_options)
         .title(&repo, no_bold, &text_colors)
         .project(&repo, &repo_url, manifest.as_ref(), number_separator)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,10 +24,6 @@ fn main() -> Result<()> {
         return cli::print_supported_package_managers();
     }
 
-    if cli_options.ascii.logo_only {
-        return cli::print_language(cli_options);
-    }
-
     if let Some(generator) = cli_options.developer.completion {
         let mut cmd = CliOptions::command();
         cli::print_completions(generator, &mut cmd);

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,10 @@ fn main() -> Result<()> {
         return cli::print_supported_package_managers();
     }
 
+    if cli_options.ascii.logo_only {
+        return cli::print_language(cli_options);
+    }
+
     if let Some(generator) = cli_options.developer.completion {
         let mut cmd = CliOptions::command();
         cli::print_completions(generator, &mut cmd);


### PR DESCRIPTION
Add the ability to print an ASCII art logo without needing a git repository.

I was kinda thinking of somehow baking this into Printer, but Printer wants an Info and the whole point is to not have an Info.