### PR TITLE
Add script to preview/validate Nerd Fonts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,7 @@ indent_style = tab
 [*.json]
 indent_style = space
 indent_size = 2
+
+[*.rb]
+indent_style = space
+indent_size = 2

--- a/scripts/nf-preview.rb
+++ b/scripts/nf-preview.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+require "yaml"
+
+LANGUAGES_FILE = File.expand_path("../../languages.yaml", __FILE__)
+
+languages = YAML.safe_load_file(ARGV[0] || LANGUAGES_FILE, symbolize_names: true)
+
+languages.each do |language, attributes|
+  icon = attributes[:icon]
+  next if icon.nil?
+  match = /\A\\u\{([A-F0-9]{4,})\}\z/i.match(icon)
+  raise "Icon for #{language} is not in the correct format: `#{icon}`" unless match
+  glyph = match.captures[0].hex.chr("UTF-8")
+  puts "#{language}: #{glyph}"
+end


### PR DESCRIPTION
Getting these PRs for Nerd Fonts, I'd like to be able to preview them without having to manually look them up. This script will display the Nerd Font glyphs in your terminal as long as you're using a compatible font.

I used Ruby because:

* Built-in YAML support, so no need to install a YAML-parsing dependency (and deal with a package manifest + recommended package manager)
* Some similarities to Rust, like a focus on using closures and "everything is an expression" behavior