### PR TITLE
fix: resolve #1460 — Can't install on Debian 12 - libc version issue

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Pin Linux to ubuntu-22.04 so release binaries keep a Debian 12-compatible glibc baseline.
+        os: [ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -28,7 +29,7 @@ jobs:
         run: make release-mac
 
       - name: Package release for Linux
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: make release-linux
 
       - name: Package release for Windows

--- a/tests/cd_workflow.rs
+++ b/tests/cd_workflow.rs
@@ -1,0 +1,11 @@
+use std::fs;
+
+#[test]
+fn linux_release_uses_ubuntu_22_04() {
+    let workflow = fs::read_to_string(".github/workflows/cd.yml").unwrap();
+
+    assert!(workflow.contains("os: [ubuntu-22.04, macos-latest, windows-latest]"));
+    assert!(workflow.contains("if: matrix.os == 'ubuntu-22.04'"));
+    assert!(workflow.contains("Debian 12-compatible glibc baseline"));
+    assert!(!workflow.contains("if: matrix.os == 'ubuntu-latest'"));
+}


### PR DESCRIPTION
## Summary

The Debian package currently depends on `libc6 (>= 2.39)`, which means the `.deb` artifact was built on a system with glibc 2.39, likely `ubuntu-24.04` or another recent runner. Debian package dependency metadata is inferred from the binary’s linked glibc symbols, so building on too-new a distribution makes the generated `.deb` unusable on Debian 12, which ships libc 2.36. The release workflow should build Linux artifacts, especially `.deb` packages, on a stable older Linux image such as `ubuntu-22.04`, or in a Debian 12 container, to keep the minimum libc requirement compatible with Debian 12 and most supported distributions

Fixes #1460

## Changes

- `.github/workflows/cd.yml`
- `tests/cd_workflow.rs` *(new)*

## Why

`.github/workflows/cd.yml`: The Debian package currently depends on `libc6 (>= 2.39)`, which means the `.deb` artifact was built on a system with glibc 2.39, likely `ubuntu-24.04` or another recent runner. Debian package dependency metadata is inferred from the binary’s linked glibc symbols, so building on too-new a distribution makes the generated `.deb` unusable on Debian 12, which ships libc 2.36. The release workflow should build Linux artifacts, especially `.deb` packages, on a stable older Linux image such as `ubuntu-22.04`, or in a Debian 12 container, to keep the minimum libc requirement compatible with Debian 12 and most supported distributions.
