### PR TITLE
Support non-colocated Jujutsu repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ cd /path/of/your/repo
 onefetch
 ```
 
+Native (non-colocated) Jujutsu repositories are also supported when `jj` is installed.
+
 ## Customization
 
 Onefetch can be customized via [command-line arguments](https://github.com/o2sh/onefetch/wiki/command-line-options) to display exactly what you want, the way you want it: adjust the text styling, disable info lines, ignore files and directories, output in multiple formats (JSON, YAML), etc.

--- a/src/info/git/mod.rs
+++ b/src/info/git/mod.rs
@@ -21,6 +21,8 @@ pub mod sig;
 
 pub fn traverse_commit_graph(
     repo: &gix::Repository,
+    head_id: ObjectId,
+    skip_head: bool,
     no_bots: Option<MyRegex>,
     churn_pool_size: Option<usize>,
     no_merges: bool,
@@ -36,7 +38,7 @@ pub fn traverse_commit_graph(
     let can_use_commit_graph = commit_graph.is_some();
 
     let commit_iter = repo
-        .head_commit()?
+        .find_commit(head_id)?
         .id()
         .ancestors()
         .sorting(Sorting::ByCommitTime(CommitTimeOrder::NewestFirst))
@@ -59,6 +61,10 @@ pub fn traverse_commit_graph(
     for commit in commit_iter {
         let commit = commit?;
         {
+            if skip_head && commit.id == head_id {
+                continue;
+            }
+
             if no_merges && commit.parent_ids.len() > 1 {
                 continue;
             }

--- a/src/info/head.rs
+++ b/src/info/head.rs
@@ -1,6 +1,7 @@
 use crate::info::utils::info_field::InfoField;
 use anyhow::{Context, Result};
 use gix::Repository;
+use gix::prelude::ObjectIdExt;
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -45,6 +46,12 @@ impl HeadInfo {
     pub fn new(repo: &Repository) -> Result<Self> {
         let head_refs = get_head_refs(repo)?;
         Ok(Self { head_refs })
+    }
+
+    pub fn from_id(repo: &Repository, head_id: gix::ObjectId) -> Result<Self> {
+        Ok(Self {
+            head_refs: HeadRefs::new(head_id.attach(repo).shorten()?.to_string(), Vec::new()),
+        })
     }
 }
 

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -15,6 +15,7 @@ use self::license::LicenseInfo;
 use self::loc::LocInfo;
 use self::pending::PendingInfo;
 use self::project::ProjectInfo;
+use self::repository::Repository as DiscoveredRepository;
 use self::size::SizeInfo;
 use self::title::Title;
 use self::url::UrlInfo;
@@ -46,6 +47,7 @@ mod license;
 mod loc;
 mod pending;
 mod project;
+mod repository;
 mod size;
 mod title;
 mod url;
@@ -109,8 +111,9 @@ impl std::fmt::Display for Info {
 }
 
 pub fn build_info(cli_options: &CliOptions) -> Result<Info> {
-    let repo = gix::discover(&cli_options.input)?;
-    let repo_path = get_work_dir(&repo)?;
+    let discovered_repo = DiscoveredRepository::discover(&cli_options.input)?;
+    let repo = discovered_repo.git();
+    let repo_path = discovered_repo.work_dir().to_owned();
     // Compute LOC in a separate thread so it runs in parallel with commit-graph traversal.
     let loc_by_language_sorted_handle = std::thread::spawn({
         let globs_to_exclude = cli_options.info.exclude.clone();
@@ -127,19 +130,17 @@ pub fn build_info(cli_options: &CliOptions) -> Result<Info> {
         }
     });
     let git_metrics = traverse_commit_graph(
-        &repo,
+        repo,
+        discovered_repo.head_id()?,
+        discovered_repo.is_jujutsu(),
         cli_options.info.no_bots.clone(),
         cli_options.info.churn_pool_size,
         cli_options.info.no_merges,
     )
     .context("Failed to traverse Git commit history")?;
     let manifest = get_manifest(&repo_path)?;
-    let repo_url = get_repo_url(
-        &repo,
-        cli_options.info.hide_token,
-        cli_options.info.http_url,
-    )
-    .context("Failed to determine repository URL")?;
+    let repo_url = get_repo_url(repo, cli_options.info.hide_token, cli_options.info.http_url)
+        .context("Failed to determine repository URL")?;
     let true_color = match cli_options.ascii.true_color {
         When::Always => true,
         When::Never => false,
@@ -169,12 +170,12 @@ pub fn build_info(cli_options: &CliOptions) -> Result<Info> {
     let show_email = cli_options.info.email;
 
     Ok(InfoBuilder::new(cli_options)
-        .title(&repo, no_bold, &text_colors)
-        .project(&repo, &repo_url, manifest.as_ref(), number_separator)?
+        .title(repo, no_bold, &text_colors)
+        .project(repo, &repo_url, manifest.as_ref(), number_separator)?
         .description(manifest.as_ref())
-        .head(&repo)?
-        .pending(&repo)?
-        .version(&repo, manifest.as_ref())?
+        .head(repo, discovered_repo.jujutsu_head())?
+        .pending(repo, discovered_repo.is_jujutsu())?
+        .version(repo, manifest.as_ref())?
         .created(&git_metrics, iso_time)
         .languages(
             loc_by_language.as_ref(),
@@ -201,7 +202,7 @@ pub fn build_info(cli_options: &CliOptions) -> Result<Info> {
             number_separator,
         )?
         .loc(loc_by_language.as_ref(), number_separator)
-        .size(&repo, number_separator)
+        .size(repo, number_separator, discovered_repo.is_jujutsu())
         .license(&repo_path, manifest.as_ref())?
         .build(cli_options, text_colors, dominant_language, ascii_colors))
 }
@@ -238,8 +239,8 @@ impl InfoBuilder {
         self
     }
 
-    fn pending(mut self, repo: &Repository) -> Result<Self> {
-        if !self.disabled_fields.contains(&InfoType::Pending) {
+    fn pending(mut self, repo: &Repository, is_jujutsu: bool) -> Result<Self> {
+        if !is_jujutsu && !self.disabled_fields.contains(&InfoType::Pending) {
             let pending = PendingInfo::new(repo)?;
             self.info_fields.push(Box::new(pending));
         }
@@ -268,9 +269,12 @@ impl InfoBuilder {
         Ok(self)
     }
 
-    fn head(mut self, repo: &Repository) -> Result<Self> {
+    fn head(mut self, repo: &Repository, jujutsu_head: Option<gix::ObjectId>) -> Result<Self> {
         if !self.disabled_fields.contains(&InfoType::Head) {
-            let head = HeadInfo::new(repo)?;
+            let head = match jujutsu_head {
+                Some(head_id) => HeadInfo::from_id(repo, head_id)?,
+                None => HeadInfo::new(repo)?,
+            };
             self.info_fields.push(Box::new(head));
         }
         Ok(self)
@@ -284,8 +288,13 @@ impl InfoBuilder {
         Ok(self)
     }
 
-    fn size(mut self, repo: &Repository, number_separator: NumberSeparator) -> Self {
-        if !self.disabled_fields.contains(&InfoType::Size) {
+    fn size(
+        mut self,
+        repo: &Repository,
+        number_separator: NumberSeparator,
+        is_jujutsu: bool,
+    ) -> Self {
+        if !is_jujutsu && !self.disabled_fields.contains(&InfoType::Size) {
             let size = SizeInfo::new(repo, number_separator);
             self.info_fields.push(Box::new(size));
         }

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -112,6 +112,11 @@ impl std::fmt::Display for Info {
 
 pub fn build_info(cli_options: &CliOptions) -> Result<Info> {
     let discovered_repo = DiscoveredRepository::discover(&cli_options.input)?;
+    if discovered_repo.is_jujutsu() {
+        eprintln!(
+            "Jujutsu support is experimental: pending changes and size are not yet supported"
+        );
+    }
     let repo = discovered_repo.git();
     let repo_path = discovered_repo.work_dir().to_owned();
     // Compute LOC in a separate thread so it runs in parallel with commit-graph traversal.
@@ -240,6 +245,7 @@ impl InfoBuilder {
     }
 
     fn pending(mut self, repo: &Repository, is_jujutsu: bool) -> Result<Self> {
+        // Jujutsu records working-copy changes in @, and its bare Git store has no worktree status.
         if !is_jujutsu && !self.disabled_fields.contains(&InfoType::Pending) {
             let pending = PendingInfo::new(repo)?;
             self.info_fields.push(Box::new(pending));

--- a/src/info/repository.rs
+++ b/src/info/repository.rs
@@ -56,14 +56,15 @@ impl Repository {
     }
 
     pub fn head_id(&self) -> Result<ObjectId> {
-        match self.jujutsu_head {
-            Some(head_id) => Ok(head_id),
-            None => Ok(self
-                .git
-                .head_id()
-                .context("Failed to retrieve HEAD ID")?
-                .detach()),
-        }
+        self.jujutsu_head.map_or_else(
+            || {
+                self.git
+                    .head_id()
+                    .context("Failed to retrieve HEAD ID")
+                    .map(|head_id| head_id.detach())
+            },
+            Ok,
+        )
     }
 
     pub fn jujutsu_head(&self) -> Option<ObjectId> {
@@ -79,15 +80,11 @@ fn find_jujutsu_root(input: &Path) -> Result<Option<PathBuf>> {
     let input = input
         .canonicalize()
         .with_context(|| format!("Failed to resolve repository path '{}'.", input.display()))?;
-    let start = if input.is_dir() {
-        input.as_path()
-    } else {
-        input
-            .parent()
-            .context("The repository path has no parent directory")?
-    };
+    if !input.is_dir() {
+        bail!("Repository path '{}' is not a directory", input.display());
+    }
 
-    Ok(start
+    Ok(input
         .ancestors()
         .find(|path| path.join(".jj").is_dir())
         .map(Path::to_owned))
@@ -124,10 +121,13 @@ mod tests {
         let fixture =
             std::env::temp_dir().join(format!("onefetch-jj-root-test-{}", std::process::id()));
         let nested = fixture.join("a/b");
+        let file = fixture.join("file");
         std::fs::create_dir_all(fixture.join(".jj"))?;
         std::fs::create_dir_all(&nested)?;
+        std::fs::write(&file, b"")?;
 
         assert_eq!(find_jujutsu_root(&nested)?, Some(fixture.canonicalize()?));
+        assert!(find_jujutsu_root(&file).is_err());
 
         std::fs::remove_dir_all(fixture)?;
         Ok(())

--- a/src/info/repository.rs
+++ b/src/info/repository.rs
@@ -1,0 +1,135 @@
+use anyhow::{Context, Result, bail};
+use gix::ObjectId;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub struct Repository {
+    git: gix::Repository,
+    work_dir: PathBuf,
+    jujutsu_head: Option<ObjectId>,
+}
+
+impl Repository {
+    pub fn discover(input: &Path) -> Result<Self> {
+        if let Some(root) = find_jujutsu_root(input)?
+            && !root.join(".git").exists()
+        {
+            return Self::open_jujutsu(root);
+        }
+
+        let git = gix::discover(input)?;
+        let work_dir = git
+            .workdir()
+            .context("please run onefetch inside of a non-bare git repository")?
+            .to_owned();
+
+        Ok(Self {
+            git,
+            work_dir,
+            jujutsu_head: None,
+        })
+    }
+
+    fn open_jujutsu(root: PathBuf) -> Result<Self> {
+        let git_dir = run_jj(&root, &["git", "root"])
+            .context("Failed to locate the Git store backing the Jujutsu repository")?;
+        let git = gix::open(git_dir.trim()).context("Failed to open the Jujutsu Git store")?;
+
+        let head = run_jj(&root, &["log", "-r", "@", "--no-graph", "-T", "commit_id"])
+            .context("Failed to determine the Jujutsu working-copy commit")?;
+        let head_id = ObjectId::from_hex(head.trim().as_bytes())
+            .context("Jujutsu returned an invalid working-copy commit ID")?;
+
+        Ok(Self {
+            git,
+            work_dir: root,
+            jujutsu_head: Some(head_id),
+        })
+    }
+
+    pub fn git(&self) -> &gix::Repository {
+        &self.git
+    }
+
+    pub fn work_dir(&self) -> &Path {
+        &self.work_dir
+    }
+
+    pub fn head_id(&self) -> Result<ObjectId> {
+        match self.jujutsu_head {
+            Some(head_id) => Ok(head_id),
+            None => Ok(self
+                .git
+                .head_id()
+                .context("Failed to retrieve HEAD ID")?
+                .detach()),
+        }
+    }
+
+    pub fn jujutsu_head(&self) -> Option<ObjectId> {
+        self.jujutsu_head
+    }
+
+    pub fn is_jujutsu(&self) -> bool {
+        self.jujutsu_head.is_some()
+    }
+}
+
+fn find_jujutsu_root(input: &Path) -> Result<Option<PathBuf>> {
+    let input = input
+        .canonicalize()
+        .with_context(|| format!("Failed to resolve repository path '{}'.", input.display()))?;
+    let start = if input.is_dir() {
+        input.as_path()
+    } else {
+        input
+            .parent()
+            .context("The repository path has no parent directory")?
+    };
+
+    Ok(start
+        .ancestors()
+        .find(|path| path.join(".jj").is_dir())
+        .map(Path::to_owned))
+}
+
+fn run_jj(root: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("jj")
+        .args([
+            "--ignore-working-copy",
+            "--no-pager",
+            "--color",
+            "never",
+            "-R",
+        ])
+        .arg(root)
+        .args(args)
+        .output()
+        .context("Failed to execute `jj`; is Jujutsu installed?")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("`jj` exited with {}: {}", output.status, stderr.trim());
+    }
+
+    String::from_utf8(output.stdout).context("Jujutsu returned non-UTF-8 output")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_jujutsu_root_from_nested_directory() -> Result<()> {
+        let fixture =
+            std::env::temp_dir().join(format!("onefetch-jj-root-test-{}", std::process::id()));
+        let nested = fixture.join("a/b");
+        std::fs::create_dir_all(fixture.join(".jj"))?;
+        std::fs::create_dir_all(&nested)?;
+
+        assert_eq!(find_jujutsu_root(&nested)?, Some(fixture.clone()));
+
+        std::fs::remove_dir_all(fixture)?;
+        Ok(())
+    }
+}

--- a/src/info/repository.rs
+++ b/src/info/repository.rs
@@ -127,7 +127,7 @@ mod tests {
         std::fs::create_dir_all(fixture.join(".jj"))?;
         std::fs::create_dir_all(&nested)?;
 
-        assert_eq!(find_jujutsu_root(&nested)?, Some(fixture.clone()));
+        assert_eq!(find_jujutsu_root(&nested)?, Some(fixture.canonicalize()?));
 
         std::fs::remove_dir_all(fixture)?;
         Ok(())


### PR DESCRIPTION
Closes #1846.

Native Jujutsu repositories keep their Git store inside `.jj`, so normal Git discovery cannot find them.

This change:

- detects non-colocated JJ workspaces;
- uses `jj git root` to locate the backing Git store;
- obtains the current JJ working-copy commit;
- reuses the existing Git history and statistics implementation;
- uses the JJ workspace root for language, manifest, and license detection;
- avoids snapshotting or modifying the JJ working copy.

The transient JJ working-copy commit is displayed as HEAD but excluded from commit statistics. Its ancestors, including multiple merge parents, are still traversed.

`Pending` and `Size` are omitted because the hidden backing repository has no Git worktree or index.

Testing:

- `cargo test -p onefetch` — 133 passed
- crate-level Clippy — clean
- manually tested with `jj git clone --no-colocate`