### PR TITLE
Add pyproject.toml manifest support (PEP 621)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,6 +2803,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,6 +2800,7 @@ version = "2.27.1"
 dependencies = [
  "anyhow",
  "cargo_toml",
+ "rstest",
  "serde",
  "serde_json",
  "strum",

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -13,3 +13,4 @@ cargo_toml = "1.0.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 strum = { version = "0.28.0", features = ["derive"] }
+toml = "1.0.0"

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -14,3 +14,6 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 strum = { version = "0.28.0", features = ["derive"] }
 toml = "1.0.0"
+
+[dev-dependencies]
+rstest = "0.26.1"

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -16,4 +16,4 @@ strum = { version = "0.28.0", features = ["derive"] }
 toml = "1.0.0"
 
 [dev-dependencies]
-rstest = "0.26.1"
+rstest.workspace = true

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -21,7 +21,6 @@ pub struct Manifest {
 pub enum ManifestType {
     Npm,
     Cargo,
-    #[strum(to_string = "pyproject.toml")]
     PyProject,
 }
 
@@ -108,7 +107,16 @@ struct PyProjectTable {
 }
 
 /// PEP 621 allows `license` to be either an SPDX expression string (PEP 639) or
-/// a table pointing at the license text or a file.
+/// a table with a `text` or `file` key.
+///
+/// - `Spdx` is the PEP 639 form, e.g. `license = "MIT"`.
+/// - `Table.text` is the older PEP 621 form, e.g. `license = { text = "MIT" }`.
+///   Its value is free-form: it is conventionally an SPDX identifier, but the
+///   spec permits any string (for example the full text of a non-standard
+///   license). We surface it verbatim and let the caller decide how to render
+///   it, rather than trying to validate it as SPDX.
+/// - `license = { file = "LICENSE" }` points at a file and carries no
+///   identifier, so it deserializes to `text: None` (the `file` key is ignored).
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum PyProjectLicense {
@@ -127,8 +135,11 @@ fn parse_pyproject_manifest(path: &Path) -> Result<Manifest> {
         .project
         .context("pyproject.toml has no [project] table")?;
 
-    // A `license = { file = "LICENSE" }` table carries no identifier, so leave it
-    // unset and let onefetch fall back to detecting the license from the repo.
+    // The SPDX string and a `{ text = "..." }` table both carry a license
+    // identifier (usually SPDX, though `text` may be any free-form string), so
+    // use them directly. A `{ file = "LICENSE" }` table has no identifier, so
+    // leave it unset and let onefetch fall back to detecting the license from
+    // the repo.
     let license = project.license.and_then(|license| match license {
         PyProjectLicense::Spdx(spdx) => Some(spdx),
         PyProjectLicense::Table { text } => text,
@@ -156,24 +167,21 @@ fn file_name_to_manifest_type(filename: &str) -> Option<ManifestType> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn parses_pep621_license_forms() {
-        // SPDX expression string (PEP 639)
-        let spdx: PyProjectTable = toml::from_str("license = \"MIT\"").unwrap();
-        assert!(matches!(spdx.license, Some(PyProjectLicense::Spdx(s)) if s == "MIT"));
-
-        // `{ text = "..." }` table (older PEP 621 form)
-        let text: PyProjectTable = toml::from_str("license = { text = \"Apache-2.0\" }").unwrap();
-        assert!(
-            matches!(text.license, Some(PyProjectLicense::Table { text: Some(t) }) if t == "Apache-2.0")
-        );
-
-        // `{ file = "LICENSE" }` table carries no identifier
-        let file: PyProjectTable = toml::from_str("license = { file = \"LICENSE\" }").unwrap();
-        assert!(matches!(
-            file.license,
-            Some(PyProjectLicense::Table { text: None })
-        ));
+    #[rstest]
+    // SPDX expression string (PEP 639)
+    #[case("license = \"MIT\"", Some("MIT"))]
+    // `{ text = "..." }` table (older PEP 621 form)
+    #[case("license = { text = \"Apache-2.0\" }", Some("Apache-2.0"))]
+    // `{ file = "LICENSE" }` table carries no identifier
+    #[case("license = { file = \"LICENSE\" }", None)]
+    fn parses_pep621_license_forms(#[case] source: &str, #[case] expected: Option<&str>) {
+        let table: PyProjectTable = toml::from_str(source).unwrap();
+        let license = table.license.and_then(|license| match license {
+            PyProjectLicense::Spdx(spdx) => Some(spdx),
+            PyProjectLicense::Table { text } => text,
+        });
+        assert_eq!(license.as_deref(), expected);
     }
 }

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -170,12 +170,9 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    // SPDX expression string (PEP 639)
-    #[case("license = \"MIT\"", Some("MIT"))]
-    // `{ text = "..." }` table (older PEP 621 form)
-    #[case("license = { text = \"Apache-2.0\" }", Some("Apache-2.0"))]
-    // `{ file = "LICENSE" }` table carries no identifier
-    #[case("license = { file = \"LICENSE\" }", None)]
+    #[case::pep_639("license = \"MIT\"", Some("MIT"))]
+    #[case::pep_621_text("license = { text = \"Apache-2.0\" }", Some("Apache-2.0"))]
+    #[case::pep_621_file("license = { file = \"LICENSE\" }", None)]
     fn parses_pep621_license_forms(#[case] source: &str, #[case] expected: Option<&str>) {
         let table: PyProjectTable = toml::from_str(source).unwrap();
         let license = table.license.and_then(|license| match license {

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -21,6 +21,8 @@ pub struct Manifest {
 pub enum ManifestType {
     Npm,
     Cargo,
+    #[strum(to_string = "pyproject.toml")]
+    PyProject,
 }
 
 pub fn get_manifests<P: AsRef<Path>>(path: P) -> Result<Vec<Manifest>> {
@@ -36,6 +38,7 @@ pub fn get_manifests<P: AsRef<Path>>(path: P) -> Result<Vec<Manifest>> {
         .filter_map(|(file_path, manifest_type)| match manifest_type {
             ManifestType::Cargo => parse_cargo_manifest(&file_path).ok(),
             ManifestType::Npm => parse_npm_manifest(&file_path).ok(),
+            ManifestType::PyProject => parse_pyproject_manifest(&file_path).ok(),
         })
         .collect::<Vec<_>>();
 
@@ -85,10 +88,92 @@ fn parse_npm_manifest(path: &Path) -> Result<Manifest> {
     })
 }
 
+/// A PEP 621 `pyproject.toml` `[project]` table.
+///
+/// Only the fields that map onto [`Manifest`] are deserialized. Tool-specific
+/// tables such as `[tool.poetry]` use a different layout and are not handled here.
+#[derive(Deserialize)]
+struct PyProject {
+    project: Option<PyProjectTable>,
+}
+
+#[derive(Deserialize)]
+struct PyProjectTable {
+    name: Option<String>,
+    version: Option<String>,
+    description: Option<String>,
+    license: Option<PyProjectLicense>,
+    #[serde(default)]
+    dependencies: Vec<String>,
+}
+
+/// PEP 621 allows `license` to be either an SPDX expression string (PEP 639) or
+/// a table pointing at the license text or a file.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PyProjectLicense {
+    Spdx(String),
+    Table { text: Option<String> },
+}
+
+fn parse_pyproject_manifest(path: &Path) -> Result<Manifest> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read pyproject.toml at '{}'", path.display()))?;
+
+    let pyproject: PyProject = toml::from_str(&content)
+        .with_context(|| format!("Failed to parse pyproject.toml at '{}'", path.display()))?;
+
+    let project = pyproject
+        .project
+        .context("pyproject.toml has no [project] table")?;
+
+    // A `license = { file = "LICENSE" }` table carries no identifier, so leave it
+    // unset and let onefetch fall back to detecting the license from the repo.
+    let license = project.license.and_then(|license| match license {
+        PyProjectLicense::Spdx(spdx) => Some(spdx),
+        PyProjectLicense::Table { text } => text,
+    });
+
+    Ok(Manifest {
+        manifest_type: ManifestType::PyProject,
+        number_of_dependencies: project.dependencies.len(),
+        name: project.name,
+        description: project.description,
+        version: project.version,
+        license,
+    })
+}
+
 fn file_name_to_manifest_type(filename: &str) -> Option<ManifestType> {
     match filename {
         "Cargo.toml" => Some(ManifestType::Cargo),
         "package.json" => Some(ManifestType::Npm),
+        "pyproject.toml" => Some(ManifestType::PyProject),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pep621_license_forms() {
+        // SPDX expression string (PEP 639)
+        let spdx: PyProjectTable = toml::from_str("license = \"MIT\"").unwrap();
+        assert!(matches!(spdx.license, Some(PyProjectLicense::Spdx(s)) if s == "MIT"));
+
+        // `{ text = "..." }` table (older PEP 621 form)
+        let text: PyProjectTable = toml::from_str("license = { text = \"Apache-2.0\" }").unwrap();
+        assert!(
+            matches!(text.license, Some(PyProjectLicense::Table { text: Some(t) }) if t == "Apache-2.0")
+        );
+
+        // `{ file = "LICENSE" }` table carries no identifier
+        let file: PyProjectTable = toml::from_str("license = { file = \"LICENSE\" }").unwrap();
+        assert!(matches!(
+            file.license,
+            Some(PyProjectLicense::Table { text: None })
+        ));
     }
 }

--- a/manifest/tests/fixtures/pyproject/pyproject.toml
+++ b/manifest/tests/fixtures/pyproject/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "my_package"
+version = "1.0.0"
+description = "description for my_package"
+license = "MIT"
+dependencies = [
+    "requests>=2.31",
+    "click>=8.1",
+    "rich>=13.0",
+]
+
+[dependency-groups]
+dev = ["pytest", "ruff"]

--- a/manifest/tests/pyproject.rs
+++ b/manifest/tests/pyproject.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use onefetch_manifest::{ManifestType, get_manifests};
+
+#[test]
+fn should_detect_and_parse_pyproject_manifest() -> Result<()> {
+    let manifests = get_manifests("tests/fixtures/pyproject")?;
+    assert_eq!(manifests.len(), 1);
+    let pyproject_manifest = manifests.first().unwrap();
+    assert_eq!(pyproject_manifest.manifest_type, ManifestType::PyProject);
+    assert_eq!(pyproject_manifest.number_of_dependencies, 3);
+    assert_eq!(pyproject_manifest.name, Some(String::from("my_package")));
+    assert_eq!(
+        pyproject_manifest.description,
+        Some("description for my_package".into())
+    );
+    assert_eq!(pyproject_manifest.version, Some(String::from("1.0.0")));
+    assert_eq!(pyproject_manifest.license, Some("MIT".into()));
+    Ok(())
+}


### PR DESCRIPTION
Closes #1590. This adds `pyproject.toml` to the set of manifests onefetch understands, so Python projects show a dependency count, description, version and license just like Cargo and npm projects already do.

Following the discussion on the issue, I focused on the format specified by the PEPs rather than tool-specific layouts. A new `ManifestType::PyProject` reads the PEP 621 `[project]` table:

- `number_of_dependencies` from `project.dependencies`
- `name` / `version` / `description` from their `project.*` fields
- `license` from `project.license`, handled as either a PEP 639 SPDX string or the older `{ text = "..." }` table. A `{ file = "LICENSE" }` table carries no identifier, so it's left unset and onefetch falls back to detecting the license from the repo as before.

Tool-specific tables such as `[tool.poetry]` use a different shape and are intentionally out of scope here.

Parsing uses `toml`, which was already in the tree via `cargo_toml`, so `Cargo.lock` only gains the existing version as a direct dependency of the manifest crate. In the Dependencies field this reads as e.g. `3 (pyproject.toml)`.

### Tests

- `manifest/tests/pyproject.rs` with a `tests/fixtures/pyproject/` fixture, mirroring the existing cargo/npm integration tests.
- A unit test in `manifest/src/lib.rs` covering the three PEP 621 `license` forms (SPDX string, `{ text }` table, `{ file }` table).
- Verified end to end against a scratch git repo containing a `pyproject.toml`: `onefetch` prints `Dependencies: 3 (pyproject.toml)` and picks up the description, version and license. `cargo fmt --all --check`, `cargo clippy`, and the full test suite pass.