### PR TITLE
chore: add missing nerd fonts icons for some languages

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -258,6 +258,7 @@ Ceylon:
       - "#CC8B18"
       - "#AB7008"
     chip: "#DFA535"
+  icon: "\u{E78B}"
 Clojure:
   type: programming
   ascii: |
@@ -310,6 +311,7 @@ CMake:
       - red
       - black
     chip: "#DA3434"
+  icon: "\u{E794}"
 CoffeeScript:
   type: programming
   ascii: |
@@ -1470,6 +1472,7 @@ Jupyter:
       - "#FF700F"
       - "#9E9E9E"
     chip: "#DA5B0B"
+  icon: "\u{E80F}"
   serialization: jupyter-notebooks
 Kotlin:
   type: programming
@@ -1557,6 +1560,7 @@ LLVM:
     hex:
       - "#98012E"
     chip: "#185619"
+  icon: "\u{E823}"
 Lua:
   type: programming
   ascii: |
@@ -1722,6 +1726,7 @@ ObjectiveC:
       - cyan
       - blue
     chip: "#438EFF"
+  icon: "\u{E84D}"
   serialization: objective-c
 OCaml:
   type: programming
@@ -2217,6 +2222,7 @@ Renpy:
       - "#FFFFFF"
       - "#B5A396"
     chip: "#FF7F7F"
+  icon: "\u{E88D}"
 Ruby:
   type: programming
   ascii: |
@@ -2428,6 +2434,7 @@ Solidity:
       - "#333333"
       - "#515151"
     chip: "#AA6746"
+  icon: "\u{E8A6}"
 Sql:
   type: data
   ascii: |
@@ -2772,6 +2779,7 @@ Vala:
       - magenta
       - white
     chip: "#A56DE2"
+  icon: "\u{E8D1}"
 Verilog:
   type: programming
   ascii: |
@@ -2879,6 +2887,7 @@ VisualBasic:
       - "#004E8C"
       - "#FFFFFF"
     chip: "#945db7"
+  icon: "\u{E8D5}"
 Vue:
   type: programming
   ascii: |

--- a/languages.yaml
+++ b/languages.yaml
@@ -258,7 +258,7 @@ Ceylon:
       - "#CC8B18"
       - "#AB7008"
     chip: "#DFA535"
-  icon: "\u{E78B}"
+  icon: '\u{E78B}'
 Clojure:
   type: programming
   ascii: |
@@ -311,7 +311,7 @@ CMake:
       - red
       - black
     chip: "#DA3434"
-  icon: "\u{E794}"
+  icon: '\u{E794}'
 CoffeeScript:
   type: programming
   ascii: |
@@ -1472,7 +1472,7 @@ Jupyter:
       - "#FF700F"
       - "#9E9E9E"
     chip: "#DA5B0B"
-  icon: "\u{E80F}"
+  icon: '\u{E80F}'
   serialization: jupyter-notebooks
 Kotlin:
   type: programming
@@ -1560,7 +1560,7 @@ LLVM:
     hex:
       - "#98012E"
     chip: "#185619"
-  icon: "\u{E823}"
+  icon: '\u{E823}'
 Lua:
   type: programming
   ascii: |
@@ -1726,7 +1726,7 @@ ObjectiveC:
       - cyan
       - blue
     chip: "#438EFF"
-  icon: "\u{E84D}"
+  icon: '\u{E84D}'
   serialization: objective-c
 OCaml:
   type: programming
@@ -2222,7 +2222,7 @@ Renpy:
       - "#FFFFFF"
       - "#B5A396"
     chip: "#FF7F7F"
-  icon: "\u{E88D}"
+  icon: '\u{E88D}'
 Ruby:
   type: programming
   ascii: |
@@ -2434,7 +2434,7 @@ Solidity:
       - "#333333"
       - "#515151"
     chip: "#AA6746"
-  icon: "\u{E8A6}"
+  icon: '\u{E8A6}'
 Sql:
   type: data
   ascii: |
@@ -2779,7 +2779,7 @@ Vala:
       - magenta
       - white
     chip: "#A56DE2"
-  icon: "\u{E8D1}"
+  icon: '\u{E8D1}'
 Verilog:
   type: programming
   ascii: |
@@ -2887,7 +2887,7 @@ VisualBasic:
       - "#004E8C"
       - "#FFFFFF"
     chip: "#945db7"
-  icon: "\u{E8D5}"
+  icon: '\u{E8D5}'
 Vue:
   type: programming
   ascii: |


### PR DESCRIPTION
Related to #1408.
# Description
Add missing nerd fonts icons for:
- Ceylon (`\u{E78B}`)
- CMake (`\u{E794}`)
- Jupyter (`\u{E80F}`)
- LLVM (`\u{E823}`)
- ObjectiveC (`\u{E84D}`)
- Renpy (`\u{E88D}`)
- Solidity (`\u{E8A6}`)
- Vala (`\u{E8D1}`)
- VisualBasic (`\u{E8D5}`)