### PR TITLE
Improve JSON ASCII logo

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -1423,28 +1423,31 @@ JavaScript:
 Json:
   type: data
   ascii: |
-    {0}           `:+osyyyso+/:`
-    {0}        :smNNNmmmddddhhhmds:
-    {0}     .oNNNNNmmmddddhhhyyyym{1}MNs.
-    {0}    oNNNNNmmmddddhhhyyyysssh{1}MMMs`
-    {0}  .dNNNNmmmddmmmdyyyyysssoooh{1}MMMm.
-    {0} `mNNNmmmmm{1}NMMMy-{0}  .+ssoooo++N{1}MMMN.
-    {0} yNNmmmdm{1}MMMMN-  {0}    .ooo+++/d{1}MMMMd
-    {0}-Nmmmddm{1}MMMMM:   {0}     .+++///y{1}MMMMM-
-    {0}+mmdddd{1}MMMMMm    {0}      /////:y{1}MMMMM+
-    {0}+ddddhd{1}MMMMMm    {0}      ///:::m{1}MMMMM+
-    {0}-ddhhhd{1}MMMMMM-   {0}     `/::::y{1}MMMMMM-
-    {0} shhyyh{1}MMMMMMm-  {0}    `:::::h{1}MMMMMMh
-    {0} .yyyyyN{1}MMMMMMMs.{0}  `-:::/y{1}NMMMMMMm`
-    {0}  .osssh{1}MMMMMMMMMmhyyydNMMMMMMMMd.
-    {0}    :oood{1}MMMMMMMMMMMMMMMMMMMMMNo
-    {0}     `:++yN{1}MMMMMMMMMMMMMMMMMNs.
-    {0}        .-/ym{1}MMMMMMMMMMMMmy:
-    {0}            `-/oyhhhys+:`
+    {0}
+    {0}   ####     {1}            {0}   ####
+    {0}  #          {1}            {0}        #
+    {0} #           {1}            {0}         #
+    {0} #           {1}            {0}         #
+    {0} #           {1}            {0}         #
+    {0} #           {1}            {0}         #
+    {0} #           {1}            {0}         #
+    {0} #           {1}### ### #  #{0}         #
+    {0} #####       {1}  # #  ## #{0}     ####
+    {0} #####       {1}  # ## # ##{0}     ####
+    {0} #####       {1}  # ###  ##{0}     ####
+    {0} #           {1}### ### # #{0}         #
+    {0} #           {1}            {0}         #
+    {0} #           {1}            {0}         #
+    {0} #           {1}            {0}         #
+    {0} #           {1}            {0}         #
+    {0} #           {1}            {0}         #
+    {0} #           {1}            {0}         #
+    {0}  #          {1}            {0}        #
+    {0}   ####     {1}            {0}   ####
   colors:
     ansi:
       - white
-      - black
+      - cyan
     chip: "#292929"
   icon: '\u{eb0f}'
 Jsonnet:


### PR DESCRIPTION
This PR improves the JSON ASCII art as requested in #777.

The previous logo was an abstract circular design that did not clearly evoke JSON. The new logo shows a symmetrical pair of large curly braces framing the language name, which is more faithful and recognizable.

- Hand-polished ASCII art (AI/online tools were used only as a base for inspiration).
- Verified with `cargo build --release` and `cargo test`.
- Rendered locally with `onefetch --ascii-language json --no-title`.

Closes #777