### PR TITLE
Fall back to all language types when `--type` matches nothing

### DIFF
--- a/docs/onefetch.1
+++ b/docs/onefetch.1
@@ -87,6 +87,8 @@ Count hidden files and directories
 .IP
 Filters output by language type
 .IP
+If no language of the selected TYPE(s) is found, falls back to counting every language type instead of showing no languages at all
+.IP
 [default: programming markup]
 [possible values: programming, markup, prose, data]
 .SS "TEXT FORMATTING:"

--- a/docs/wiki/command-line-options.md
+++ b/docs/wiki/command-line-options.md
@@ -63,6 +63,8 @@ INFO:
   -T, --type <TYPE>...
           Filters output by language type
 
+          If no language of the selected TYPE(s) is found, falls back to counting every language type instead of showing no languages at all
+
           [default: programming markup]
           [possible values: programming, markup, prose, data]
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,6 +110,9 @@ pub struct InfoCliOptions {
     #[arg(long)]
     pub include_hidden: bool,
     /// Filters output by language type
+    ///
+    /// If no language of the selected TYPE(s) is found, falls back to counting
+    /// every language type instead of showing no languages at all
     #[arg(
         long,
         num_args = 1..,

--- a/src/info/langs/language.tera
+++ b/src/info/langs/language.tera
@@ -13,7 +13,7 @@ pub struct Colors {
 
 const DEFAULT_CHIP_ICON: char = '\u{25CF}';
 
-#[derive(Clone, PartialEq, Eq, Debug, clap::ValueEnum)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, EnumIter, clap::ValueEnum)]
 pub enum LanguageType {
     Programming,
     Markup,

--- a/src/info/langs/mod.rs
+++ b/src/info/langs/mod.rs
@@ -13,6 +13,10 @@ pub fn get_main_language(loc_by_language: &[(Language, usize)]) -> Language {
 /// Returns a vector of tuples containing all the languages detected inside the repository.
 /// Each tuple is composed of the language and its corresponding loc (lines of code).
 /// The vector is sorted by loc in descending order.
+///
+/// If the given `language_types` filter doesn't match any language in the repository,
+/// this falls back to counting every language type instead of reporting nothing.
+/// See <https://github.com/o2sh/onefetch/issues/1705>.
 pub fn get_loc_by_language_sorted(
     dir: &Path,
     globs_to_exclude: &[String],
@@ -20,8 +24,19 @@ pub fn get_loc_by_language_sorted(
     include_hidden: bool,
 ) -> Option<Vec<(Language, usize)>> {
     let locs = get_locs(dir, globs_to_exclude, language_types, include_hidden);
-    let loc_by_language_opt = get_loc_by_language(&locs);
+    let loc_by_language_opt = get_loc_by_language(&locs).or_else(|| {
+        if all_types_selected(language_types) {
+            return None;
+        }
+        let all_types: Vec<LanguageType> = LanguageType::iter().collect();
+        let locs = get_locs(dir, globs_to_exclude, &all_types, include_hidden);
+        get_loc_by_language(&locs)
+    });
     loc_by_language_opt.map(sort_by_loc)
+}
+
+fn all_types_selected(language_types: &[LanguageType]) -> bool {
+    LanguageType::iter().all(|t| language_types.contains(&t))
 }
 
 fn sort_by_loc(map: HashMap<Language, usize>) -> Vec<(Language, usize)> {
@@ -199,5 +214,16 @@ mod test {
     fn test_get_total_loc() {
         let loc_by_language = [(Language::JavaScript, 100), (Language::Markdown, 300)];
         assert_eq!(get_total_loc(&loc_by_language), 400);
+    }
+
+    #[test]
+    fn all_types_selected_is_true_for_every_language_type() {
+        let all_types: Vec<LanguageType> = LanguageType::iter().collect();
+        assert!(all_types_selected(&all_types));
+    }
+
+    #[test]
+    fn all_types_selected_is_false_for_a_partial_selection() {
+        assert!(!all_types_selected(&[LanguageType::Programming]));
     }
 }

--- a/tests/fixtures/make_repo_with_only_prose.sh
+++ b/tests/fixtures/make_repo_with_only_prose.sh
@@ -1,0 +1,21 @@
+set -eu -o pipefail
+
+git init -q
+
+# BOTH NAME AND EMAIL ARE NEEDED FOR RECOGNITION
+git config --local --add "committer.name" "onefetch-committer-name"
+git config --local --add "committer.email" "onefetch-committer-email@onefetch.com"
+
+git remote add origin https://github.com/user/repo.git
+
+git checkout -b main
+
+# Markdown is prose, so the default `--type programming markup` matches nothing
+# here and onefetch has to fall back to every type (cf. #1705)
+cat <<'EOF' > README.md
+# Title
+
+Some prose, and no code at all.
+EOF
+git add README.md
+git commit -q -m c1

--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use gix::{Repository, ThreadSafeRepository, open};
 use onefetch::cli::{CliOptions, InfoCliOptions, TextForamttingCliOptions};
+use onefetch::info::langs::language::Language;
 use onefetch::info::{build_info, get_work_dir};
 
 fn repo(name: &str) -> Result<Repository> {
@@ -114,5 +115,20 @@ fn test_repo_without_code() -> Result<()> {
         ..Default::default()
     };
     let _info = build_info(&config).expect("no error");
+    Ok(())
+}
+
+// https://github.com/o2sh/onefetch/issues/1705
+#[test]
+fn test_repo_with_only_prose_falls_back_to_all_language_types() -> Result<()> {
+    let repo = repo("make_repo_with_only_prose.sh")?;
+    let config: CliOptions = CliOptions {
+        input: repo.path().to_path_buf(),
+        ..Default::default()
+    };
+    let info = build_info(&config)?;
+    // The default `--type programming markup` matches nothing in this repo, so
+    // without the fallback there is no dominant language and no Languages field.
+    assert_eq!(info.dominant_language, Some(Language::Markdown));
     Ok(())
 }


### PR DESCRIPTION
Closes #1705.

### What

When `--type`/`-T` filters out every language in the repository, `get_loc_by_language_sorted` now retries the count over all four types instead of returning nothing. That's the "second pass over the repo if the original sum is 0" option from @spenserblack's comment on the issue — I went with it over summing undisplayed languages up front so the common case keeps a single pass.

The retry is guarded twice: it only runs when the first pass found nothing, and it's skipped when the selection already covers every type (`all_types_selected`), so there's no pointless second walk.

### Before / after

On a repo holding only a README and a `compose.yaml` — the case from the issue:

| | Languages field |
|---|---|
| `main` | *(nothing, and no ascii-art language)* |
| this branch | `Markdown (60.0 %)`, `TOML (40.0 %)` |

### Tests

`tests/repo.rs` gets `test_repo_with_only_prose_falls_back_to_all_language_types`, backed by a new `make_repo_with_only_prose.sh` fixture (a README with actual prose, no code).

I checked it's a real regression test rather than one that happens to pass — reverting just the `src/` change and rerunning gives:

```
assertion `left == right` failed
  left: None
 right: Some(Markdown)
```

I initially tried to reuse the existing `make_repo_without_code.sh`, but its README is created with `touch`, so it has zero lines and there's genuinely nothing for the fallback to find — hence the separate fixture.

Two small unit tests cover `all_types_selected` directly.

### Notes

- `LanguageType` in `language.tera` gains `EnumIter` (and `Copy`) so the fallback can enumerate every variant.
- Updated the `--type` long help, and the two checked-in copies of it that would otherwise drift: `docs/onefetch.1` and `docs/wiki/command-line-options.md`.
- One behavioural thing worth a second opinion: the fallback fires whenever the filter matches nothing, including when the user passed `-T` explicitly rather than relying on the default. That's what the issue asks for and it can't be distinguished from the default at the clap level, but if you'd rather it only apply to the default selection, say so and I'll rework it.

`cargo test` (127 unit + 8 integration), `cargo fmt --check`, and `cargo clippy --all-targets` are all clean on macOS aarch64.