### PR TITLE
Update cargo_toml dependency to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,12 +336,13 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo_toml"
-version = "0.22.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
+checksum = "aa61aec073ec94791433ddf3df2323ff9d1711557c2a0eefb0f99cb4f8dca520"
 dependencies = [
+ "semver",
  "serde",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -3188,6 +3189,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -3702,29 +3707,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "indexmap",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
  "toml_writer",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3734,15 +3727,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -9,7 +9,7 @@ description = "Detect and parse manifest files"
 
 [dependencies]
 anyhow = "1.0.101"
-cargo_toml = "0.22.3"
+cargo_toml = "1.0.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 strum = { version = "0.28.0", features = ["derive"] }

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -53,7 +53,7 @@ fn parse_cargo_manifest(path: &Path) -> Result<Manifest> {
         number_of_dependencies: m.dependencies.len(),
         name: Some(package.name.clone()),
         description,
-        version: Some(package.version().into()),
+        version: Some(package.version().to_string()),
         license: package.license().map(Into::into),
     })
 }


### PR DESCRIPTION
Updates the `cargo_toml` dependency to 1.0.0.

https://gitlab.com/lib.rs/cargo_toml/-/compare/v0.22.3...v1.0.0

The MSRV and Edition have been bumped, and the package version is now a [`semver::Version`](https://docs.rs/semver/latest/semver/struct.Version.html), for which a small source-code change was required.