### PR TITLE
Use flame NF icon for Mojo

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -1816,7 +1816,7 @@ Mojo:
       - "#FF4500"
       - "#FFD700"
     chip: "#FF4C1F"
-  icon: '\u{1F525}'
+  icon: '\u{eaf2}'
 Nim:
   type: programming
   ascii: |


### PR DESCRIPTION
While previewing the icons, I noticed that Mojo wasn't using a Nerd Font icon, but the emoji 🔥. This PR replaces the emoji with a flame icon (``).

Mojo is an interesting case, because IIRC 🔥 was (and maybe still is) a valid file extension. E.g. `hello-world.🔥`. So we may want to keep the emoji to reflect Mojo's unique quirk.