### PR TITLE
Add colors to --help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-cargo"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d546f0e84ff2bfa4da1ce9b54be42285767ba39c688572ca32412a09a73851e5"
+dependencies = [
+ "anstyle",
+ "clap",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,7 +514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2706,6 +2716,7 @@ dependencies = [
  "askalono",
  "byte-unit",
  "clap",
+ "clap-cargo",
  "clap_complete",
  "criterion",
  "crossbeam-channel",
@@ -4238,7 +4249,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ anyhow.workspace = true
 askalono = "0.5.0"
 byte-unit = "5.1.6"
 clap.workspace = true
+clap-cargo = "0.15.2"
 clap_complete = "4.5.55"
 crossbeam-channel = "0.5.15"
 gix = { version = "0.73.0", default-features = false, features = [

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,7 @@ pub const NO_BOTS_DEFAULT_REGEX_PATTERN: &str = r"(?:-|\s)[Bb]ot$|\[[Bb]ot\]";
 
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
 #[command(version, about)]
+#[command(styles = clap_cargo::style::CLAP_STYLING)]
 pub struct CliOptions {
     /// Run as if onefetch was started in <input> instead of the current working directory
     #[arg(default_value = ".", hide_default_value = true, value_hint = ValueHint::DirPath)]


### PR DESCRIPTION
I used [clap-cargo](https://github.com/crate-ci/clap-cargo) as it's easy to use and provides sensible default styles.
User can disable colors via `NO_COLOR=1` environment variable

Output of `onefetch -h`:
| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="1446" height="1113" alt="onefetch-before" src="https://github.com/user-attachments/assets/a56094f0-53a4-43cd-8d95-3df881589a83" /> | <img width="1446" height="1113" alt="onefetch-colors" src="https://github.com/user-attachments/assets/3d6ab0d2-1c08-4b2e-8998-4a90983a2f90" /> | <img width="1446" height="1113" alt="onefetch-no-color" src="https://github.com/user-attachments/assets/2ebda336-d7a2-4b81-9e90-27f2445d6a7c" /> |