### PR TITLE
Prevent churn calculation from returning an error on partial clones

### DIFF
--- a/src/info/git/mod.rs
+++ b/src/info/git/mod.rs
@@ -180,6 +180,11 @@ fn update_signature_counts(
     Ok(())
 }
 
+
+/// This will get the trees for a commit and its parent and compute the diff. On success, this
+/// returns `Ok(true)`. If the trees are not available due to a partial clone, this will return
+/// `Ok(false)`. Essentially, this function will have successfully determined that there is no diff
+/// to compute. Other issues that prevent calculation will return `Err`. 
 fn compute_diff_with_parent(
     change_map: &mut HashMap<BString, usize>,
     commit: &Commit,

--- a/src/info/git/mod.rs
+++ b/src/info/git/mod.rs
@@ -130,8 +130,9 @@ fn get_churn_channel(
                 if is_bot_commit(&commit, &mailmap, bot_regex_pattern.as_ref())? {
                     continue;
                 }
-                compute_diff_with_parent(&mut number_of_commits_by_file_path, &commit, &repo)?;
-                diffs_computed += 1;
+                if compute_diff_with_parent(&mut number_of_commits_by_file_path, &commit, &repo)? {
+                    diffs_computed += 1;
+                }
                 if should_break(
                     is_traversal_complete.load(Ordering::Relaxed),
                     total_number_of_commits.load(Ordering::Relaxed),
@@ -183,7 +184,7 @@ fn compute_diff_with_parent(
     change_map: &mut HashMap<BString, usize>,
     commit: &Commit,
     repo: &gix::Repository,
-) -> Result<()> {
+) -> Result<bool> {
     let mut parents = commit.parent_ids();
     let parents = (
         parents
@@ -194,8 +195,12 @@ fn compute_diff_with_parent(
     );
 
     if let (parent_tree_id, None) = parents {
-        let old_tree = parent_tree_id.object()?.into_tree();
-        let new_tree = commit.tree()?;
+        let Some(old_tree) = parent_tree_id.try_object()?.map(|tree| tree.into_tree()) else {
+            return Ok(false);
+        };
+        let Some(new_tree) = commit.tree_id()?.try_object()?.map(|tree| tree.into_tree()) else {
+            return Ok(false);
+        };
         let changes =
             repo.diff_tree_to_tree(&old_tree, &new_tree, Options::default().with_rewrites(None))?;
         for change in &changes {
@@ -212,7 +217,7 @@ fn compute_diff_with_parent(
         }
     }
 
-    Ok(())
+    Ok(true)
 }
 
 fn is_bot_commit(

--- a/tests/fixtures/make_partial_repo.sh
+++ b/tests/fixtures/make_partial_repo.sh
@@ -28,3 +28,8 @@ git clone --filter=blob:none file://$PWD/base partial
 (cd partial
     git config diff.renames true
 )
+
+git clone --filter=tree:0 file://$PWD/base partial_treeless
+(cd partial_treeless
+    git config diff.renames true
+)

--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -85,6 +85,17 @@ fn test_partial_repo() -> Result<()> {
 }
 
 #[test]
+fn test_treeless_partial_repo() -> Result<()> {
+    let repo = named_repo("make_partial_repo.sh", "partial_treeless")?;
+    let config: CliOptions = CliOptions {
+        input: repo.path().to_path_buf(),
+        ..Default::default()
+    };
+    let _info = build_info(&config).expect("no error");
+    Ok(())
+}
+
+#[test]
 fn test_repo_with_pre_epoch_dates() -> Result<()> {
     let repo = repo("make_pre_epoch_repo.sh")?;
     let config: CliOptions = CliOptions {


### PR DESCRIPTION
Fixes #1706.

Before this change, `onefetch` could fail on tree-filtered partial clones with:

```text
Error: Failed to traverse Git commit history

Caused by:
    sending on a closed channel
```

The churn worker assumed parent and current commit trees were always present locally. In a `git clone --filter=tree:0` partial clone, those tree objects can be missing, which caused the worker to exit early and the main traversal loop to hit the closed-channel error.

This keeps the rest of the repository info working by skipping churn diffing for commits whose tree objects are not available locally. The regression coverage now extends the existing partial-clone fixture with a `tree:0` variant.

Validation:
- `cargo fmt --all -- --check`
- `cargo test --test repo`
- `cargo test`
- `git clone --filter=tree:0 https://github.com/sharkdp/fd /tmp/onefetch-fd-tree0-fixed && target/debug/onefetch /tmp/onefetch-fd-tree0-fixed`