### PR TITLE
fix: count C++ modules as C++

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,10 @@ CSharp: # required, this will be the name of the enum variant for the language a
   serialization: c# # required only if the Enum name `CSharp` doesn't match the display name `C#`
 ```
 
+When Tokei splits a language into variants that Onefetch should display
+together, list the extra enum names under `tokei_aliases`. For example, the
+`Cpp` entry aliases `CppModule`, so both contribute to the C++ total.
+
 - [1] https://github.com/XAMPPRocky/tokei#supported-languages
 - [2] https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
 - [3] https://www.nerdfonts.com/cheat-sheet

--- a/languages.yaml
+++ b/languages.yaml
@@ -444,6 +444,8 @@ Coq:
     chip: "#D0B68C"
 Cpp:
   type: programming
+  tokei_aliases:
+    - CppModule
   ascii: |
     {0}                 ++++++
     {0}              ++++++++++++

--- a/src/info/langs/language.tera
+++ b/src/info/langs/language.tera
@@ -46,6 +46,11 @@ impl From<tokei::LanguageType> for Language {
         match language {
             {% for language, _ in languages -%}
                 tokei::LanguageType::{{ language }} => Self::{{ language }},
+                {% if languages[language].tokei_aliases is defined -%}
+                    {% for alias in languages[language].tokei_aliases -%}
+                        tokei::LanguageType::{{ alias }} => Self::{{ language }},
+                    {% endfor %}
+                {% endif -%}
             {% endfor %}
             _ => unimplemented!("Language {:?}", language),
         }
@@ -63,6 +68,21 @@ impl From<Language> for tokei::LanguageType {
 }
 
 impl Language {
+    pub fn get_tokei_types(&self) -> Vec<tokei::LanguageType> {
+        match self {
+            {% for language, attrs in languages -%}
+                Language::{{ language }} => vec![
+                    tokei::LanguageType::{{ language }},
+                    {% if attrs.tokei_aliases is defined -%}
+                        {% for alias in attrs.tokei_aliases -%}
+                            tokei::LanguageType::{{ alias }},
+                        {% endfor %}
+                    {% endif -%}
+                ],
+            {% endfor %}
+        }
+    }
+
     pub fn get_ascii_art(&self) -> &'static str {
         match self {
             {% for language, attrs in languages -%}

--- a/src/info/langs/language.tera
+++ b/src/info/langs/language.tera
@@ -68,10 +68,10 @@ impl From<Language> for tokei::LanguageType {
 }
 
 impl Language {
-    pub fn get_tokei_types(&self) -> Vec<tokei::LanguageType> {
+    pub fn get_tokei_types(&self) -> &'static [tokei::LanguageType] {
         match self {
             {% for language, attrs in languages -%}
-                Language::{{ language }} => vec![
+                Language::{{ language }} => &[
                     tokei::LanguageType::{{ language }},
                     {% if attrs.tokei_aliases is defined -%}
                         {% for alias in attrs.tokei_aliases -%}

--- a/src/info/langs/mod.rs
+++ b/src/info/langs/mod.rs
@@ -37,7 +37,9 @@ fn get_loc_by_language(languages: &tokei::Languages) -> Option<HashMap<Language,
         let loc = language::loc(language_name, language);
 
         if loc > 0 {
-            loc_by_language.insert(Language::from(*language_name), loc);
+            *loc_by_language
+                .entry(Language::from(*language_name))
+                .or_insert(0) += loc;
         }
     }
 
@@ -75,7 +77,7 @@ fn get_locs(
 fn filter_languages_on_type(types: &[LanguageType]) -> Vec<tokei::LanguageType> {
     Language::iter()
         .filter(|language| types.contains(&language.get_type()))
-        .map(std::convert::Into::into)
+        .flat_map(|language| language.get_tokei_types())
         .collect()
 }
 
@@ -111,6 +113,34 @@ mod test {
         // NOTE: JS  with 100 lines of code, MD with 300 lines of code + comments
         assert_eq!(loc_by_language[&Language::JavaScript], 100);
         assert_eq!(loc_by_language[&Language::Markdown], 300);
+    }
+
+    #[test]
+    fn cpp_modules_are_aggregated_with_cpp() {
+        let cpp = tokei::Language {
+            code: 100,
+            ..Default::default()
+        };
+        let cpp_module = tokei::Language {
+            code: 25,
+            ..Default::default()
+        };
+
+        let mut languages = tokei::Languages::new();
+        languages.insert(tokei::LanguageType::Cpp, cpp);
+        languages.insert(tokei::LanguageType::CppModule, cpp_module);
+
+        let loc_by_language = get_loc_by_language(&languages).unwrap();
+
+        assert_eq!(loc_by_language[&Language::Cpp], 125);
+    }
+
+    #[test]
+    fn programming_filter_includes_cpp_modules() {
+        let languages = filter_languages_on_type(&[LanguageType::Programming]);
+
+        assert!(languages.contains(&tokei::LanguageType::Cpp));
+        assert!(languages.contains(&tokei::LanguageType::CppModule));
     }
 
     #[test]

--- a/src/info/langs/mod.rs
+++ b/src/info/langs/mod.rs
@@ -77,7 +77,7 @@ fn get_locs(
 fn filter_languages_on_type(types: &[LanguageType]) -> Vec<tokei::LanguageType> {
     Language::iter()
         .filter(|language| types.contains(&language.get_type()))
-        .flat_map(|language| language.get_tokei_types())
+        .flat_map(|language| language.get_tokei_types().iter().copied())
         .collect()
 }
 


### PR DESCRIPTION
Closes #1855.

Adds a reusable Tokei alias mapping, maps `CppModule` into Onefetch’s existing C++ language, and sums aliased LOC buckets. Tests cover both scan selection and aggregation.

Validation: `cargo test`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo fmt --check`
