### PR TITLE
fix: resolve #1520 — Add FAQ to the wiki

### DIFF
--- a/docs/wiki/faq.md
+++ b/docs/wiki/faq.md
@@ -9,6 +9,6 @@ Common reasons include:
 - The file is very small and does not contain enough information to identify the language.
 - The file uses an uncommon or unsupported extension.
 - The file is generated, vendored, binary, ignored, or otherwise excluded from analysis.
-- The language is not currently supported by onefetch.
+- The language is not currently supported by Onefetch.
 
-If your language is not shown, first check whether it is supported by onefetch. If it is not supported yet, open a new language request so support can be added.
+If your language is not shown, first check whether it is supported by Onefetch. If it is not supported yet, open a new language request so support can be added.

--- a/docs/wiki/faq.md
+++ b/docs/wiki/faq.md
@@ -1,0 +1,14 @@
+# FAQ
+
+## Why isn’t my language detected?
+
+Onefetch relies on language detection rules from the Linguist ecosystem and the language definitions supported by onefetch. If a language is not detected, it is usually because the repository contents do not match those rules.
+
+Common reasons include:
+
+- The file is very small and does not contain enough information to identify the language.
+- The file uses an uncommon or unsupported extension.
+- The file is generated, vendored, binary, ignored, or otherwise excluded from analysis.
+- The language is not currently supported by onefetch.
+
+If your language is not shown, first check whether it is supported by onefetch. If it is not supported yet, open a new language request so support can be added.

--- a/tests/faq_docs.rs
+++ b/tests/faq_docs.rs
@@ -1,12 +1,18 @@
 use std::fs;
+use std::path::Path;
 
 fn faq() -> String {
-    fs::read_to_string("docs/wiki/faq.md").unwrap()
+    let faq_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("docs/wiki/faq.md");
+    fs::read_to_string(&faq_path)
+        .expect("failed to read FAQ at repo path docs/wiki/faq.md")
 }
 
 #[test]
 fn faq_has_title() {
-    assert!(faq().starts_with("# FAQ\n"));
+    let faq = faq();
+    let first_line = faq.lines().next().unwrap_or("").trim();
+
+    assert_eq!(first_line, "# FAQ");
 }
 
 #[test]

--- a/tests/faq_docs.rs
+++ b/tests/faq_docs.rs
@@ -1,0 +1,28 @@
+use std::fs;
+
+fn faq() -> String {
+    fs::read_to_string("docs/wiki/faq.md").unwrap()
+}
+
+#[test]
+fn faq_has_title() {
+    assert!(faq().starts_with("# FAQ\n"));
+}
+
+#[test]
+fn faq_explains_language_detection_limits() {
+    let faq = faq();
+
+    assert!(faq.contains("Linguist"));
+    assert!(faq.contains("very small"));
+    assert!(faq.contains("uncommon or unsupported extension"));
+    assert!(faq.contains("generated, vendored, binary, ignored"));
+}
+
+#[test]
+fn faq_guides_unsupported_language_requests() {
+    let faq = faq();
+
+    assert!(faq.contains("check whether it is supported"));
+    assert!(faq.contains("open a new language request"));
+}


### PR DESCRIPTION
## Summary

Create a dedicated FAQ page in the wiki documentation. The primary entry should answer the common question: “Why isn’t my language detected?” This should explain that onefetch relies on language detection rules from the Linguist ecosystem / supported language definitions, that very small files or uncommon extensions may not be recognized, that generated/vendor/binary/ignored files may be excluded, and that unsupported languages require adding language support to onefetch. The FAQ should also guide users toward checking whether their language is supported and opening a new language request if needed

Fixes #1520

## Changes

- `docs/wiki/faq.md` *(new)*
- `tests/faq_docs.rs` *(new)*

## Why

`docs/wiki/faq.md`: Create a dedicated FAQ page in the wiki documentation. The primary entry should answer the common question: “Why isn’t my language detected?” This should explain that onefetch relies on language detection rules from the Linguist ecosystem / supported language definitions, that very small files or uncommon extensions may not be recognized, that generated/vendor/binary/ignored files may be excluded, and that unsupported languages require adding language support to onefetch. The FAQ should also guide users toward checking whether their language is supported and opening a new language request if needed.
