### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/image/src/kitty.rs
+++ b/image/src/kitty.rs
@@ -17,7 +17,7 @@ impl KittyBackend {
         let stdin = std::io::stdin();
         // save terminal attributes and disable canonical input processing mode
         let old_attributes = {
-            let old = tcgetattr(&stdin).context("Failed to recieve terminal attibutes")?;
+            let old = tcgetattr(&stdin).context("Failed to receive terminal attributes")?;
 
             let mut new = old.clone();
             new.local_modes &= !LocalModes::ICANON;

--- a/image/src/sixel.rs
+++ b/image/src/sixel.rs
@@ -20,7 +20,7 @@ impl SixelBackend {
         let stdin = std::io::stdin();
         // save terminal attributes and disable canonical input processing mode
         let old_attributes = {
-            let old = tcgetattr(&stdin).context("Failed to recieve terminal attibutes")?;
+            let old = tcgetattr(&stdin).context("Failed to receive terminal attributes")?;
 
             let mut new = old.clone();
             new.local_modes &= !LocalModes::ICANON;


### PR DESCRIPTION
Fix minor typos found by codespell.

- `recieve` → `receive` in `image/src/kitty.rs` and `image/src/sixel.rs`
- `attibutes` → `attributes` in `image/src/kitty.rs` and `image/src/sixel.rs`