### PR TITLE
Update cargo_toml from 0.21.0 to 0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,9 +331,9 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cargo_toml"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbd1fe9db3ebf71b89060adaf7b0504c2d6a425cf061313099547e382c2e472"
+checksum = "02260d489095346e5cafd04dea8e8cb54d1d74fcd759022a9b72986ebe9a1257"
 dependencies = [
  "serde",
  "toml 0.8.19",

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -9,6 +9,6 @@ description = "Detect and parse manifest files"
 
 [dependencies]
 anyhow.workspace = true
-cargo_toml = "0.21.0"
+cargo_toml = "0.22.1"
 npm-package-json = "0.1.3"
 strum.workspace = true


### PR DESCRIPTION
This crate does not maintain a changelog, but here is the source diff:

https://gitlab.com/lib.rs/cargo_toml/-/compare/ab52d4f02ed72452a742264e5f877b8373f6b6b9...v0.22.1

I verified that `cargo test --workspace` still passes.

I’m patching `rust-cargo-manifest` in Fedora to allow the new `cargo_toml` version, and it’s my habit and Fedora’s policy to send patches upstream wherever possible. Because this is not a particularly urgent update, I waited for the weekly batch of PR’s from dependabot (as suggested in https://github.com/o2sh/onefetch/pull/1481), but there wasn’t an PR for `cargo_toml` in today’s batch. I’m not sure why.