### PR TITLE
Update cargo_toml from 0.20.5 to 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,9 +358,9 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cargo_toml"
-version = "0.20.5"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88da5a13c620b4ca0078845707ea9c3faf11edbc3ffd8497d11d686211cd1ac0"
+checksum = "5fbd1fe9db3ebf71b89060adaf7b0504c2d6a425cf061313099547e382c2e472"
 dependencies = [
  "serde",
  "toml 0.8.19",

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -9,6 +9,6 @@ description = "Detect and parse manifest files"
 
 [dependencies]
 anyhow.workspace = true
-cargo_toml = "0.20.5"
+cargo_toml = "0.21.0"
 npm-package-json = "0.1.3"
 strum.workspace = true


### PR DESCRIPTION
This crate does not maintain a changelog, but here is the source diff:

https://gitlab.com/lib.rs/cargo_toml/-/compare/v0.20.5...ab52d4f02ed72452a742264e5f877b8373f6b6b9

I verified that `cargo test --workspace` still passes.